### PR TITLE
Add option to skip non-test assemblies

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -60,6 +60,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "runners", "runners", "{F3E8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mock-assembly", "src\NUnitEngine\mock-assembly\mock-assembly.csproj", "{D2C80E4B-1117-4F02-AB02-E453BDA0C58E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "notest-assembly", "src\NUnitEngine\notest-assembly\notest-assembly.csproj", "{B1D90742-39BD-429C-8E87-C5CD2991DF27}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +100,10 @@ Global
 		{D2C80E4B-1117-4F02-AB02-E453BDA0C58E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D2C80E4B-1117-4F02-AB02-E453BDA0C58E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D2C80E4B-1117-4F02-AB02-E453BDA0C58E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1D90742-39BD-429C-8E87-C5CD2991DF27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1D90742-39BD-429C-8E87-C5CD2991DF27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1D90742-39BD-429C-8E87-C5CD2991DF27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1D90742-39BD-429C-8E87-C5CD2991DF27}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -114,6 +120,7 @@ Global
 		{43A219A8-2995-4884-806F-FDB9CD25D403} = {A972031D-2F61-4183-AF75-99EE1A9F6B32}
 		{F3E87D0F-6F06-4C0B-AE06-42C0834C3C6E} = {A972031D-2F61-4183-AF75-99EE1A9F6B32}
 		{D2C80E4B-1117-4F02-AB02-E453BDA0C58E} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
+		{B1D90742-39BD-429C-8E87-C5CD2991DF27} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\NUnitFramework\tests\nunitlite.tests-2.0.csproj

--- a/build.cake
+++ b/build.cake
@@ -130,6 +130,7 @@ Task("BuildEngine")
 
         // Engine tests
         BuildProject("./src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj", configuration);
+        BuildProject("./src/NUnitEngine/notest-assembly/notest-assembly.csproj", configuration);
     });
 
 //////////////////////////////////////////////////////////////////////
@@ -220,6 +221,7 @@ var BinFiles = new FilePath[]
     "ConsoleTests.nunit",
     "EngineTests.nunit",
     "mock-assembly.dll",
+	"notest-assembly.dll",
     "Mono.Cecil.dll",
     "nunit-agent-x86.exe",
     "nunit-agent-x86.exe.config",

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -81,6 +81,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("DebugTests", "debug")]
         [TestCase("PauseBeforeRun", "pause")]
         [TestCase("LoadUserProfile", "loaduserprofile")]
+        [TestCase("SkipNonTestAssemblies", "skipnontestassemblies")]
 #if DEBUG
         [TestCase("DebugAgent", "debug-agent")]
 #endif

--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -74,6 +74,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--debug", "DebugTests", true)]
         [TestCase("--pause", "PauseBeforeRun", true)]
         [TestCase("--params:X=5;Y=7", "TestParameters", "X=5;Y=7")]
+        [TestCase("--skipnontestassemblies", "SkipNonTestAssemblies", true)]
 #if DEBUG
         [TestCase("--debug-agent", "DebugAgent", true)]
 #endif

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -39,11 +39,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03507\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03507\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnitConsole/nunit3-console.tests/packages.config
+++ b/src/NUnitConsole/nunit3-console.tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0-dev-03477" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-dev-03507" targetFramework="net20" />
 </packages>

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -82,6 +82,8 @@ namespace NUnit.Common
 
         public bool LoadUserProfile { get; private set; }
 
+        public bool SkipNonTestAssemblies { get; private set; }
+
         private int _maxAgents = -1;
         public int MaxAgents { get { return _maxAgents; } }
         public bool MaxAgentsSpecified { get { return _maxAgents >= 0; } }
@@ -150,6 +152,9 @@ namespace NUnit.Common
 
             this.Add("loaduserprofile", "Load user profile in test runner processes",
                 v => LoadUserProfile = v != null);
+
+            this.Add("skipnontestassemblies", "Skip any non-test assemblies specified, without error.",
+                v => SkipNonTestAssemblies = v != null);
 
             this.Add("agents=", "Specify the maximum {NUMBER} of test assembly agents to run at one time. If not specified, there is no limit.",
                 v => _maxAgents = RequiredInt(v, "--agents"));

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -384,6 +384,9 @@ namespace NUnit.ConsoleRunner
             if (options.LoadUserProfile)
                 package.AddSetting(EnginePackageSettings.LoadUserProfile, true);
 
