### PR TITLE
Back out use of floating version for teamcity

### DIFF
--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -34,7 +34,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="[1.0.*,1.1)" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0.2" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -36,7 +36,7 @@
         <dependency id="NUnit.Extension.VSProjectLoader" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="$version$" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="$version$" />
-        <dependency id="NUnit.Extension.TeamCityEventListener" version="[1.0.*,1.1)" />
+        <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0.2" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This restores teamcity to depending on version 1.0.2 rather than using a range with a floating version. See discussion on PR #74.