### PR TITLE
Display warnings in the console runner reports

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -74,7 +74,7 @@ namespace NUnit.ConsoleRunner.Tests
             var reportSequence = new[]
             {
                 "Tests Not Run",
-                "Errors and Failures",
+                "Errors, Failures and Warnings",
                 "Test Run Summary"
             };
 
@@ -95,7 +95,7 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new [] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-                "  Test Count: 28, Passed: 15, Failed: 5, Inconclusive: 1, Skipped: 7",
+                "  Test Count: 29, Passed: 15, Failed: 5, Warnings: 1, Inconclusive: 1, Skipped: 7",
                 "    Failed Tests - Failures: 1, Errors: 1, Invalid: 3",
                 "    Skipped Tests - Ignored: 4, Explicit: 3, Other: 0",
                 "  Start time: 2015-10-19 02:12:28Z",
@@ -114,7 +114,7 @@ namespace NUnit.ConsoleRunner.Tests
             var nl = Environment.NewLine;
 
             var expected = new[] {
-                "Errors and Failures",
+                "Errors, Failures and Warnings",
                 "1) Failed : NUnit.Tests.Assemblies.MockTestFixture.FailingTest" + nl +
                 "Intentional failure",
                 "2) Invalid : NUnit.Tests.Assemblies.MockTestFixture.NonPublicTest" + nl +
@@ -123,11 +123,13 @@ namespace NUnit.ConsoleRunner.Tests
                 "No arguments were provided",
                 "4) Error : NUnit.Tests.Assemblies.MockTestFixture.TestWithException" + nl +
                 "System.Exception : Intentional Exception",
-                "5) Invalid : NUnit.Tests.BadFixture" + nl +
+                "5) Warning : NUnit.Tests.Assemblies.MockTestFixture.WarningTest" + nl +
+                "Warning Message",
+                "6) Invalid : NUnit.Tests.BadFixture" + nl +
                 "No suitable constructor was found"
         };
