### PR TITLE
fix Issue #110 Writability check could give a friendlier message

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -169,7 +169,17 @@ namespace NUnit.ConsoleRunner
             foreach (var spec in _options.ResultOutputSpecifications)
             {
                 var outputPath = Path.Combine(_workDirectory, spec.OutputPath);
-                GetResultWriter(spec).CheckWritability(outputPath);
+                try
+                {
+                    GetResultWriter(spec).CheckWritability(outputPath);
+                }
+                catch (SystemException ex)
+                {
+                    throw new NUnitEngineException(
+                        String.Format(
+                            "The path specified in --result {0} could not be written to",
+                            spec.OutputPath), ex);
+                }
             }
 
             // TODO: Incorporate this in EventCollector?


### PR DESCRIPTION
Fix Issue #110 Writability check could give a friendlier message 
Throw a NUnitEngineException with the system exception set as the inner exception