+            if (options.SkipNonTestAssemblies)
+                package.AddSetting(EnginePackageSettings.SkipNonTestAssemblies, true);
+
             if (options.DefaultTimeout >= 0)
                 package.AddSetting(FrameworkPackageSettings.DefaultTimeout, options.DefaultTimeout);
 

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -129,6 +129,11 @@ namespace NUnit
         public const string LoadUserProfile = "LoadUserProfile";
 
         /// <summary>
+        /// Bool flag indicating that non-test assemblies should be skipped without error.
+        /// </summary>
+        public const string SkipNonTestAssemblies = "SkipNonTestAssemblies";
+
+        /// <summary>
         /// Flag (bool) indicating whether to pause execution of tests to allow
         /// the user to attache a debugger.
         /// </summary>

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -66,11 +66,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03507\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03507\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System">

--- a/src/NUnitEngine/mock-assembly/packages.config
+++ b/src/NUnitEngine/mock-assembly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0-dev-03477" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-dev-03507" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/notest-assembly/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/notest-assembly/Properties/AssemblyInfo.cs
@@ -1,0 +1,40 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("notest-assembly")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Hewlett-Packard")]
+[assembly: AssemblyProduct("notest-assembly")]
+[assembly: AssemblyCopyright("Copyright © Hewlett-Packard 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b1d90742-39bd-429c-8e87-c5cd2991df27")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Even though this assembly has a reference to the NUnit
+// framework, it declares itself ask not containing tests.
+[assembly: NUnit.Framework.NonTestAssembly]

--- a/src/NUnitEngine/notest-assembly/notest-assembly.csproj
+++ b/src/NUnitEngine/notest-assembly/notest-assembly.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B1D90742-39BD-429C-8E87-C5CD2991DF27}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>notest_assembly</RootNamespace>
+    <AssemblyName>notest-assembly</AssemblyName>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0-dev-03507\lib\net20\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0-dev-03507\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NUnitEngine/notest-assembly/packages.config
+++ b/src/NUnitEngine/notest-assembly/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.0-dev-03507" targetFramework="net20" />
+</packages>

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -27,94 +27,110 @@ using System.Xml;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using NUnit.Engine.Extensibility;
+using System;
 
 namespace NUnit.Engine.Drivers.Tests
 {
     // Functional tests of the NUnitFrameworkDriver calling into the framework.
-    public class NotRunnableFrameworkDriverTests
+    public abstract class NotRunnableFrameworkDriverTests
     {
-        private const string REASON = "Assembly could not be found";
+        private const string DRIVER_ID = "99";
+        private const string EXPECTED_ID = "99-1";
+
+        protected string _expectedRunState;
+        protected string _expectedReason;
+        protected string _expectedResult;
+        protected string _expectedLabel;
 
         [TestCase("junk.dll", "Assembly")]
         [TestCase("junk.exe", "Assembly")]
         [TestCase("junk.cfg", "Unknown")]
-        public void Load_ReturnsNonRunnableSuite(string badFile, string expectedType)
+        public void Load(string filePath, string expectedType)
         {
-            IFrameworkDriver driver = CreateDriver(badFile);
-            var result = XmlHelper.CreateXmlNode(driver.Load(badFile, new Dictionary<string, object>()));
+            IFrameworkDriver driver = GetDriver(filePath);
+            var result = XmlHelper.CreateXmlNode(driver.Load(filePath, new Dictionary<string, object>()));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
             Assert.That(result.GetAttribute("type"), Is.EqualTo(expectedType));
-            Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
-            Assert.That(result.GetAttribute("name"), Is.EqualTo(badFile));
-            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(badFile)));
-            Assert.That(result.GetAttribute("runstate"), Is.EqualTo("NotRunnable"));
+            Assert.That(result.GetAttribute("id"), Is.EqualTo(EXPECTED_ID));
+            Assert.That(result.GetAttribute("name"), Is.EqualTo(filePath));
+            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(filePath)));
+            Assert.That(result.GetAttribute("runstate"), Is.EqualTo(_expectedRunState));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));
-            Assert.That(GetSkipReason(result), Is.EqualTo(REASON));
+            Assert.That(GetSkipReason(result), Is.EqualTo(_expectedReason));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
         }
 
         [TestCase("junk.dll", "Assembly")]
         [TestCase("junk.exe", "Assembly")]
         [TestCase("junk.cfg", "Unknown")]