-
-            var actualErrorFailuresReport = GetReport(_reporter.WriteErrorsAndFailuresReport);
+            
+            var actualErrorFailuresReport = GetReport(_reporter.WriteErrorsFailuresAndWarningsReport);
 
             foreach (var ex in expected)
             {

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -39,11 +39,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -38,15 +38,17 @@
     <NoWarn>1685</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-      <HintPath>..\..\..\packages\NUnit.3.4.1\lib\net20\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="NUnit.System.Linq, Version=0.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb">
-      <HintPath>..\..\..\packages\NUnit.3.4.1\lib\net20\NUnit.System.Linq.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">

--- a/src/NUnitConsole/nunit3-console.tests/packages.config
+++ b/src/NUnitConsole/nunit3-console.tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0-ci-03472-pr-1920" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-dev-03477" targetFramework="net20" />
 </packages>

--- a/src/NUnitConsole/nunit3-console.tests/packages.config
+++ b/src/NUnitConsole/nunit3-console.tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.4.1" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-ci-03472-pr-1920" targetFramework="net20" />
 </packages>

--- a/src/NUnitConsole/nunit3-console/ConsoleTestResult.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleTestResult.cs
@@ -149,7 +149,7 @@ namespace NUnit.ConsoleRunner
         {
             return Result == "Failed"
                 ? ColorStyle.Failure
-                : Status == "Ignored"
+                : Result == "Warning" || Status == "Ignored"
                     ? ColorStyle.Warning
                     : ColorStyle.Output;
         }

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -65,7 +65,7 @@ namespace NUnit.ConsoleRunner
                 WriteNotRunReport();
 
             if (OverallResult == "Failed")
-                WriteErrorsAndFailuresReport();
+                WriteErrorsFailuresAndWarningsReport();
 
             WriteRunSettingsReport();
 
@@ -114,6 +114,7 @@ namespace NUnit.ConsoleRunner
             WriteSummaryCount("  Test Count: ", Summary.TestCount);
             WriteSummaryCount(", Passed: ", Summary.PassCount);
             WriteSummaryCount(", Failed: ", Summary.FailedCount, ColorStyle.Failure);
+            WriteSummaryCount(", Warnings: ", Summary.WarningCount, ColorStyle.Warning);
             WriteSummaryCount(", Inconclusive: ", Summary.InconclusiveCount);
             WriteSummaryCount(", Skipped: ", Summary.TotalSkipCount);
             Writer.WriteLine();
@@ -145,15 +146,15 @@ namespace NUnit.ConsoleRunner
 
         #endregion
 
-        #region Errors and Failures Report
+        #region Errors, Failures and Warnings Report
 
-        public void WriteErrorsAndFailuresReport()
+        public void WriteErrorsFailuresAndWarningsReport()
         {
             ReportIndex = 0;
-            Writer.WriteLine(ColorStyle.SectionHeader, "Errors and Failures");
+            Writer.WriteLine(ColorStyle.SectionHeader, "Errors, Failures and Warnings");
             Writer.WriteLine();
 
-            WriteErrorsAndFailures(ResultNode);
+            WriteErrorsFailuresAndWarnings(ResultNode);
 
             if (Options.StopOnError)
             {
@@ -162,24 +163,24 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        private void WriteErrorsAndFailures(XmlNode resultNode)
+        private void WriteErrorsFailuresAndWarnings(XmlNode resultNode)
         {
             string resultState = resultNode.GetAttribute("result");
 
             switch (resultNode.Name)
             {
                 case "test-case":
-                    if (resultState == "Failed")
+                    if (resultState == "Failed" || resultState == "Warning")
                         new ConsoleTestResult(resultNode, ++ReportIndex).WriteResult(Writer);
                     return;
 
                 case "test-run":
                     foreach (XmlNode childResult in resultNode.ChildNodes)
-                        WriteErrorsAndFailures(childResult);
+                        WriteErrorsFailuresAndWarnings(childResult);
                     break;
 
                 case "test-suite":
-                    if (resultState == "Failed")
+                    if (resultState == "Failed" || resultState == "Warning")
                     {
                         if (resultNode.GetAttribute("type") == "Theory")
                         {
@@ -195,7 +196,7 @@ namespace NUnit.ConsoleRunner
                     }
                     
                     foreach (XmlNode childResult in resultNode.ChildNodes)
-                        WriteErrorsAndFailures(childResult);
+                        WriteErrorsFailuresAndWarnings(childResult);
 
                     break;
             }

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -81,6 +81,8 @@ namespace NUnit.ConsoleRunner
             get { return FailureCount + InvalidCount + ErrorCount;  }
         }
 
+        public int WarningCount { get; private set; }
+
         /// <summary>
         /// Returns the sum of skipped test cases, including ignored and explicit tests
         /// </summary>
@@ -155,6 +157,7 @@ namespace NUnit.ConsoleRunner
             TestCount = 0;
             PassCount = 0;
             FailureCount = 0;
+            WarningCount = 0;
             ErrorCount = 0;
             InconclusiveCount = 0;
             SkipCount = 0;
@@ -188,6 +191,9 @@ namespace NUnit.ConsoleRunner
                             else
                                 ErrorCount++;
                             break;
+                        case "Warning":
+                            WarningCount++;
+                            break;
                         case "Inconclusive":
                             InconclusiveCount++;
                             break;
@@ -200,7 +206,7 @@ namespace NUnit.ConsoleRunner
                                 SkipCount++;
                             break;
                         default:
-                            SkipCount++;
+                            //SkipCount++;
                             break;
                     }
                     break;

--- a/src/NUnitEngine/mock-assembly/MockAssembly.cs
+++ b/src/NUnitEngine/mock-assembly/MockAssembly.cs
@@ -79,19 +79,25 @@ namespace NUnit.Tests
             public const int ExplicitFixtures = 1;
             public const int SuitesRun = Suites - ExplicitFixtures;
 
-            public const int Ignored = MockTestFixture.Ignored + IgnoredFixture.Tests;
-            public const int Explicit = MockTestFixture.Explicit + ExplicitFixture.Tests;
-            public const int Skipped = Ignored + Explicit;
-            public const int NotRun = Ignored + Explicit + NotRunnable;
-            public const int TestsRun = Tests - NotRun;
-            public const int ResultCount = Tests - Explicit;
+            public const int Passed = MockTestFixture.Passed
+                        + Singletons.OneTestCase.Tests
+                        + TestAssembly.MockTestFixture.Tests
+                        + FixtureWithTestCases.Tests
+                        + ParameterizedFixture.Tests
+                        + GenericFixtureConstants.Tests;
 
-            public const int Errors = MockTestFixture.Errors;
-            public const int Failures = MockTestFixture.Failures;
-            public const int NotRunnable = MockTestFixture.NotRunnable + BadFixture.Tests;
-            public const int ErrorsAndFailures = Errors + Failures + NotRunnable;
+            public const int Skipped_Ignored = MockTestFixture.Skipped_Ignored + IgnoredFixture.Tests;
+            public const int Skipped_Explicit = MockTestFixture.Skipped_Explicit + ExplicitFixture.Tests;
+            public const int Skipped = Skipped_Ignored + Skipped_Explicit;
+
+            public const int Failed_Error = MockTestFixture.Failed_Error;
+            public const int Failed_Other = MockTestFixture.Failed_Other;
+            public const int Failed_NotRunnable = MockTestFixture.Failed_NotRunnable + BadFixture.Tests;
+            public const int Failed = Failed_Error + Failed_Other + Failed_NotRunnable;
+
+            public const int Warnings = MockTestFixture.Warnings;
+
             public const int Inconclusive = MockTestFixture.Inconclusive;
-            public const int Success = TestsRun - Errors - Failures - Inconclusive;
 
             public static readonly string AssemblyPath = AssemblyHelper.GetAssemblyPath(typeof(MockAssembly).Assembly);
         }
@@ -100,20 +106,21 @@ namespace NUnit.Tests
         [Category("FixtureCategory")]
         public class MockTestFixture
         {
-            public const int Tests = 8;
+            public const int Tests = 9;
             public const int Suites = 1;
 
-            public const int Ignored = 1;
-            public const int Explicit = 1;
+            public const int Passed = 1;
 
-            public const int NotRun = Ignored + Explicit;
-            public const int TestsRun = Tests - NotRun;
-            public const int ResultCount = Tests - Explicit;
+            public const int Skipped_Ignored = 1;
+            public const int Skipped_Explicit = 1;
+            public const int Skipped = Skipped_Ignored + Skipped_Explicit;
 
-            public const int Failures = 1;
-            public const int Errors = 1;
-            public const int NotRunnable = 2;
-            public const int ErrorsAndFailures = Errors + Failures + NotRunnable;
+            public const int Failed_Other = 1;
+            public const int Failed_Error = 1;
+            public const int Failed_NotRunnable = 2;
+            public const int Failed = Failed_Error + Failed_Other + Failed_NotRunnable;
+
+            public const int Warnings = 1;
 
             public const int Inconclusive = 1;
 
@@ -130,6 +137,12 @@ namespace NUnit.Tests
             {
                 Console.Error.WriteLine("Immediate Error Message");
                 Assert.Fail("Intentional failure");
+            }
+
+            [Test]
+            public void WarningTest()
+            {
+                Assert.Warn("Warning Message");
             }
 
             [Test, Ignore("Ignore Message")]

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -65,12 +65,12 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.4.1\lib\net20\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NUnit.System.Linq, Version=0.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.4.1\lib\net20\NUnit.System.Linq.dll</HintPath>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System">

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -66,11 +66,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System">

--- a/src/NUnitEngine/mock-assembly/packages.config
+++ b/src/NUnitEngine/mock-assembly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0-ci-03472-pr-1920" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-dev-03477" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/mock-assembly/packages.config
+++ b/src/NUnitEngine/mock-assembly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.4.1" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-ci-03472-pr-1920" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -138,8 +138,8 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(result.GetAttribute("runstate"), Is.EqualTo("Runnable"));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("passed"), Is.EqualTo(MockAssembly.Success.ToString()));
-            Assert.That(result.GetAttribute("failed"), Is.EqualTo(MockAssembly.ErrorsAndFailures.ToString()));
+            Assert.That(result.GetAttribute("passed"), Is.EqualTo(MockAssembly.Passed.ToString()));
+            Assert.That(result.GetAttribute("failed"), Is.EqualTo(MockAssembly.Failed.ToString()));
             Assert.That(result.GetAttribute("skipped"), Is.EqualTo(MockAssembly.Skipped.ToString()));
             Assert.That(result.GetAttribute("inconclusive"), Is.EqualTo(MockAssembly.Inconclusive.ToString()));
             Assert.That(result.SelectNodes("test-suite").Count, Is.GreaterThan(0), "Explore result should have child tests");

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -120,8 +120,8 @@ namespace NUnit.Engine.Runners.Tests
             Assert.That(result.Name, Is.EqualTo("test-run"));
             Assert.That(result.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Success));
-            Assert.That(result.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Passed));
+            Assert.That(result.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.Failed));
             Assert.That(result.GetAttribute("skipped", 0), Is.EqualTo(MockAssembly.Skipped));
             Assert.That(result.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));
 
