### PR TITLE
Fix split

### DIFF
--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -34,7 +34,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -19,10 +19,11 @@
       * VSProjectLoader        - loads tests from Visual Studio projects
       * NUnitV2ResultWriter    - saves results in NUnit V2 format.
       * NUnitV2FrameworkDriver - runs NUnit V2 tests.
+      * TeamCityEventListener - supports special progress messages used by teamcity.
 
       Other extensions, if needed, must be installed separately.
     </description>
-    <releaseNotes>This release removes the TeamCityEventListener extension, which must now be installed separately.</releaseNotes>
+    <releaseNotes>This release uses the latest version of the TeamCityEventListener extension.</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2016 Charlie Poole</copyright>
@@ -33,6 +34,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -36,7 +36,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -19,12 +19,13 @@
       * VSProjectLoader        - loads tests from Visual Studio projects
       * NUnitV2ResultWriter    - saves results in NUnit V2 format.
       * NUnitV2FrameworkDriver - runs NUnit V2 tests.
+      * TeamCityEventListener - supports special progress messages used by teamcity.
 
       Other extensions, if needed, must be installed separately.
 
-      This package is being replaced by the NUnit.Console package. Users may update their projects to use the NUnit.Console package directly if desired.
+      This package is being replaced by the NUnit.Console package and will eventually be removed. Users should update their projects to use the NUnit.Console package directly if desired.
     </description>
-    <releaseNotes>This release removes the TeamCityEventListener extension, which must now be installed separately.</releaseNotes>
+    <releaseNotes>This release uses the latest version of the TeamCityEventListener extension.</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2016 Charlie Poole</copyright>
@@ -35,6 +36,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -134,13 +134,12 @@ namespace NUnit.ConsoleRunner.Tests
         //}
 
         [Test]
-        public void WhenNoOptionsAreSpecified_PackageContainsWorkDirectorySettingOnly()
+        public void WhenNoOptionsAreSpecified_PackageContainsOnlyTwoSettings()
         {
             var options = new ConsoleOptions("test.dll");
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.AreEqual(1, package.Settings.Count);
-            Assert.That(package.Settings.Keys, Contains.Item("WorkDirectory"));
+            Assert.That(package.Settings.Keys, Is.EquivalentTo(new string[] { "WorkDirectory", "DisposeRunners" }));
         }
     }
 }

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -364,7 +364,8 @@ namespace NUnit.ConsoleRunner
             if (options.RunAsX86)
                 package.AddSetting(EnginePackageSettings.RunAsX86, true);
 
-            if (options.DisposeRunners)
+            // Console runner always sets DisposeRunners
+            //if (options.DisposeRunners)
                 package.AddSetting(EnginePackageSettings.DisposeRunners, true);
 
             if (options.ShadowCopyFiles)

--- a/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
+++ b/src/NUnitEngine/Addins/nunit.v2.driver/XmlExtensions.cs
@@ -101,6 +101,10 @@ namespace NUnit.Engine.Drivers
             thisNode.AddAttribute("id", string.Format("{0}-{1}", tn.RunnerID, tn.TestID));
             thisNode.AddAttribute("name", tn.Name);
             thisNode.AddAttribute("fullname", tn.FullName);