-        public void Explore_ReturnsNonRunnableSuite(string badFile, string expectedType)
+        public void Explore(string filePath, string expectedType)
         {
-            IFrameworkDriver driver = CreateDriver(badFile);
+            IFrameworkDriver driver = GetDriver(filePath);
             var result = XmlHelper.CreateXmlNode(driver.Explore(TestFilter.Empty.Text));
 
             Assert.That(result.Name, Is.EqualTo("test-suite"));
-            Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
-            Assert.That(result.GetAttribute("name"), Is.EqualTo(badFile));
-            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(badFile)));
+            Assert.That(result.GetAttribute("id"), Is.EqualTo(EXPECTED_ID));
+            Assert.That(result.GetAttribute("name"), Is.EqualTo(filePath));
+            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(filePath)));
             Assert.That(result.GetAttribute("type"), Is.EqualTo(expectedType));
-            Assert.That(result.GetAttribute("runstate"), Is.EqualTo("NotRunnable"));
+            Assert.That(result.GetAttribute("runstate"), Is.EqualTo(_expectedRunState));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));
-            Assert.That(GetSkipReason(result), Is.EqualTo(REASON));
+            Assert.That(GetSkipReason(result), Is.EqualTo(_expectedReason));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Result should not have child tests");
         }
 
         [TestCase("junk.dll")]
         [TestCase("junk.exe")]
         [TestCase("junk.cfg")]
-        public void CountTestCases_ReturnsZero(string badFile)
+        public void CountTestCases(string filePath)
         {
-            IFrameworkDriver driver = CreateDriver(badFile);
+            IFrameworkDriver driver = CreateDriver(filePath);
             Assert.That(driver.CountTestCases(TestFilter.Empty.Text), Is.EqualTo(0));
         }
 
         [TestCase("junk.dll", "Assembly")]
         [TestCase("junk.exe", "Assembly")]
         [TestCase("junk.cfg", "Unknown")]
-        public void Run_ReturnsNonRunnableSuite(string badFile, string expectedType)
+        public void Run(string filePath, string expectedType)
         {
-            IFrameworkDriver driver = CreateDriver(badFile);
+            IFrameworkDriver driver = GetDriver(filePath);
             var result = XmlHelper.CreateXmlNode(driver.Run(new NullListener(), TestFilter.Empty.Text));
             Assert.That(result.Name, Is.EqualTo("test-suite"));
-            Assert.That(result.GetAttribute("id"), Is.EqualTo("99-1"));
-            Assert.That(result.GetAttribute("name"), Is.EqualTo(badFile));
-            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(badFile)));
+            Assert.That(result.GetAttribute("id"), Is.EqualTo(EXPECTED_ID));
+            Assert.That(result.GetAttribute("name"), Is.EqualTo(filePath));
+            Assert.That(result.GetAttribute("fullname"), Is.EqualTo(Path.GetFullPath(filePath)));
             Assert.That(result.GetAttribute("type"), Is.EqualTo(expectedType));
-            Assert.That(result.GetAttribute("runstate"), Is.EqualTo("NotRunnable"));
+            Assert.That(result.GetAttribute("runstate"), Is.EqualTo(_expectedRunState));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo("0"));
-            Assert.That(GetSkipReason(result), Is.EqualTo(REASON));
+            Assert.That(GetSkipReason(result), Is.EqualTo(_expectedReason));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
-            Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("label"), Is.EqualTo("Invalid"));
-            Assert.That(result.SelectSingleNode("reason/message").InnerText, Is.EqualTo(REASON));
+            Assert.That(result.GetAttribute("result"), Is.EqualTo(_expectedResult));
+            Assert.That(result.GetAttribute("label"), Is.EqualTo(_expectedLabel));
+            Assert.That(result.SelectSingleNode("reason/message").InnerText, Is.EqualTo(_expectedReason));
         }
 
+        #region Abstract Properties and Methods
+
+        protected abstract IFrameworkDriver CreateDriver(string filePath);
+
+        #endregion
+
         #region Helper Methods
