### PR TITLE
Fix --framework option

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -378,17 +378,12 @@ void CheckForError(ref List<string> errorDetail)
 
 void BuildProject(string projectPath, string configuration)
 {
-    BuildProject(projectPath, configuration, MSBuildPlatform.Automatic);
-}
-
-void BuildProject(string projectPath, string configuration, MSBuildPlatform buildPlatform)
-{
     if(IsRunningOnWindows())
     {
         // Use MSBuild
         MSBuild(projectPath, new MSBuildSettings()
             .SetConfiguration(configuration)
-            .SetMSBuildPlatform(buildPlatform)
+            .SetMSBuildPlatform(MSBuildPlatform.Automatic)
             .SetVerbosity(Verbosity.Minimal)
             .SetNodeReuse(false)
 			.SetPlatformTarget(PlatformTarget.MSIL)
@@ -396,6 +391,7 @@ void BuildProject(string projectPath, string configuration, MSBuildPlatform buil
     }
     else
     {
+        Information(string.Format("Building {0}...", projectPath));
         // Use XBuild
         XBuild(projectPath, new XBuildSettings()
             .WithTarget("Build")

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -74,5 +74,20 @@ namespace NUnit.Engine.Services.Tests
             foreach (var framework in available)
                 Console.WriteLine("Available: {0}", framework.DisplayName);
         }
+
+        [TestCase("mono", 4, 5, "net-4.5")]
+        [TestCase("net", 4, 0, "net-4.5")]
+        [TestCase("net", 4, 5, "net-4.5")]
+
+        public void EngineOptionPreferredOverImageTarget(string framework, int majorVersion, int minorVersion, string requested)
+        {
+            var package = new TestPackage("test");
+            package.AddSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, framework);
+            package.AddSetting(InternalEnginePackageSettings.ImageRuntimeVersion, new Version(majorVersion, minorVersion));
+            package.AddSetting(EnginePackageSettings.RuntimeFramework, requested);
+
+            _runtimeService.SelectRuntimeFramework(package);
+            Assert.That(package.GetSetting<string>(EnginePackageSettings.RuntimeFramework, null), Is.EqualTo(requested));
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1685</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,9 +34,16 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1685</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
@@ -138,6 +146,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\nunit.snk">
+      <Link>nunit.snk</Link>
+    </None>
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/src/NUnitEngine/nunit.engine/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/nunit.engine/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -15,3 +16,10 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("5796938b-03c9-4b75-8b43-89a8adc4acd0")]
+
+[assembly: InternalsVisibleTo("nunit.engine.tests, PublicKey="+
+    "002400000480000094000000060200000024000052534131000400000100010031eea370b1984b" +
+    "fa6d1ea760e1ca6065cee41a1a279ca234933fe977a096222c0e14f9e5a17d5689305c6d7f1206"+
+    "a85a53c48ca010080799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9bee5e972a004"+
+    "ddd692dec8fa404ba4591e847a8cf35de21c2d3723bc8d775a66b594adeb967537729fe2a446b5"+
+    "48cd57a6")]

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -96,7 +96,10 @@ namespace NUnit.Engine.Services
         /// <returns>A string representing the selected RuntimeFramework</returns>
         public string SelectRuntimeFramework(TestPackage package)
         {
-            // Start by examining the provided settings
+            // Evaluate package target framework
+            ApplyImageData(package);
+
+            // Examine the provided settings
             RuntimeFramework currentFramework = RuntimeFramework.CurrentFramework;
             string frameworkSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");
             RuntimeFramework requestedFramework = frameworkSetting.Length > 0
@@ -115,13 +118,10 @@ namespace NUnit.Engine.Services
             if (targetRuntime == RuntimeType.Any)
                 targetRuntime = currentFramework.Runtime;
 
-            // Examine the package 
-            ApplyImageData(package);
+            if (targetVersion == RuntimeFramework.DefaultVersion)
+                targetVersion = package.GetSetting(InternalEnginePackageSettings.ImageRuntimeVersion, currentFramework.FrameworkVersion);
 
-            // Modify settings if necessary
-            targetVersion = package.GetSetting(InternalEnginePackageSettings.ImageRuntimeVersion, targetVersion);
-            RuntimeFramework checkFramework = new RuntimeFramework(targetRuntime, targetVersion);
-            if (!checkFramework.IsAvailable)
+            if (!new RuntimeFramework(targetRuntime, targetVersion).IsAvailable)
             {
                 log.Debug("Preferred version {0} is not installed or this NUnit installation does not support it", targetVersion);
                 if (targetVersion < currentFramework.FrameworkVersion)


### PR DESCRIPTION
Fixes #151. 

Think this was just something that was caught in a refactor, and untested. This PR also adds InternalsVisibleTo for the test assembly, so the package setting constants could be used.