### PR TITLE
Added unescape of unicode characters for console output

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -67,6 +67,8 @@ namespace NUnit.Common
 
         public bool LoadUserProfile { get; private set; }
 
+        public string ConsoleEncoding { get; private set; }
+
         private int maxAgents = -1;
         public int MaxAgents { get { return maxAgents; } }
         public bool MaxAgentsSpecified { get { return maxAgents >= 0; } }
@@ -147,6 +149,9 @@ namespace NUnit.Common
 
             this.Add("list-extensions", "List all extension points and the extensions for each.",
                 v => ListExtensions = v != null);
+
+            this.Add("encoding=", "Specifies the encoding to use for Console output.",
+                v => ConsoleEncoding = RequiredValue(v, "--encoding"));
 
 #if DEBUG
             this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",

--- a/src/NUnitConsole/nunit3-console/ExtendedTextWrapper.cs
+++ b/src/NUnitConsole/nunit3-console/ExtendedTextWrapper.cs
@@ -21,8 +21,10 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace NUnit.ConsoleRunner
 {
@@ -56,6 +58,7 @@ namespace NUnit.ConsoleRunner
         /// </summary>
         public override void Write(string value)
         {
+            value = UnescapeUnicodeChars(value);
             _writer.Write(value);
         }
 
@@ -64,6 +67,7 @@ namespace NUnit.ConsoleRunner
         /// </summary>
         public override void WriteLine(string value)
         {
+            value = UnescapeUnicodeChars(value);
             _writer.WriteLine(value);
         }
 
@@ -149,6 +153,14 @@ namespace NUnit.ConsoleRunner
         public override void WriteLabelLine(string label, object option, ColorStyle valueStyle)
         {
             WriteLabelLine(label, option);
+        }
+
+        private static string UnescapeUnicodeChars(string text)
+        {
+            return Regex.Replace(text, @"\\[Uu]([0-9A-Fa-f]{4})", match => {
+                ushort value = ushort.Parse(match.Groups[1].Value, NumberStyles.AllowHexSpecifier);
+                return char.ToString((char)value);
+            });
         }
 
         #endregion

--- a/src/NUnitConsole/nunit3-console/ExtendedTextWrapper.cs
+++ b/src/NUnitConsole/nunit3-console/ExtendedTextWrapper.cs
@@ -157,10 +157,40 @@ namespace NUnit.ConsoleRunner
 
         private static string UnescapeUnicodeChars(string text)
         {
-            return Regex.Replace(text, @"\\[Uu]([0-9A-Fa-f]{4})", match => {
-                ushort value = ushort.Parse(match.Groups[1].Value, NumberStyles.AllowHexSpecifier);
-                return char.ToString((char)value);
-            });
+            if (string.IsNullOrEmpty(text)) return text;
+            StringBuilder builder = new StringBuilder();
+
+            int pos = 0;
+            for (int i = 0; i < text.Length; i++) {
+                char c = text[i];
+                if (c != '\\') continue;
+
+                if (i > pos) {
+                    builder.Append(text, pos, i - pos);
+                    pos = i;
+                }
+
+                switch (text[i + 1]) {
+                    case '\\':
+                        builder.Append('\\');
+                        pos += 2;
+                        i += 2;
+                        break;
+                    case 'u':
+                        if (i + 5 >= text.Length) continue;
+                        string unicodeText = text.Substring(i+2, 4);
+                        ushort unicodeValue = ushort.Parse(unicodeText, NumberStyles.AllowHexSpecifier);
+                        builder.Append((char)unicodeValue);
+                        pos += 6;
+                        i += 6;
+                        break;
+                }
+            }
+
+            if (pos < text.Length)
+                builder.Append(text, pos, text.Length - pos);
+
+            return builder.ToString();
         }
 
         #endregion

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using NUnit.Common;
 using NUnit.Options;
 using NUnit.Engine;
@@ -62,6 +63,17 @@ namespace NUnit.ConsoleRunner
                 WriteHeader();
                 OutWriter.WriteLine(ColorStyle.Error, string.Format(ex.Message, ex.OptionName));
                 return ConsoleRunner.INVALID_ARG;
+            }
+
+            if (!string.IsNullOrEmpty(Options.ConsoleEncoding)) {
+                try {
+                    Console.OutputEncoding = Encoding.GetEncoding(Options.ConsoleEncoding);
+                }
+                catch (Exception error) {
+                    WriteHeader();
+                    OutWriter.WriteLine(ColorStyle.Error, string.Format("Invalid Encoding! {0}", error.Message));
+                    return ConsoleRunner.INVALID_ARG;
+                }
             }
 
             //ColorConsole.Enabled = !Options.NoColor;


### PR DESCRIPTION
[nunit > issue #1787](https://github.com/nunit/nunit/issues/1787)

Quick and dirty attempt at unescaping unicode characters before printing them to the console.