+            if (!string.IsNullOrEmpty(test.MethodName))
+                thisNode.AddAttribute("methodname", test.MethodName);
+            if (!string.IsNullOrEmpty(test.ClassName))
+                thisNode.AddAttribute("classname", test.ClassName);
             thisNode.AddAttribute("runstate", test.RunState.ToString());
 
             if (test.IsSuite)

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
@@ -1,0 +1,64 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Runners.Tests
+{
+    public class MultipleTestProcessRunnerTests
+    {
+        [TestCase(1, 0, ExpectedResult = 1)]
+        [TestCase(1, 1, ExpectedResult = 1)]
+        [TestCase(3, 0, ExpectedResult = 3)]
+        [TestCase(3, 1, ExpectedResult = 1)]
+        [TestCase(3, 2, ExpectedResult = 2)]
+        [TestCase(3, 3, ExpectedResult = 3)]
+        [TestCase(20, 8, ExpectedResult = 8)]
+        [TestCase(8, 20, ExpectedResult = 8)]
+        public int CheckLevelOfParallelism_ListOfAssemblies(int assemblyCount, int maxAgents)
+        {
+            return CreateRunner(assemblyCount, maxAgents).LevelOfParallelism;
+        }
+
+        [Test]
+        public void CheckLevelOfParallelism_SingleAssembly()
+        {
+            var package = new TestPackage("junk.dll");
+            Assert.That(new MultipleTestProcessRunner(new ServiceContext(), package).LevelOfParallelism, Is.EqualTo(0));
+        }
+
+        // Create a MultipleTestProcessRunner with a fake package consisting of
+        // some number of assemblies and with an optional MaxAgents setting.
+        // Zero means that MaxAgents is not specified.
+        MultipleTestProcessRunner CreateRunner(int assemblyCount, int maxAgents)
+        {
+            // Currently, we can get away with null entries here
+            var package = new TestPackage(new string[assemblyCount]);
+            if (maxAgents > 0)
+                package.Settings[EnginePackageSettings.MaxAgents] = maxAgents;
+            return new MultipleTestProcessRunner(new ServiceContext(), package);
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -94,11 +94,6 @@ namespace NUnit.Engine.Services.Tests
             var runner = _factory.MakeTestRunner(package);
 
             Assert.That(runner, Is.TypeOf(expectedType));
-
-            var aggRunner = runner as AggregatingTestRunner;
-            if (aggRunner != null)
-                foreach (var childRunner in aggRunner.Runners)
-                    Assert.That(childRunner, Is.TypeOf<TestDomainRunner>());
         }
 
         [TestCase("x.junk", typeof(ProcessRunner))]

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Internal\ServerUtilityTests.cs" />
     <Compile Include="Internal\SettingsGroupTests.cs" />
     <Compile Include="ResultHelperTests.cs" />
+    <Compile Include="Runners\MultipleTestProcessRunnerTests.cs" />
     <Compile Include="Runners\ParallelTaskWorkerPoolTests.cs" />
     <Compile Include="RuntimeFrameworkTests.cs" />
     <Compile Include="Services\ExtensionAssemblyTests.cs" />

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -194,17 +194,6 @@ namespace NUnit.Engine.Agents
         }
 
         /// <summary>
-        /// Start a run of the tests in the loaded TestPackage. The tests are run
-        /// asynchronously and the listener interface is notified as it progresses.
-        /// </summary>
-        /// <param name="listener">An ITestEventHandler to receive events</param>
-        /// <param name="filter">A TestFilter used to select tests</param>
-        public void StartRun(ITestEventListener listener, TestFilter filter)
-        {
-            RunAsync(listener, filter);
-        }
-
-        /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
         /// </summary>
         /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>

--- a/src/NUnitEngine/nunit.engine/ITestEngineRunner.cs
+++ b/src/NUnitEngine/nunit.engine/ITestEngineRunner.cs
@@ -78,14 +78,6 @@ namespace NUnit.Engine
         AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter);
         
         /// <summary>
-        /// Start a run of the tests in the loaded TestPackage. The tests are run
-        /// asynchronously and the listener interface is notified as it progresses.
-        /// </summary>
-        /// <param name="listener">An ITestEventHandler to receive events</param>
-        /// <param name="filter">A TestFilter used to select tests</param>
-        void StartRun(ITestEventListener listener, TestFilter filter);
-
-        /// <summary>
         /// Cancel the current test run. If no test is running,
         /// the call is ignored.
         /// </summary>

--- a/src/NUnitEngine/nunit.engine/Internal/Logging/InternalTraceWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/Logging/InternalTraceWriter.cs
@@ -93,7 +93,10 @@ namespace NUnit.Engine.Internal
         /// <param name="value">The string to write. If <paramref name="value" /> is null, only the line terminator is written.</param>
         public override void WriteLine(string value)
         {
-            writer.WriteLine(value);
+            lock (myLock)
+            {
+                writer.WriteLine(value);
+            }
         }
 
         /// <summary>
