### PR TITLE
Fix Detection of invalid framework when --inprocess

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -229,8 +229,9 @@ namespace NUnit.Engine.Runners
             // be used to determine how to run the assembly.
             _runtimeService.SelectRuntimeFramework(TestPackage);
 
-            if (IntPtr.Size == 8 &&
-                TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "") == "InProcess" &&
+            var processModel = TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "").ToLower();
+
+            if (IntPtr.Size == 8 && (processModel == "inprocess" || processModel == "single")  &&
                 TestPackage.GetSetting(EnginePackageSettings.RunAsX86, false))
             {
                 throw new NUnitEngineException("Cannot run tests in process - a 32 bit process is required.");
@@ -298,8 +299,8 @@ namespace NUnit.Engine.Runners
                     throw new NUnitEngineException(string.Format("The requested framework {0} is unknown or not available.", frameworkSetting));
 
                 // If running in process, check requested framework is compatible
-                var processModel = TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "Default");
-                if (processModel.ToLower() == "single")
+                var processModel = TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "Default").ToLower();
+                if (processModel == "single" || processModel == "inprocess")
                 {
                     var currentFramework = RuntimeFramework.CurrentFramework;
                     var requestedFramework = RuntimeFramework.Parse(frameworkSetting);


### PR DESCRIPTION
When running with an invalid framework and the `--inprocess` flag - this wouldn't be detected, and the tests would be run in the current framework. This was caused by the engine checking for the (obsoleted) ProcessModel "single", whilst the console converts all uses of "single" to "inprocess".

I searched for other uses at the same time, and made one further change to check for both inprocess AND single. (As the current conversion is done in the runner, I assume a different (old) runner could still be using the obsoleted "single" option, so the engine should check for both.)

There's no test, as the check currently relies on the static `CurrentFramework` property - so faking it all out was a little non-trivial. Could revisit that, if people think it's worthwhile? The other option would be to instead compile the engine tests for .NET 3.5, so we have an actual 'invalid framework' to use. 