### PR TITLE
Ping remote Agent before shutdown

### DIFF
--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -105,6 +105,11 @@ namespace NUnit.Engine.Agents
             stopSignal.Set();
         }
 
+        public override void Ping()
+        {
+            log.Info("Ping");
+        }
+
         public bool WaitForStop(int timeout)
         {
             return stopSignal.WaitOne(timeout);

--- a/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
@@ -102,6 +102,11 @@ namespace NUnit.Engine.Agents
         public abstract void Stop();
 
         /// <summary>
+        /// Pings the agent to check that it is still alive.
+        /// </summary>
+        public abstract void Ping();
+
+        /// <summary>
         ///  Creates a test runner
         /// </summary>
         public abstract ITestEngineRunner CreateRunner(TestPackage package);

--- a/src/NUnitEngine/nunit.engine/ITestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/ITestAgent.cs
@@ -52,6 +52,11 @@ namespace NUnit.Engine
         void Stop();
 
         /// <summary>
+        /// Pings the agent to check that it is still alive.
+        /// </summary>
+        void Ping();
+
+        /// <summary>
         ///  Creates a test runner
         /// </summary>
         ITestEngineRunner CreateRunner(TestPackage package);


### PR DESCRIPTION
Original issue #171 

Stopping the agent may cause a 'SocketException'.
Call 'Ping' before, in order to check that the
agent is still alive and waiting for its shutdown.