### PR TITLE
Remove some user settings that are no longer supported

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -49,7 +49,7 @@ namespace NUnit.ConsoleRunner.Tests
             var fileSystem = new VirtualFileSystem();
             fileSystem.SetupFiles(files);
 
-            var expectedErrors = expectedErrorMessages.Split(new [] {'\n'}, StringSplitOptions.RemoveEmptyEntries);
+            var expectedErrors = expectedErrorMessages.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             var options = new ConsoleOptions(new DefaultOptionsProviderStub(false), fileSystem, new SimpleArgumentsFileParser());
 
@@ -117,18 +117,19 @@ namespace NUnit.ConsoleRunner.Tests
             }
         }
 
-        [TestCase("WhereClause",        "where",      new string[] { "cat==Fast" },                      new string[0])]
-        [TestCase("ActiveConfig",       "config",     new string[] { "Debug" },                          new string[0])]
-        [TestCase("ProcessModel",       "process",    new string[] { "InProcess", "Separate", "Multiple" }, new string[] { "JUNK" })]
-        [TestCase("DomainUsage",        "domain",     new string[] { "None", "Single", "Multiple" },     new string[] { "JUNK" })]
-        [TestCase("Framework",          "framework",  new string[] { "net-4.0" },                        new string[0])]
-        [TestCase("OutFile",            "output|out", new string[] { "output.txt" },                     new string[0])]
-        [TestCase("ErrFile",            "err",        new string[] { "error.txt" },                      new string[0])]
-        [TestCase("WorkDirectory",      "work",       new string[] { "results" },                        new string[0])]
-        [TestCase("DisplayTestLabels",  "labels",     new string[] { "Off", "On", "All" },               new string[] { "JUNK" })]
-        [TestCase("InternalTraceLevel", "trace",      new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" }, new string[] { "JUNK" })]
+        [TestCase("WhereClause", "where", new string[] { "cat==Fast" }, new string[0])]
+        [TestCase("ActiveConfig", "config", new string[] { "Debug" }, new string[0])]
+        [TestCase("ProcessModel", "process", new string[] { "InProcess", "Separate", "Multiple" }, new string[] { "JUNK" })]
+        [TestCase("DomainUsage", "domain", new string[] { "None", "Single", "Multiple" }, new string[] { "JUNK" })]
+        [TestCase("Framework", "framework", new string[] { "net-4.0" }, new string[0])]
+        [TestCase("OutFile", "output|out", new string[] { "output.txt" }, new string[0])]
+        [TestCase("ErrFile", "err", new string[] { "error.txt" }, new string[0])]
+        [TestCase("WorkDirectory", "work", new string[] { "results" }, new string[0])]
+        [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "All" }, new string[] { "JUNK" })]
+        [TestCase("InternalTraceLevel", "trace", new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" }, new string[] { "JUNK" })]
         [TestCase("DefaultTestNamePattern", "test-name-format", new string[] { "{m}{a}" }, new string[0])]
-        [TestCase("ConsoleEncoding",    "encoding",   new string[] { "utf-8", "ascii", "unicode" },      new string[0])]
+        [TestCase("ConsoleEncoding", "encoding", new string[] { "utf-8", "ascii", "unicode" }, new string[0])]
+        [TestCase("PrincipalPolicy", "set-principal-policy", new string[] { "UnauthenticatedPrincipal", "NoPrincipal", "WindowsPrincipal" }, new string[] { "JUNK" })]
         public void CanRecognizeStringOptions(string propertyName, string pattern, string[] goodValues, string[] badValues)
         {
             string[] prototypes = pattern.Split('|');

--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -74,6 +74,8 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--debug", "DebugTests", true)]
         [TestCase("--pause", "PauseBeforeRun", true)]
         [TestCase("--params:X=5;Y=7", "TestParameters", "X=5;Y=7")]
+        [TestCase("--set-principal-policy:UnauthenticatedPrincipal", "PrincipalPolicy", "UnauthenticatedPrincipal")]
+
 #if DEBUG
         [TestCase("--debug-agent", "DebugAgent", true)]
 #endif

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -94,6 +94,8 @@ namespace NUnit.Common
 
         public bool PauseBeforeRun { get; private set; }
 
+        public string PrincipalPolicy { get; private set; }
+
         #endregion
 
         #region Overrides
@@ -162,6 +164,9 @@ namespace NUnit.Common
 
             this.Add("list-extensions", "List all extension points and the extensions for each.",
                 v => ListExtensions = v != null);
+
+            this.Add("set-principal-policy=", "Set PrincipalPolicy for the test domain.",
+                v => PrincipalPolicy = RequiredValue(v, "--set-principal-policy", "UnauthenticatedPrincipal", "NoPrincipal", "WindowsPrincipal"));
 
 #if DEBUG
             this.Add("debug-agent", "Launch debugger in nunit-agent when it starts.",

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -420,6 +420,9 @@ namespace NUnit.ConsoleRunner
             if (options.PauseBeforeRun)
                 package.AddSetting(FrameworkPackageSettings.PauseBeforeRun, true);
 
+            if (options.PrincipalPolicy != null)
+                package.AddSetting(EnginePackageSettings.PrincipalPolicy, options.PrincipalPolicy);
+
 #if DEBUG
             if (options.DebugAgent)
                 package.AddSetting(EnginePackageSettings.DebugAgent, true);

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -141,6 +141,12 @@ namespace NUnit
         /// </summary>
         public const string InternalTraceLevel = "InternalTraceLevel";
 
+        /// <summary>
+        /// The PrincipalPolicy to set on the test AppDomain. Values are:
+        /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
+        /// </summary>
+        public const string PrincipalPolicy = "PrincipalPolicy";
+
         #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -79,17 +79,6 @@ namespace NUnit.ConsoleRunner
                 }
             }
 
-            //ColorConsole.Enabled = !Options.NoColor;
-
-            // Create SettingsService early so we know the trace level right at the start
-            //SettingsService settingsService = new SettingsService();
-            //InternalTraceLevel level = (InternalTraceLevel)settingsService.GetSetting("Options.InternalTraceLevel", InternalTraceLevel.Default);
-            //if (options.trace != InternalTraceLevel.Default)
-            //    level = options.trace;
-
-            //InternalTrace.Initialize("nunit3-console_%p.log", level);
-            
-            //log.Info("NUnit3-console.exe starting");
             try
             {
                 if (Options.ShowVersion || !Options.NoHeader)

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -121,7 +121,6 @@ namespace NUnit.Agent
             engine.Services.Add(new DomainManager());
             engine.Services.Add(new InProcessTestRunnerFactory());
             engine.Services.Add(new DriverService());
-            //engine.Services.Add( new TestLoader() );
 
             // Initialize Services
             log.Info("Initializing Services");

--- a/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
@@ -36,10 +36,6 @@ namespace NUnit.Engine.Services.Tests
     [TestFixture]
     public class RecentFilesTests
     {
-        private const int MAX = 24;
-        private const int MIN = 0;
-        private const int DEFAULT = 5;
-
         RecentFilesService _recentFiles;
 
         [SetUp]
@@ -59,40 +55,6 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
-        public void CountDefault()
-        {
-            Assert.AreEqual( DEFAULT, _recentFiles.MaxFiles );
-        }
-
-        [Test]
-        public void CountOverMax()
-        {
-            _recentFiles.MaxFiles = MAX + 1;
-            Assert.AreEqual( MAX, _recentFiles.MaxFiles );
-        }
-
-        [Test]
-        public void CountUnderMin()
-        {
-            _recentFiles.MaxFiles = MIN - 1;
-            Assert.AreEqual( MIN, _recentFiles.MaxFiles );
-        }
-
-        [Test]
-        public void CountAtMax()
-        {
-            _recentFiles.MaxFiles = MAX;
-            Assert.AreEqual( MAX, _recentFiles.MaxFiles );
-        }
-
-        [Test]
-        public void CountAtMin()
-        {
-            _recentFiles.MaxFiles = MIN;
-            Assert.AreEqual( MIN, _recentFiles.MaxFiles );
-        }
-
-        [Test]
         public void EmptyList()
         {
             Assert.IsNotNull(  _recentFiles.Entries, "Entries should never be null" );
@@ -106,48 +68,31 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
+        public void AddTenItems()
+        {
+            CheckAddItems(10);
+        }
+
+        [Test]
         public void AddMaxItems()
         {
-            CheckAddItems( 5 );
+            CheckAddItems( _recentFiles.MaxFiles );
         }
 
         [Test]
         public void AddTooManyItems()
         {
-            CheckAddItems( 10 );
+            CheckAddItems( _recentFiles.MaxFiles + 5 );
         }
 
         [Test]
-        public void IncreaseSize()
-        {
-            _recentFiles.MaxFiles = 10;
-            CheckAddItems( 10 );
-        }
-
-        [Test]
-        public void ReduceSize()
-        {
-            _recentFiles.MaxFiles = 3;
-            CheckAddItems( 10 );
-        }
-
-        [Test]
-        public void IncreaseSizeAfterAdd()
+        public void AddMixedItems()
         {
             SetMockValues(5);
-            _recentFiles.MaxFiles = 7;
             _recentFiles.SetMostRecent( "30" );
             _recentFiles.SetMostRecent( "20" );
             _recentFiles.SetMostRecent( "10" );
-            CheckListContains( 10, 20, 30, 1, 2, 3, 4 );
-        }
-
-        [Test]
-        public void ReduceSizeAfterAdd()
-        {
-            SetMockValues( 5 );
-            _recentFiles.MaxFiles = 3;
-            CheckMockValues( 3 );
+            CheckListContains( 10, 20, 30, 1, 2, 3, 4, 5 );
         }
 
         [Test]
@@ -182,14 +127,6 @@ namespace NUnit.Engine.Services.Tests
             SetMockValues( 5 );
             _recentFiles.SetMostRecent( "1" );
             CheckListContains( 1, 2, 3, 4, 5 );
-        }
-
-        [Test]
-        public void ReorderWithListNotFull()
-        {
-            SetMockValues( 3 );
-            _recentFiles.SetMostRecent( "3" );
-            CheckListContains( 3, 1, 2 );
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -141,6 +141,12 @@ namespace NUnit
         /// </summary>
         public const string InternalTraceLevel = "InternalTraceLevel";
 
+        /// <summary>
+        /// The PrincipalPolicy to set on the test AppDomain. Values are:
+        /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
+        /// </summary>
+        public const string PrincipalPolicy = "PrincipalPolicy";
+
         #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -76,17 +76,18 @@ namespace NUnit.Engine.Services
                 Hash hash = new Hash(assembly);
                 evidence.AddHost(hash);
             }
-
+            
             log.Info("Creating AppDomain " + domainName);
 
             AppDomain runnerDomain = AppDomain.CreateDomain(domainName, evidence, setup);
 
-            // Set PrincipalPolicy for the domain if called for in the settings
-            if (_settingsService != null && _settingsService.GetSetting("Options.TestLoader.SetPrincipalPolicy", false))
+            // Set PrincipalPolicy for the domain if called for in the package settings
+            if (package.Settings.ContainsKey(EnginePackageSettings.PrincipalPolicy))
             {
-                runnerDomain.SetPrincipalPolicy(_settingsService.GetSetting(
-                    "Options.TestLoader.PrincipalPolicy", 
-                    PrincipalPolicy.UnauthenticatedPrincipal));
+                PrincipalPolicy policy = (PrincipalPolicy)Enum.Parse(typeof(PrincipalPolicy),
+                    package.GetSetting(EnginePackageSettings.PrincipalPolicy, "UnauthenticatedPricipal"));
+
+                runnerDomain.SetPrincipalPolicy(policy);
             }
 
             return runnerDomain;

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -46,8 +46,6 @@ namespace NUnit.Engine.Services
         private static readonly PropertyInfo TargetFrameworkNameProperty =
             typeof(AppDomainSetup).GetProperty("TargetFrameworkName", BindingFlags.Public | BindingFlags.Instance);
 
-        private ISettings _settingsService;
-
         #region Create and Unload Domains
         /// <summary>
         /// Construct an application domain for running a test package
@@ -369,27 +367,6 @@ namespace NUnit.Engine.Services
 
             if ((thread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) != 0)
                 thread.Interrupt();
-        }
-
-        #endregion
-
-        #region Service Overrides
-
-        public override void StartService() 
-        {
-            try
-            {
-                // DomainManager has a soft dependency on the SettingsService.
-                // If it's not available, default values are used.
-                _settingsService = ServiceContext.GetService<ISettings>();
-
-                Status = ServiceStatus.Started;
-            }
-            catch
-            {
-                Status = ServiceStatus.Error;
-                throw;
-            }
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
@@ -34,35 +34,17 @@ namespace NUnit.Engine.Services
         private IList<string> _fileEntries = new List<string>();
         private ISettings _userSettings;
 
-        private const int MinSize = 0;
-        private const int MaxSize = 24;
-        private const int DefaultSize = 5;
+        private const int MAX_FILES = 24;
 
         #region Properties
 
         public int MaxFiles
         {
-            get 
-            { 
-                int size = _userSettings.GetSetting("Gui.RecentProjects.MaxFiles", DefaultSize );
-                
-                if ( size < MinSize ) size = MinSize;
-                if ( size > MaxSize ) size = MaxSize;
-                
-                return size;
-            }
-            set 
-            { 
-                int oldSize = MaxFiles;
-                int newSize = value;
-                
-                if ( newSize < MinSize ) newSize = MinSize;
-                if ( newSize > MaxSize ) newSize = MaxSize;
-
-                _userSettings.SaveSetting( "Gui.RecentProjects.MaxFiles", newSize );
-                if ( newSize < oldSize ) SaveEntriesToSettings();
-            }
+            get { return MAX_FILES; }
+            set { /* Noop in this implementation */ }
+            // NOTE: we retain the setter to avoid changing the interface
         }
+
         #endregion
 
         #region Public Methods
@@ -79,8 +61,8 @@ namespace NUnit.Engine.Services
             _fileEntries.Remove(filePath);
 
             _fileEntries.Insert( 0, filePath );
-            if( _fileEntries.Count > MaxFiles )
-                _fileEntries.RemoveAt( MaxFiles );
+            if( _fileEntries.Count > MAX_FILES )
+                _fileEntries.RemoveAt( MAX_FILES );
         }
         #endregion
 
@@ -96,9 +78,9 @@ namespace NUnit.Engine.Services
 
         private void AddEntriesForPrefix(string prefix)
         {
-            for (int index = 1; index < MaxFiles; index++)
+            for (int index = 1; index < MAX_FILES; index++)
             {
-                if (_fileEntries.Count >= MaxFiles) break;
+                if (_fileEntries.Count >= MAX_FILES) break;
 
                 string fileSpec = _userSettings.GetSetting(GetRecentFileKey(prefix, index)) as string;
                 if (fileSpec != null) _fileEntries.Add(fileSpec);
@@ -109,10 +91,10 @@ namespace NUnit.Engine.Services
         {
             string prefix = "Gui.RecentProjects";
 
-            while( _fileEntries.Count > MaxFiles )
+            while( _fileEntries.Count > MAX_FILES )
                 _fileEntries.RemoveAt( _fileEntries.Count - 1 );
 
-            for( int index = 0; index < MaxSize; index++ ) 
+            for( int index = 0; index < MAX_FILES; index++ ) 
             {
                 string keyName = GetRecentFileKey( prefix, index + 1 );
                 if ( index < _fileEntries.Count )

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -84,18 +84,13 @@ namespace NUnit.Engine
         /// </summary>
         public void Initialize()
         {
-            SettingsService settingsService = new SettingsService(true);
-
-            if(InternalTraceLevel == InternalTraceLevel.Default)
-                InternalTraceLevel = settingsService.GetSetting("Options.InternalTraceLevel", InternalTraceLevel.Off);
-
             if(InternalTraceLevel != InternalTraceLevel.Off && !InternalTrace.Initialized)
             {
                 var logName = string.Format("InternalTrace.{0}.log", Process.GetCurrentProcess().Id);
                 InternalTrace.Initialize(Path.Combine(WorkDirectory, logName), InternalTraceLevel);
             }
 
-            Services.Add(settingsService);
+            Services.Add(new SettingsService(true));
             Services.Add(new DomainManager());
             Services.Add(new ExtensionService());
             Services.Add(new DriverService());


### PR DESCRIPTION
Fixes #153 

This PR removes the settings listed in the issue and additionally adds a command-line option `--set-principal-policy` to ensure that users still have the ability to specify this somewhat rare option.