### PR TITLE
Remove all zip tasks

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -47,10 +47,6 @@ var NUNIT3_CONSOLE = BIN_DIR + "nunit3-console.exe";
 var ENGINE_TESTS = "nunit.engine.tests.dll";
 var CONSOLE_TESTS = "nunit3-console.tests.dll";
 
-// Packages
-var SRC_PACKAGE = PACKAGE_DIR + "NUnit-" + version + modifier + "-src.zip";
-var ZIP_PACKAGE = PACKAGE_DIR + "NUnit-" + packageVersion + ".zip";
-
 //////////////////////////////////////////////////////////////////////
 // CLEAN
 //////////////////////////////////////////////////////////////////////
@@ -245,14 +241,6 @@ var BinFiles = new FilePath[]
     "TestListWithEmptyLine.tst",
     "TextSummary.xslt",
 };
-
-Task("PackageSource")
-    .Description("Creates a ZIP file of the source code")
-    .Does(() =>
-    {
-        CreateDirectory(PACKAGE_DIR);
-        RunGitCommand(string.Format("archive -o {0} HEAD", SRC_PACKAGE));
-    });
 
 Task("CreateImage")
     .Description("Copies all files into the image directory")


### PR DESCRIPTION
From tidying up https://github.com/nunit/nunit-console/issues/133

`ZIP_PACKAGE` is no longer user. `SRC_PACKAGE` is no longer used in the release process, and I think keeping the task in the cake file causes more confusion than removing it. GitHub provides 1-click functionality if a source zip is still required for any reason. 