@@ -102,11 +105,14 @@ namespace NUnit.Engine.Internal
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && writer != null)
+            lock (myLock)
             {
-                writer.Flush();
-                writer.Dispose();
-                writer = null;
+                if (disposing && writer != null)
+                {
+                    writer.Flush();
+                    writer.Dispose();
+                    writer = null;
+                }
             }
 
             base.Dispose(disposing);

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -36,8 +36,6 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public abstract class AbstractTestRunner : ITestEngineRunner
     {
-        protected const string TEST_RUN_ELEMENT = "test-run";
-
         public AbstractTestRunner(IServiceLocator services, TestPackage package)
         {
             Services = services;
@@ -169,8 +167,6 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         public TestEngineResult Explore(TestFilter filter)
         {
-            EnsurePackageIsLoaded();
-
             return ExploreTests(filter);
         }
 
@@ -213,8 +209,6 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases.</returns>
         public int CountTestCases(TestFilter filter)
         {
-            EnsurePackageIsLoaded();
-
             return CountTests(filter);
         }
 
@@ -227,8 +221,6 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult giving the result of the test execution</returns>
         public TestEngineResult Run(ITestEventListener listener, TestFilter filter)
         {
-            EnsurePackageIsLoaded();
-
             return RunTests(listener, filter);
         }
 
@@ -241,23 +233,9 @@ namespace NUnit.Engine.Runners
         /// <returns>An <see cref="AsyncTestEngineResult"/> that will provide the result of the test execution</returns>
         public AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter)
         {
-            EnsurePackageIsLoaded();
-
             return RunTestsAsync(listener, filter);
         }
         
-        /// <summary>
-        /// Start a run of the tests in the TestPackage. The tests are run
-        /// asynchronously and the listener interface is notified as it progresses.
-        /// Loads the TestPackage if not already loaded.
-        /// </summary>
-        /// <param name="listener">An ITestEventHandler to receive events</param>
-        /// <param name="filter">A TestFilter used to select tests</param>
-        public void StartRun(ITestEventListener listener, TestFilter filter)
-        {
-            RunAsync(listener, filter);
-        }
-
         #endregion
 
         #region IDisposable Members
@@ -293,7 +271,7 @@ namespace NUnit.Engine.Runners
                 && ProjectService.CanLoadFrom(package.FullName);
         }
 
-        private void EnsurePackageIsLoaded()
+        protected void EnsurePackageIsLoaded()
         {
             if (!IsPackageLoaded)
                 LoadResult = LoadPackage();

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -167,6 +167,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         public TestEngineResult Explore(TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return ExploreTests(filter);
         }
 
@@ -209,6 +210,7 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases.</returns>
         public int CountTestCases(TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return CountTests(filter);
         }
 
@@ -221,6 +223,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult giving the result of the test execution</returns>
         public TestEngineResult Run(ITestEventListener listener, TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return RunTests(listener, filter);
         }
 
@@ -233,6 +236,7 @@ namespace NUnit.Engine.Runners
         /// <returns>An <see cref="AsyncTestEngineResult"/> that will provide the result of the test execution</returns>
         public AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter)
         {
+            EnsurePackageIsLoaded();
             return RunTestsAsync(listener, filter);
         }
         

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -126,8 +126,6 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases.</returns>
         public int CountTestCases(TestFilter filter)
         {
-            EnsurePackageIsLoaded();
-
             return _engineRunner.CountTestCases(filter);
         }
 
@@ -173,8 +171,6 @@ namespace NUnit.Engine.Runners
         /// <returns>An XmlNode representing the tests found.</returns>
         public XmlNode Explore(TestFilter filter)
         {
-            EnsurePackageIsLoaded(); // Needed?
-
             return _engineRunner.Explore(filter)
                 .Aggregate(TEST_RUN_ELEMENT, TestPackage.Name, TestPackage.FullName).Xml;
         }
@@ -208,12 +204,6 @@ namespace NUnit.Engine.Runners
         #endregion
 
         #region Helper Methods
