### PR TITLE
Add task descriptions to build.cake

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,14 +12,14 @@ There are two ways to build NUnit: using the solution file in an IDE or through 
 
 ## Solution Build
 
-All projects are built together using a single Visual Studio solution NUnitConsole.sln, which may be 
-built with Visual Studio 2012+, SharpDevelop or MonoDevelop. The solutions all place their output in 
+All projects are built together using a single Visual Studio solution NUnitConsole.sln, which may be
+built with Visual Studio 2012+, SharpDevelop or MonoDevelop. The solutions all place their output in
 a common bin directory.
 
 ## Build Script
 
 We use **Cake** (http://cakebuild.net) to build NUnit for distribution. The primary script that controls
-building, running tests and packaging is build.cake. We modify build.cake when we need to add new 
+building, running tests and packaging is build.cake. We modify build.cake when we need to add new
 targets or change the way the build is done. Normally build.cake is not invoked directly but through
 build.ps1 (on Windows) or build.sh (on Linux). These two scripts are provided by the Cake project
 and ensure that Cake is properly installed before trying to run the cake script. This helps the
@@ -38,9 +38,10 @@ it out each time.
 Key arguments to build.cmd / build:
  * -Target, -t <task>                 The task to run - see below.
  * -Configuration, -c [Release|Debug] The configuration to use (default is Release)
+ * -ShowDescription                   Shows all of the build tasks and their descriptions
  * -Experimental, -e                  Use the experimental build of Roslyn
 
-The build.cake script contains a large number of interdependent tasks. The most 
+The build.cake script contains a large number of interdependent tasks. The most
 important top-level tasks to use are listed here:
 
 ```
@@ -51,6 +52,8 @@ important top-level tasks to use are listed here:
  * TestConsole         Runs the console tests. Dependent on Build.
  * Package             Creates all packages without building first. See Note below.
 ```
+
+For a full list of tasks, run `build.cmd -ShowDescription`.
 
 ### Notes:
  1. By design, the Package target does not depend on Build. This is to allow re-packaging

--- a/build.cake
+++ b/build.cake
@@ -56,6 +56,7 @@ var ZIP_PACKAGE = PACKAGE_DIR + "NUnit-" + packageVersion + ".zip";
 //////////////////////////////////////////////////////////////////////
 
 Task("Clean")
+    .Description("Deletes all files in the BIN directory")
     .Does(() =>
     {
         CleanDirectory(BIN_DIR);
@@ -67,6 +68,7 @@ Task("Clean")
 //////////////////////////////////////////////////////////////////////
 
 Task("InitializeBuild")
+    .Description("Initializes the build")
     .Does(() =>
     {
 		NuGetRestore(SOLUTION_FILE, new NuGetRestoreSettings()
@@ -120,6 +122,7 @@ Task("InitializeBuild")
 //////////////////////////////////////////////////////////////////////
 
 Task("BuildEngine")
+    .Description("Builds the engine")
     .IsDependentOn("InitializeBuild")
     .Does(() =>
     {
@@ -138,6 +141,7 @@ Task("BuildEngine")
 //////////////////////////////////////////////////////////////////////
 
 Task("BuildConsole")
+    .Description("Builds the console runner")
     .IsDependentOn("InitializeBuild")
     .Does(() =>
     {
@@ -150,6 +154,7 @@ Task("BuildConsole")
 //////////////////////////////////////////////////////////////////////
 
 Task("BuildCppTestFiles")
+    .Description("Builds the C++ mock test assemblies")
     .IsDependentOn("InitializeBuild")
     .WithCriteria(IsRunningOnWindows)
     .Does(() =>
@@ -173,6 +178,7 @@ Task("BuildCppTestFiles")
 //////////////////////////////////////////////////////////////////////
 
 Task("CheckForError")
+    .Description("Checks for errors running the test suites")
     .Does(() => CheckForError(ref ErrorDetail));
 
 //////////////////////////////////////////////////////////////////////
@@ -180,6 +186,7 @@ Task("CheckForError")
 //////////////////////////////////////////////////////////////////////
 
 Task("TestEngine")
+    .Description("Tests the engine")
     .IsDependentOn("Build")
     .OnError(exception => { ErrorDetail.Add(exception.Message); })
     .Does(() =>
@@ -192,6 +199,7 @@ Task("TestEngine")
 //////////////////////////////////////////////////////////////////////
 
 Task("TestConsole")
+    .Description("Tests the console runner")
     .IsDependentOn("Build")
     .OnError(exception => { ErrorDetail.Add(exception.Message); })
     .Does(() =>
@@ -239,13 +247,15 @@ var BinFiles = new FilePath[]
 };
 
 Task("PackageSource")
-  .Does(() =>
+    .Description("Creates a ZIP file of the source code")
+    .Does(() =>
     {
         CreateDirectory(PACKAGE_DIR);
         RunGitCommand(string.Format("archive -o {0} HEAD", SRC_PACKAGE));
     });
 
 Task("CreateImage")
+    .Description("Copies all files into the image directory")
     .Does(() =>
     {
         var currentImageDir = IMAGE_DIR + "NUnit-" + packageVersion + "/";
@@ -269,6 +279,7 @@ Task("CreateImage")
     });
 
 Task("PackageEngine")
+    .Description("Creates NuGet packages of the engine")
     .IsDependentOn("CreateImage")
     .Does(() =>
     {
@@ -302,6 +313,7 @@ Task("PackageEngine")
     });
 
 Task("PackageConsole")
+    .Description("Creates NuGet packages of the console runner")
     .IsDependentOn("CreateImage")
     .Does(() =>
     {
@@ -444,32 +456,39 @@ void RunTest(FilePath exePath, DirectoryPath workingDir, string arguments, strin
 //////////////////////////////////////////////////////////////////////
 
 Task("Build")
-  .IsDependentOn("BuildEngine")
-  .IsDependentOn("BuildConsole");
+    .Description("Builds the engine and console runner")
+    .IsDependentOn("BuildEngine")
+    .IsDependentOn("BuildConsole");
 
 Task("Rebuild")
+    .Description("Rebuilds the engine and console runner")
     .IsDependentOn("Clean")
     .IsDependentOn("Build");
 
 Task("Test")
+    .Description("Builds and tests the engine and console runner")
     .IsDependentOn("TestEngine")
     .IsDependentOn("TestConsole");
 
 Task("Package")
+    .Description("Packages the engine and console runner")
     .IsDependentOn("CheckForError")
     .IsDependentOn("PackageEngine")
     .IsDependentOn("PackageConsole");
 
 Task("Appveyor")
+    .Description("Builds, tests and packages on AppVeyor")
     .IsDependentOn("Build")
     .IsDependentOn("Test")
     .IsDependentOn("Package");
 
 Task("Travis")
+    .Description("Builds and tests on Travis")
     .IsDependentOn("Build")
     .IsDependentOn("Test");
 
 Task("Default")
+    .Description("Builds the engine and console runner")
     .IsDependentOn("Build"); // Rebuild?
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #113 

Running `.\build.ps1 --showdescription` or `.\build.cmd --showdescription` shows,

```
Task                          Description
===============================================================================
Clean                         Deletes all files in the BIN directory
InitializeBuild               Initializes the build
BuildEngine                   Builds the engine
BuildConsole                  Builds the console runner
BuildCppTestFiles             Builds the C++ mock test assemblies
CheckForError                 Checks for errors running the test suites
TestEngine                    Tests the engine
TestConsole                   Tests the console runner
PackageSource                 Creates a ZIP file of the source code
CreateImage                   Copies all files into the image directory
PackageEngine                 Creates NuGet packages of the engine
PackageConsole                Creates NuGet packages of the console runner
Build                         Builds the engine and console runner
Rebuild                       Rebuilds the engine and console runner
Test                          Builds and tests the engine and console runner
Package                       Packages the engine and console runner
Appveyor                      Builds, tests and packages on AppVeyor
Travis                        Builds and tests on Travis
Default                       Builds the engine and console runner
```