### PR TITLE
Terminate agent if main process has terminated

### DIFF
--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -105,9 +105,9 @@ namespace NUnit.Engine.Agents
             stopSignal.Set();
         }
 
-        public void WaitForStop()
+        public bool WaitForStop(int timeout)
         {
-            stopSignal.WaitOne();
+            return stopSignal.WaitOne(timeout);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -167,10 +167,10 @@ namespace NUnit.Engine.Services
             bool debugAgent = package.GetSetting(EnginePackageSettings.DebugAgent, false);
             string traceLevel = package.GetSetting(EnginePackageSettings.InternalTraceLevel, "Off");
             bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
-
+            
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
-            string agentArgs = string.Empty;
+            string agentArgs = "--pid=" + Process.GetCurrentProcess().Id.ToString();
             if (debugAgent)
                 agentArgs += " --debug-agent";
             if (traceLevel != "Off")


### PR DESCRIPTION
Fixes #128 

My preference would have been to fix this by monitoring the remoting interface to the TestAgency but that gets very involved because of timeouts and because the agent doesn't actually intercept the test events that are sent back to the main process. Instead, I'm checking the process itself, which is much quicker although it won't be a solution if we start running agents on other machines. 

I can see that we will need to revamp the communications layer, which I wrote many years ago as my first toe-dipping into the TCP swamp. 😄 For now, this should solve the problem. I've tested by running  manually and canceling the console process. No agent processes remain according to Task Manager.