### PR TITLE
Fixes #110 Writability check could give a friendlier message

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
@@ -19,8 +19,8 @@ namespace NUnit.ConsoleRunner.Tests
             try
             {
                 var directorySecurity = new DirectorySecurity();
-                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.Write, AccessControlType.Deny));
-                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.DeleteSubdirectoriesAndFiles, AccessControlType.Allow));
+                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().User, FileSystemRights.Write, AccessControlType.Deny));
+                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().User, FileSystemRights.DeleteSubdirectoriesAndFiles, AccessControlType.Allow));
                 Directory.SetAccessControl(tempDirPath, directorySecurity);
 
                 var consoleRunner = new ConsoleRunner(

--- a/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using NUnit.Common;
 using NUnit.Engine;
 using NUnit.Framework;
@@ -10,12 +13,28 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void ThrowsExceptionWhenWorkingDirectoryIsUnAuthorized()
         {
-            var options = new ConsoleOptions("tests.dll","-result=results.xml",@"--work=c:\windows\");
-            var engine = TestEngineActivator.CreateInstance();
-            var consoleRunner = new ConsoleRunner(engine, options, new ColorConsoleWriter());
+            var tempDirPath = Directory.GetCurrentDirectory() + "\\" + Path.GetRandomFileName();
+            var directory = Directory.CreateDirectory(tempDirPath);
 
-            var exception = Assert.Throws<UnauthorizedAccessException>(()=> { consoleRunner.Execute(); });
-            Assert.That(exception.Message, Is.EqualTo("Error: Unauthorized working directory"));
+            try
+            {
+                var directorySecurity = new DirectorySecurity();
+                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.Write, AccessControlType.Deny));
+                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, FileSystemRights.DeleteSubdirectoriesAndFiles, AccessControlType.Allow));
+                Directory.SetAccessControl(tempDirPath, directorySecurity);
+
+                var consoleRunner = new ConsoleRunner(
+                    TestEngineActivator.CreateInstance(), 
+                    new ConsoleOptions("tests.dll", "-result=results.xml", 
+                        string.Format(@"--work={0}", directory.FullName)), new ColorConsoleWriter());
+
+                var exception = Assert.Throws<UnauthorizedAccessException>(() => { consoleRunner.Execute(); });
+                Assert.That(exception.Message, Is.EqualTo("Error: Unauthorized working directory"));
+            }
+            finally
+            {
+                directory.Delete(true);
+            }
         }
     }
 }