-
-        private void EnsurePackageIsLoaded()
-        {
-            if (!IsPackageLoaded)
-                LoadPackage();
-        }
 
         /// <summary>
         /// Load a TestPackage for possible execution,

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+
 namespace NUnit.Engine.Runners
 {
     /// <summary>
@@ -34,18 +36,24 @@ namespace NUnit.Engine.Runners
         /// </summary>
         /// <param name="services">The services.</param>
         /// <param name="package">The package.</param>
-        public MultipleTestProcessRunner(IServiceLocator services, TestPackage package) : base(services, package) { }
+        public MultipleTestProcessRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        {
+        }
 
         #region AggregatingTestRunner Overrides
+
+        public override int LevelOfParallelism
+        {
+            get
+            {
+                int maxAgents = TestPackage.GetSetting(EnginePackageSettings.MaxAgents, int.MaxValue);
+                return Math.Min(maxAgents, TestPackage.SubPackages.Count);
+            }
+        }
 
         protected override ITestEngineRunner CreateRunner(TestPackage package)
         {
             return new ProcessRunner(Services, package);
-        }
-
-        protected override int GetLevelOfParallelism()
-        {
-            return TestPackage.GetSetting(EnginePackageSettings.MaxAgents, int.MaxValue);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -64,7 +64,6 @@ namespace NUnit.Engine.Runners
         {
             try
             {
-                EnsurePackageIsLoaded();
                 return _remoteRunner.Explore(filter);
             }
             catch (Exception e)
@@ -144,7 +143,6 @@ namespace NUnit.Engine.Runners
         {
             try
             {
-                EnsurePackageIsLoaded();
                 return _remoteRunner.CountTestCases(filter);
             }
             catch (Exception e)
@@ -166,8 +164,6 @@ namespace NUnit.Engine.Runners
 
             try
             {
-                EnsurePackageIsLoaded();
-
                 var result = _remoteRunner.Run(listener, filter);
                 log.Info("Done running " + TestPackage.Name);
                 return result;
@@ -193,7 +189,6 @@ namespace NUnit.Engine.Runners
 
             try
             {
-                EnsurePackageIsLoaded();
                 return _remoteRunner.RunAsync(listener, filter);
             }
             catch (Exception e)

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -64,6 +64,7 @@ namespace NUnit.Engine.Runners
         {
             try
             {
+                EnsurePackageIsLoaded();
                 return _remoteRunner.Explore(filter);
             }
             catch (Exception e)
@@ -120,7 +121,7 @@ namespace NUnit.Engine.Runners
             {
                 if (_remoteRunner != null)
                 {
-                    log.Info("Unloading remote runner");
+                    log.Info("Unloading " + TestPackage.Name);
                     _remoteRunner.Unload();
                     _remoteRunner = null;
                 }
@@ -143,6 +144,7 @@ namespace NUnit.Engine.Runners
         {
             try
             {
+                EnsurePackageIsLoaded();
                 return _remoteRunner.CountTestCases(filter);
             }
             catch (Exception e)
@@ -160,9 +162,15 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestResult giving the result of the test execution</returns>
         protected override TestEngineResult RunTests(ITestEventListener listener, TestFilter filter)
         {
+            log.Info("Running " + TestPackage.Name);
+
             try
             {
-                return _remoteRunner.Run(listener, filter);
+                EnsurePackageIsLoaded();
+
+                var result = _remoteRunner.Run(listener, filter);
+                log.Info("Done running " + TestPackage.Name);
+                return result;
             }
             catch (Exception e)
             {
@@ -181,8 +189,11 @@ namespace NUnit.Engine.Runners
         /// <returns>An AsyncTestRun that will provide the result of the test execution</returns>
         protected override AsyncTestEngineResult RunTestsAsync(ITestEventListener listener, TestFilter filter)
         {
+            log.Info("Running " + TestPackage.Name + " (async)");
+
             try
             {
+                EnsurePackageIsLoaded();
                 return _remoteRunner.RunAsync(listener, filter);
             }
             catch (Exception e)
@@ -218,7 +229,7 @@ namespace NUnit.Engine.Runners
             {
                 if (disposing && _agent != null)
                 {
-                    log.Info("Stopping remote agent");
+                    log.Debug("Stopping remote agent");
                     _agent.Stop();
                     _agent = null;
                 }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -229,8 +229,8 @@ namespace NUnit.Engine.Services
             
             //p.Exited += new EventHandler(OnProcessExit);
             p.Start();
-            log.Info("Launched Agent process {0} - see nunit-agent_{0}.log", p.Id);
-            log.Info("Command line: \"{0}\" {1}", p.StartInfo.FileName, p.StartInfo.Arguments);
+            log.Debug("Launched Agent process {0} - see nunit-agent_{0}.log", p.Id);
+            log.Debug("Command line: \"{0}\" {1}", p.StartInfo.FileName, p.StartInfo.Arguments);
 
             _agentData.Add( new AgentRecord( agentId, p, null, AgentStatus.Starting ) );
             return agentId;


### PR DESCRIPTION
This PR adds commits that were omitted when we moved the console and engine to its new repo.

Basically, I went through every commit in the last three weeks in the nunit repo that affected the engine or console. If it was not already reflected in this repo I created a patch and applied it.

I discovered this while working on issue #36, which is probably still going to be a problem after this is merged, but it's important to get all the changes in first.