### PR TITLE
--encoding option for Console std-out

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -104,6 +104,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("DisplayTestLabels",  "labels",     new string[] { "Off", "On", "All" },               new string[] { "JUNK" })]
         [TestCase("InternalTraceLevel", "trace",      new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" }, new string[] { "JUNK" })]
         [TestCase("DefaultTestNamePattern", "test-name-format", new string[] { "{m}{a}" }, new string[0])]
+        [TestCase("ConsoleEncoding",    "encoding",   new string[] { "utf-8", "ascii", "unicode" },      new string[0])]
         public void CanRecognizeStringOptions(string propertyName, string pattern, string[] goodValues, string[] badValues)
         {
             string[] prototypes = pattern.Split('|');
@@ -209,6 +210,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--trace")]
         [TestCase("--test-name-format")]
         [TestCase("--params")]
+        [TestCase("--encoding")]
         public void MissingValuesAreReported(string option)
         {
             ConsoleOptions options = new ConsoleOptions(option + "=");

--- a/src/NUnitConsole/nunit3-console.tests/ConsoleOutputTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleOutputTests.cs
@@ -21,10 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework;
+using System;
 
 namespace NUnit.ConsoleRunner.Tests
 {
@@ -70,6 +68,12 @@ namespace NUnit.ConsoleRunner.Tests
             Console.WriteLine("Test: Console.WriteLine()");
             Console.Error.WriteLine("Test: Console.Error.WriteLine()");
             TestContext.WriteLine("Test: TestContext.WriteLine()");
+        }
+
+        [Test]
+        public void ConsoleEncoding()
+        {
+            TestContext.WriteLine("•ÑÜńĭŧ·");
         }
     }
 }

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -375,7 +375,7 @@ namespace NUnit.Common
             this.Add("version|V", "Display the header and exit.",
                 v => ShowVersion = v != null);
 
-            this.Add("encoding=", "Specifies the encoding to use for Console standard output.",
+            this.Add("encoding=", "Specifies the encoding to use for Console standard output, for example utf-8, ascii, unicode.",
                 v => ConsoleEncoding = RequiredValue(v, "--encoding"));
 
             // Default

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -109,6 +109,8 @@ namespace NUnit.Common
 
         // Output Control
 
+        public string ConsoleEncoding { get; private set; }
+
         public bool NoHeader { get; private set; }
 
         public bool NoColor { get; private set; }
@@ -372,6 +374,9 @@ namespace NUnit.Common
 
             this.Add("version|V", "Display the header and exit.",
                 v => ShowVersion = v != null);
+
+            this.Add("encoding=", "Specifies the encoding to use for Console standard output.",
+                v => ConsoleEncoding = RequiredValue(v, "--encoding"));
 
             // Default
             this.Add("<>", v =>

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -67,6 +67,8 @@ namespace NUnit.Common
 
         public bool LoadUserProfile { get; private set; }
 
+        public string ConsoleEncoding { get; private set; }
+
         private int maxAgents = -1;
         public int MaxAgents { get { return maxAgents; } }
         public bool MaxAgentsSpecified { get { return maxAgents >= 0; } }
@@ -147,6 +149,9 @@ namespace NUnit.Common
 
             this.Add("list-extensions", "List all extension points and the extensions for each.",
                 v => ListExtensions = v != null);
+
+            this.Add("encoding=", "Specifies the encoding to use for Console standard output.",
+                v => ConsoleEncoding = RequiredValue(v, "--encoding"));
 
 #if DEBUG
             this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -67,8 +67,6 @@ namespace NUnit.Common
 
         public bool LoadUserProfile { get; private set; }
 
-        public string ConsoleEncoding { get; private set; }
-
         private int maxAgents = -1;
         public int MaxAgents { get { return maxAgents; } }
         public bool MaxAgentsSpecified { get { return maxAgents >= 0; } }
@@ -149,9 +147,6 @@ namespace NUnit.Common
 
             this.Add("list-extensions", "List all extension points and the extensions for each.",
                 v => ListExtensions = v != null);
-
-            this.Add("encoding=", "Specifies the encoding to use for Console standard output.",
-                v => ConsoleEncoding = RequiredValue(v, "--encoding"));
 
 #if DEBUG
             this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -74,7 +74,7 @@ namespace NUnit.ConsoleRunner
                 catch (Exception error)
                 {
                     WriteHeader();
-                    OutWriter.WriteLine(ColorStyle.Error, string.Format("Unsupported Encoding! {0}", error.Message));
+                    OutWriter.WriteLine(ColorStyle.Error, string.Format("Unsupported Encoding, {0}", error.Message));
                     return ConsoleRunner.INVALID_ARG;
                 }
             }

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using System.Text;
 using NUnit.Common;
 using NUnit.Options;
 using NUnit.Engine;
@@ -62,6 +63,20 @@ namespace NUnit.ConsoleRunner
                 WriteHeader();
                 OutWriter.WriteLine(ColorStyle.Error, string.Format(ex.Message, ex.OptionName));
                 return ConsoleRunner.INVALID_ARG;
+            }
+
+            if (!string.IsNullOrEmpty(Options.ConsoleEncoding))
+            {
+                try
+                {
+                    Console.OutputEncoding = Encoding.GetEncoding(Options.ConsoleEncoding);
+                }
+                catch (Exception error)
+                {
+                    WriteHeader();
+                    OutWriter.WriteLine(ColorStyle.Error, string.Format("Unsupported Encoding! {0}", error.Message));
+                    return ConsoleRunner.INVALID_ARG;
+                }
             }
 
             //ColorConsole.Enabled = !Options.NoColor;


### PR DESCRIPTION
\* _This PR is a subset of the changes from PR #54._

Adds an option to nunit3-console for specifying the consoles standard-output encoding. This is required to display non-CP437 unicode characters. Since this is only a visual change, no tests were created.