-        private IFrameworkDriver CreateDriver(string filePath)
+
+        private IFrameworkDriver GetDriver(string filePath)
         {
-            IFrameworkDriver driver = new InvalidAssemblyFrameworkDriver(filePath, REASON);
-            driver.ID = "99";
+            IFrameworkDriver driver = CreateDriver(filePath);
+            driver.ID = DRIVER_ID;
             return driver;
         }
+
         private static string GetSkipReason(XmlNode result)
         {
             var propNode = result.SelectSingleNode(string.Format("properties/property[@name='{0}']", PropertyNames.SkipReason));
             return propNode == null ? null : propNode.GetAttribute("value");
         }
+
         #endregion
 
         #region Nested NullListener Class
@@ -126,5 +142,37 @@ namespace NUnit.Engine.Drivers.Tests
             }
         }
         #endregion
+    }
+
+    public class InvalidAssemblyFrameworkDriverTests : NotRunnableFrameworkDriverTests
+    {
+        public InvalidAssemblyFrameworkDriverTests()
+        {
+            _expectedRunState = "NotRunnable";
+            _expectedReason = "Assembly could not be found";
+            _expectedResult = "Failed";
+            _expectedLabel = "Invalid";
+        }
+
+        protected override IFrameworkDriver CreateDriver(string filePath)
+        {
+            return new InvalidAssemblyFrameworkDriver(filePath, _expectedReason);
+        }
+    }
+
+    public class SkippedAssemblyFrameworkDriverTests : NotRunnableFrameworkDriverTests
+    {
+        public SkippedAssemblyFrameworkDriverTests()
+        {
+            _expectedRunState = "Runnable";
+            _expectedReason = "Skipping non-test assembly";
+            _expectedResult = "Skipped";
+            _expectedLabel = "NoTests";
+        }
+
+        protected override IFrameworkDriver CreateDriver(string filePath)
+        {
+            return new SkippedAssemblyFrameworkDriver(filePath);
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -106,7 +106,7 @@ namespace NUnit.Engine.Drivers.Tests
         #region Helper Methods
         private IFrameworkDriver CreateDriver(string filePath)
         {
-            IFrameworkDriver driver = new NotRunnableFrameworkDriver(filePath, REASON);
+            IFrameworkDriver driver = new InvalidAssemblyFrameworkDriver(filePath, REASON);
             driver.ID = "99";
             return driver;
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -52,16 +52,23 @@ namespace NUnit.Engine.Services.Tests
         }
 
 
-        [TestCase("mock-assembly.dll", typeof(NUnit3FrameworkDriver))]
-        [TestCase("mock-assembly.pdb", typeof(InvalidAssemblyFrameworkDriver))]
-        [TestCase("junk.dll", typeof(InvalidAssemblyFrameworkDriver))]
-        public void CorrectDriverIsUsed(string fileName, Type expectedType)
+        [TestCase("mock-assembly.dll", false, typeof(NUnit3FrameworkDriver))]
+        [TestCase("mock-assembly.dll", true, typeof(NUnit3FrameworkDriver))]
+        [TestCase("mock-assembly.pdb", false, typeof(InvalidAssemblyFrameworkDriver))]
+        [TestCase("mock-assembly.pdb", true, typeof(InvalidAssemblyFrameworkDriver))]
+        [TestCase("junk.dll", false, typeof(InvalidAssemblyFrameworkDriver))]
+        [TestCase("junk.dll", true, typeof(InvalidAssemblyFrameworkDriver))]
+        [TestCase("nunit.engine.dll", false, typeof(InvalidAssemblyFrameworkDriver))]
+        [TestCase("nunit.engine.dll", true, typeof(SkippedAssemblyFrameworkDriver))]
+        [TestCase("notest-assembly.dll", false, typeof(NUnit3FrameworkDriver))]
+        [TestCase("notest-assembly.dll", true, typeof(SkippedAssemblyFrameworkDriver))]
+        public void CorrectDriverIsUsed(string fileName, bool skipNonTestAssemblies, Type expectedType)
         {
             var driver = _driverService.GetDriver(
                 AppDomain.CurrentDomain,
                 Path.Combine(TestContext.CurrentContext.TestDirectory, fileName),
                 null,
-                false);
+                skipNonTestAssemblies);
 
             Assert.That(driver, Is.InstanceOf(expectedType));
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -53,14 +53,15 @@ namespace NUnit.Engine.Services.Tests
 
 
         [TestCase("mock-assembly.dll", typeof(NUnit3FrameworkDriver))]
-        [TestCase("mock-assembly.pdb", typeof(NotRunnableFrameworkDriver))]
-        [TestCase("junk.dll", typeof(NotRunnableFrameworkDriver))]
+        [TestCase("mock-assembly.pdb", typeof(InvalidAssemblyFrameworkDriver))]
+        [TestCase("junk.dll", typeof(InvalidAssemblyFrameworkDriver))]
         public void CorrectDriverIsUsed(string fileName, Type expectedType)
         {
             var driver = _driverService.GetDriver(
                 AppDomain.CurrentDomain,
                 Path.Combine(TestContext.CurrentContext.TestDirectory, fileName),
-                null);
+                null,
+                false);
 
             Assert.That(driver, Is.InstanceOf(expectedType));
         }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -47,11 +47,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\nunit.framework.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03507\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03477\lib\net20\NUnit.System.Linq.dll</HintPath>
+      <HintPath>..\..\..\packages\NUnit.3.6.0-dev-03507\lib\net20\NUnit.System.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/NUnitEngine/nunit.engine.tests/packages.config
+++ b/src/NUnitEngine/nunit.engine.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net20" />
-  <package id="NUnit" version="3.6.0-dev-03477" targetFramework="net20" />
+  <package id="NUnit" version="3.6.0-dev-03507" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NotRunnableFrameworkDriver.cs
@@ -27,22 +27,22 @@ using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Drivers
 {
-    public class NotRunnableFrameworkDriver : IFrameworkDriver
+    public abstract class NotRunnableFrameworkDriver : IFrameworkDriver
     {
         private const string LOAD_RESULT_FORMAT =
-            "<test-suite type='{0}' id='{1}' name='{2}' fullname='{3}' testcasecount='0' runstate='NotRunnable'>" +
+            "<test-suite type='{0}' id='{1}' name='{2}' fullname='{3}' testcasecount='0' runstate='{4}'>" +
                 "<properties>" +
-                    "<property name='_SKIPREASON' value='{4}'/>" +
+                    "<property name='_SKIPREASON' value='{5}'/>" +
                 "</properties>" +
             "</test-suite>";
 
         private const string RUN_RESULT_FORMAT =
-            "<test-suite type='{0}' id='{1}' name='{2}' fullname='{3}' testcasecount='0' runstate='NotRunnable' result='Failed' label='Invalid'>" +
+            "<test-suite type='{0}' id='{1}' name='{2}' fullname='{3}' testcasecount='0' runstate='{4}' result='{5}' label='{6}'>" +
                 "<properties>" +
-                    "<property name='_SKIPREASON' value='{4}'/>" +
+                    "<property name='_SKIPREASON' value='{7}'/>" +
                 "</properties>" +
                 "<reason>" +
-                    "<message>{4}</message>" +
+                    "<message>{7}</message>" +
                 "</reason>" +
             "</test-suite>";
 
@@ -51,19 +51,23 @@ namespace NUnit.Engine.Drivers
         private string _message;
         private string _type;
 
+        protected string _runstate;
+        protected string _result;
+        protected string _label;
+
         public NotRunnableFrameworkDriver(string assemblyPath, string message)
         {
             _name = Escape(Path.GetFileName(assemblyPath));
             _fullname = Escape(Path.GetFullPath(assemblyPath));
             _message = Escape(message);
-            _type = new List<string> {".dll", ".exe"}.Contains(Path.GetExtension(assemblyPath)) ? "Assembly" : "Unknown";
+            _type = new List<string> { ".dll", ".exe" }.Contains(Path.GetExtension(assemblyPath)) ? "Assembly" : "Unknown";
         }
 
         public string ID { get; set; }
 
         public string Load(string assemblyPath, IDictionary<string, object> settings)
         {
-            return string.Format(LOAD_RESULT_FORMAT, _type, TestID, _name, _fullname, _message);
+            return GetLoadResult();
         }
 
         public int CountTestCases(string filter)
@@ -73,12 +77,13 @@ namespace NUnit.Engine.Drivers
 
         public string Run(ITestEventListener listener, string filter)
         {
-            return string.Format(RUN_RESULT_FORMAT, _type, TestID, _name, _fullname, _message);
+            return string.Format(RUN_RESULT_FORMAT, 
+                _type, TestID, _name, _fullname, _runstate, _result, _label, _message);
         }
 
         public string Explore(string filter)
         {
-            return string.Format(LOAD_RESULT_FORMAT, _type, TestID, _name, _fullname, _message);
+            return GetLoadResult();
         }
 
         public void StopRun(bool force)
@@ -95,6 +100,13 @@ namespace NUnit.Engine.Drivers
                 .Replace(">", "&gt;");
         }
 
+        private string GetLoadResult()
+        {
+            return string.Format(
+                LOAD_RESULT_FORMAT,
+                _type, TestID, _name, _fullname, _runstate, _message);
+        }
+
         private string TestID
         {
             get
@@ -103,6 +115,28 @@ namespace NUnit.Engine.Drivers
                     ? "1"
                     : ID + "-1";
             }
+        }
+    }
+
+    public class InvalidAssemblyFrameworkDriver :NotRunnableFrameworkDriver
+    {
+        public InvalidAssemblyFrameworkDriver(string assemblyPath, string message)
+            : base(assemblyPath, message)
+        {
+            _runstate = "NotRunnable";
+            _result = "Failed";
+            _label = "Invalid";
+        }
+    }
+
+    public class SkippedAssemblyFrameworkDriver : NotRunnableFrameworkDriver
+    {
+        public SkippedAssemblyFrameworkDriver(string assemblyPath)
+            : base(assemblyPath, "Skipping non-test assembly")
+        {
+            _runstate = "Runnable";
+            _result = "Skipped";
+            _label = "NoTests";
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -129,6 +129,11 @@ namespace NUnit
         public const string LoadUserProfile = "LoadUserProfile";
 
         /// <summary>
+        /// Bool flag indicating that non-test assemblies should be skipped without error.
+        /// </summary>
+        public const string SkipNonTestAssemblies = "SkipNonTestAssemblies";
+
+        /// <summary>
         /// Flag (bool) indicating whether to pause execution of tests to allow
         /// the user to attach a debugger.
         /// </summary>

--- a/src/NUnitEngine/nunit.engine/IDriverService.cs
+++ b/src/NUnitEngine/nunit.engine/IDriverService.cs
@@ -39,6 +39,6 @@ namespace NUnit.Engine
         /// <param name="assemblyPath">The path to the test assembly</param>
         /// <param name="targetFramework">The value of any TargetFrameworkAttribute on the assembly, or null</param>
         /// <returns></returns>
-        IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, string targetFramework);
+        IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, string targetFramework, bool skipNonTestAssemblies);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -104,9 +104,10 @@ namespace NUnit.Engine.Runners
                     _assemblyResolver.AddPathFromFile(testFile);
                 }
 
-                var targetFramework = subPackage.GetSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, (string)null);
-
-                IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile, targetFramework);
+                string targetFramework = subPackage.GetSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, (string)null);
+                bool skipNonTestAssemblies = subPackage.GetSetting(EnginePackageSettings.SkipNonTestAssemblies, false);
+                
+                IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile, targetFramework, skipNonTestAssemblies);
                 driver.ID = TestPackage.ID;
                 result.Add(driver.Load(testFile, subPackage.Settings));
                 _drivers.Add(driver);

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -72,7 +72,7 @@ namespace NUnit.Engine.Services
                 if (skipNonTestAssemblies)
                 {
                     foreach (var attr in assemblyDef.CustomAttributes)
-                        if (attr.AttributeType.FullName == "NUnit.Framework.NonTestAssembly")
+                        if (attr.AttributeType.FullName == "NUnit.Framework.NonTestAssemblyAttribute")
                             return new SkippedAssemblyFrameworkDriver(assemblyPath);
                 }
 


### PR DESCRIPTION
Fixes #62 

I followed the choices laid out in the discussion on the issue. The use of NonTestAssemblyAttribute was tested on an adhoc basis but would still need to be added to the framework.