### PR TITLE
Fix problem with parallel loading and limitations on number of agents

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -54,7 +54,7 @@ namespace NUnit.Engine.Runners
             _runtimeService = _services.GetService<IRuntimeFrameworkService>();
             _extensionService = _services.GetService<ExtensionService>();
             _engineRunner = _services.GetService<ITestRunnerFactory>().MakeTestRunner(package);
-            LoadPackage();
+            //LoadPackage();
         }
 
         #region Properties

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -50,11 +50,13 @@ namespace NUnit.Engine.Runners
             _services = services;
             TestPackage = package;
 
+            // Get references to the services we use
             _projectService = _services.GetService<IProjectService>();
             _runtimeService = _services.GetService<IRuntimeFrameworkService>();
             _extensionService = _services.GetService<ExtensionService>();
             _engineRunner = _services.GetService<ITestRunnerFactory>().MakeTestRunner(package);
-            //LoadPackage();
+
+            InitializePackage();
         }
 
         #region Properties
@@ -204,10 +206,10 @@ namespace NUnit.Engine.Runners
         #region Helper Methods
 
         /// <summary>
-        /// Load a TestPackage for possible execution,
-        /// saving the result in the LoadResult property.
+        /// Check the package settings, expand projects and
+        /// determine what runtimes may be needed.
         /// </summary>
-        private void LoadPackage()
+        private void InitializePackage()
         {
             // Last chance to catch invalid settings in package,
             // in case the client runner missed them.
@@ -230,8 +232,6 @@ namespace NUnit.Engine.Runners
             {
                 throw new NUnitEngineException("Cannot run tests in process - a 32 bit process is required.");
             }
-
-            LoadResult = _engineRunner.Load().Aggregate(TEST_RUN_ELEMENT, TestPackage.Name, TestPackage.FullName);
         }
 
         private TestEngineResult PrepareResult(TestEngineResult result)

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -36,7 +36,27 @@ namespace NUnit.Engine
     /// </summary>
     [Serializable]
     public sealed class RuntimeFramework : IRuntimeFramework
-    {
+    { 
+        // TODO: RuntimeFramework was originally created for use in
+        // a single-threaded environment. The introduction of parallel
+        // execution and especially parallel loading of tests has
+        // exposed some weaknesses.
+        //
+        // Ideally, we should remove all knowledge of the environment
+        // from RuntimeFramework. An instance of RuntimeFramework does
+        // not need to know, for example, if it is available on the 
+        // current system. In the present architecture, that's really
+        // the job of the RuntimeFrameworkService. Other functions
+        // may actually belong in TestAgency.
+        //
+        // All the static properties of RuntimeFrameowork need to be
+        // examined for thread-safety, particularly CurrentFramework
+        // and AvailableFrameworks. The latter caused a problem with
+        // parallel loading, which has been fixed for now through a
+        // hack added to RuntimeFrameworkService. We may be able to
+        // move all this functionality to services, eliminating the
+        // use of public static properties here.
+
         #region Static Fields
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -33,12 +33,17 @@ namespace NUnit.Engine.Services
     {
         static Logger log = InternalTrace.GetLogger(typeof(RuntimeFrameworkService));
 
+        // HACK: This line forces RuntimeFramework to initialize the static property
+        // AvailableFrameworks before it is accessed by mulitiple threads. See comment
+        // on RuntimeFramework class for a more detailled explanation.
+        static RuntimeFramework[] _availableRuntimes = RuntimeFramework.AvailableFrameworks;
+
         /// <summary>
         /// Gets a list of available runtimes.
         /// </summary>
         public IList<IRuntimeFramework> AvailableRuntimes
         {
-            get { return RuntimeFramework.AvailableFrameworks; }
+            get { return _availableRuntimes; }
         }
 
         /// <summary>


### PR DESCRIPTION
A problem crept into the engine causing all assemblies to be loaded as soon as the MasterTestRunner was created. Of course, this causes all processes to be created at once, in spite of any limitation the user may have set with the `--agents` option.

After removing the offending line of code, I discovered that there were random failures occuring because of threading issues in RuntimeFramework. This will need a lot of work at some time, so I added an explanatory comment to RuntimeFramework. For the moment, the hack I added to RuntimeFrameworkService prevents the problem from occuring by forcing RuntimeFramework to initialize the list of available frameworks early enough that it's ready for use when multiple threads start trying to access it.

@chris-smith-zocdoc This is the fix you will want to have in your own PR. Since you are set up to test the situation of loading multiple assemblies in parallel, could you pull this and try it out? I have been running with only two processes and various command-line options. I haven't seen the exception thrown for the last dozen or so runs, so I'm fairly confident, but it's hard to test a negative!