--- a/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using NUnit.Common;
+using NUnit.Engine;
+using NUnit.Framework;
+
+namespace NUnit.ConsoleRunner.Tests
+{
+    class ConsoleRunnerTests
+    {
+        [Test]
+        public void ThrowsExceptionWhenWorkingDirectoryIsUnAuthorized()
+        {
+            var options = new ConsoleOptions("tests.dll","-result=results.xml",@"--work=c:\windows\");
+            var engine = TestEngineActivator.CreateInstance();
+            var consoleRunner = new ConsoleRunner(engine, options, new ColorConsoleWriter());
+
+            var exception = Assert.Throws<UnauthorizedAccessException>(()=> { consoleRunner.Execute(); });
+            Assert.That(exception.Message, Is.EqualTo("Error: Unauthorized working directory"));
+        }
+    }
+}

--- a/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
@@ -19,8 +19,9 @@ namespace NUnit.ConsoleRunner.Tests
             try
             {
                 var directorySecurity = new DirectorySecurity();
-                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().User, FileSystemRights.Write, AccessControlType.Deny));
-                directorySecurity.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().User, FileSystemRights.DeleteSubdirectoriesAndFiles, AccessControlType.Allow));
+                SecurityIdentifier everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+                directorySecurity.AddAccessRule(new FileSystemAccessRule(everyone, FileSystemRights.Write, AccessControlType.Deny));
+                directorySecurity.AddAccessRule(new FileSystemAccessRule(everyone, FileSystemRights.DeleteSubdirectoriesAndFiles, AccessControlType.Allow));
                 Directory.SetAccessControl(tempDirPath, directorySecurity);
 
                 var consoleRunner = new ConsoleRunner(

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="ColorStyleTests.cs" />
     <Compile Include="CommandLineTests.cs" />
     <Compile Include="ConsoleOutputTests.cs" />
+    <Compile Include="ConsoleRunnerTests.cs" />
     <Compile Include="DefaultOptionsProviderTests.cs" />
     <Compile Include="ExtendedTextWrapperTests.cs" />
     <Compile Include="MakeTestPackageTests.cs" />

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -156,7 +156,7 @@ namespace NUnit.ConsoleRunner
             {
                 foreach (OutputSpecification spec in _options.ExploreOutputSpecifications)
                 {
-                    _resultService.GetResultWriter(spec.Format, new object[] {spec.Transform}).WriteResultFile(result, spec.OutputPath);
+                    _resultService.GetResultWriter(spec.Format, new object[] { spec.Transform }).WriteResultFile(result, spec.OutputPath);
                     _outWriter.WriteLine("Results ({0}) saved as {1}", spec.Format, spec.OutputPath);
                 }
             }
@@ -169,7 +169,14 @@ namespace NUnit.ConsoleRunner
             foreach (var spec in _options.ResultOutputSpecifications)
             {
                 var outputPath = Path.Combine(_workDirectory, spec.OutputPath);
-                GetResultWriter(spec).CheckWritability(outputPath);
+                try
+                {
+                    GetResultWriter(spec).CheckWritability(outputPath);
+                }
+                catch (UnauthorizedAccessException e)
+                {
+                    throw new UnauthorizedAccessException("Error: Unauthorized working directory",e);
+                }
             }
 
             // TODO: Incorporate this in EventCollector?
@@ -259,8 +266,8 @@ namespace NUnit.ConsoleRunner
                     var unixVariant = Marshal.PtrToStringAnsi(buf);
                     if (unixVariant.Equals("Darwin"))
                         unixVariant = "MacOSX";
-                    
-                    osString = string.Format("{0} {1} {2}", unixVariant, os.Version, os.ServicePack); 
+
+                    osString = string.Format("{0} {1} {2}", unixVariant, os.Version, os.ServicePack);
                 }
                 Marshal.FreeHGlobal(buf);
             }
@@ -344,7 +351,7 @@ namespace NUnit.ConsoleRunner
 
         private IResultWriter GetResultWriter(OutputSpecification spec)
         {
-            return _resultService.GetResultWriter(spec.Format, new object[] {spec.Transform});
+            return _resultService.GetResultWriter(spec.Format, new object[] { spec.Transform });
         }
 
         // This is public static for ease of testing
@@ -366,7 +373,7 @@ namespace NUnit.ConsoleRunner
 
             // Console runner always sets DisposeRunners
             //if (options.DisposeRunners)
-                package.AddSetting(EnginePackageSettings.DisposeRunners, true);
+            package.AddSetting(EnginePackageSettings.DisposeRunners, true);
 
             if (options.ShadowCopyFiles)
                 package.AddSetting(EnginePackageSettings.ShadowCopyFiles, true);

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -128,6 +128,11 @@ namespace NUnit.ConsoleRunner
                     {
                         return new ConsoleRunner(engine, Options, OutWriter).Execute();
                     }
+                    catch (UnauthorizedAccessException ex)
+                    {
+                        OutWriter.WriteLine(ColorStyle.Error, ex.Message);
+                        return ConsoleRunner.INVALID_ARG;
+                    }
                     catch (TestSelectionParserException ex)
                     {
                         OutWriter.WriteLine(ColorStyle.Error, ex.Message);


### PR DESCRIPTION
This fixes #110.

I've added a test which uses `c:\windows` as the working directory in system which should not be authorized unless you are running from an elevated prompt. 

My PR is slightly different from #119 where I catch and throw an UnAuthorizedAccessException because,

1. I figured CheckWritability could fail for multiple reasons but this issue was more focused on permission issues.
2. I also modified Program.cs to catch UnAuthorizedException to suppress the stacktrace which I thought was unnecessary.
3. I've tried to follow the error message similar to other ones.

I also noticed that throwing an exception as soon as CheckWritability fails causes the Test Summary to be not printed. I feel this could be improved upon. @CharliePoole what do you think?