@@ -129,8 +129,8 @@ namespace NUnit.Engine.Runners.Tests
             Assert.NotNull("No suite found");
             Assert.That(suite.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(suite.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(suite.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Success));
-            Assert.That(suite.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(suite.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Passed));
+            Assert.That(suite.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.Failed));
             Assert.That(suite.GetAttribute("skipped", 0), Is.EqualTo(MockAssembly.Skipped));
             Assert.That(suite.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));
 

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -165,8 +165,8 @@ namespace NUnit.Engine.Runners.Tests
         private void CheckRunResult(XmlNode result)
         {
             CheckBasicResult(result);
-            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Success));
-            Assert.That(result.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.ErrorsAndFailures));
+            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Passed));
+            Assert.That(result.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.Failed));
             Assert.That(result.GetAttribute("skipped", 0), Is.EqualTo(MockAssembly.Skipped));
             Assert.That(result.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));
         }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -39,11 +39,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -38,12 +38,12 @@
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.4.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.4.1\lib\net20\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NUnit.System.Linq, Version=0.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.4.1\lib\net20\NUnit.System.Linq.dll</HintPath>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.6.0-ci-03472-pr-1920\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnitEngine/nunit.engine.tests/packages.config
+++ b/src/NUnitEngine/nunit.engine.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net20" />
-  <package id="NUnit" version="3.4.1" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-ci-03472-pr-1920" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/nunit.engine.tests/packages.config
+++ b/src/NUnitEngine/nunit.engine.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net20" />
-  <package id="NUnit" version="3.6.0-ci-03472-pr-1920" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-dev-03477" targetFramework="net20" />
 </packages>


### PR DESCRIPTION
Fixes #138 

This basically ports the changes made to the nunitlite reports to the console runner so that warnings are listed along with failures and errors.
