### PR TITLE
Remove unused build targets

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
-# Building NUnit 3.0
+# Building NUnit 3.0 Console and Engine
 
-NUnit 3.0 consists of three separate layers: the Framework, the Engine and the Console Runner. 
-The source code is kept in a single GitHub repository at http://github.com/nunit/nunit.git.
+NUnit 3.0 consists of two parts: the Engine and the Console Runner. 
+The source code is kept in a single GitHub repository at http://github.com/nunit/nunit-console.git.
 
 Note that assemblies in one layer must not reference those in any other layer, except as follows:
  * The console runner references the nunit.engine.api assembly, but not the nunit.engine assembly.
@@ -12,17 +12,9 @@ There are two ways to build NUnit: using the solution file in an IDE or through 
 
 ## Solution Build
 
-All three layers are built together using a single Visual Studio solution (nunit.sln on Windows 
-and nunit.linux.sln on Linux), which may be built with Visual Studio 2012+, SharpDevelop.
-or MonoDevelop.
-
-There is a separate VS2008 solution for building the framework to run under the .NET
-compact framework 3.5.
-
-The solutions all place their output in a common bin directory. Console runner and engine
-components are placed directly in the bin directory while framework components end up in
-subdirectories net-2.0, net4.0, sl-5.0, portable and netcf-3.5. Future platform
-builds will cause new subdirectories to be created.
+All projects are built together using a single Visual Studio solution NUnitConsole.sln, which may be 
+built with Visual Studio 2012+, SharpDevelop or MonoDevelop. The solutions all place their output in 
+a common bin directory.
 
 ## Build Script
 
@@ -55,14 +47,6 @@ important top-level tasks to use are listed here:
  * Build               Builds everything. This is the default if no target is given.
  * Rebuild             Cleans the output directory and builds everything
  * Test                Runs all tests. Dependent on Build.
- * TestAll             Runs all tests. Dependent on Build.
- * TestAllFrameworks   Runs all framework tests. Dependent on Build.
- * Test45              Tests the 4.5 framework without building first.
- * Test40              Tests the 4.0 framework without building first.
- * Test20              Tests the 2.0 framework without building first.
- * TestPortable        Tests the portable framework without building first.
- * TestSL              Tests the Silverlight framework without building first.
- * TestCF              Tests the compact framework without building first.
  * TestEngine          Runs all engine tests. Dependent on Build.
  * TestConsole         Runs the console tests. Dependent on Build.
  * Package             Creates all packages without building first. See Note below.
@@ -73,10 +57,4 @@ important top-level tasks to use are listed here:
     when necessary without changing the binaries themselves. Of course, this means that
     you have to be very careful that the build is up to date before packaging.
 
- 2. If the compact framework or Silverlight SDK are not installed on a machine, the relevant 
-    building and testing tasks are skipped and a warning is issued.
-
- 3. The Test and TestAll targets currently do the same thing. Both are retained for backwards
-    compatibility and the semantics of at least one of them may change in the future.
-
- 4. For additional targets, refer to the build.cake script itself.
+ 2. For additional targets, refer to the build.cake script itself.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
 # Building NUnit 3.0 Console and Engine
 
-NUnit 3.0 consists of two parts: the Engine and the Console Runner. 
-The source code is kept in a single GitHub repository at http://github.com/nunit/nunit-console.git.
+NUnit 3.0 consists of three separate layers: the Framework, the Engine and the Console Runner. This
+repository contains the Engine and Console Runner. The source code is kept in the GitHub repository at https://github.com/nunit/nunit-console. Source for the framework can be found at https://github.com/nunit/nunit
 
 Note that assemblies in one layer must not reference those in any other layer, except as follows:
  * The console runner references the nunit.engine.api assembly, but not the nunit.engine assembly.


### PR DESCRIPTION
Updated the Building.md file to better reflect the repository split. This was edited on GitHub, so there are likely more changes we will want to make.