### PR TITLE
Default to multiple agent process when using a single nunit project file

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -52,15 +52,15 @@ namespace NUnit.Engine.Services.Tests
         {
             Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started));
         }
-
+        
         // Single file
-        [TestCase("EngineTests.nunit", null,        typeof(ProcessRunner))] // Needs to exist because contents are checked
+        [TestCase("x.nunit",           null,        typeof(AggregatingTestRunner))]
         [TestCase("x.dll",             null,        typeof(ProcessRunner))]
-        [TestCase("EngineTests.nunit", "Single",    typeof(TestDomainRunner))]
+        [TestCase("x.nunit",           "Single",    typeof(TestDomainRunner))]
         [TestCase("x.dll",             "Single",    typeof(TestDomainRunner))]
-        [TestCase("EngineTests.nunit", "Separate",  typeof(ProcessRunner))]
+        [TestCase("x.nunit",           "Separate",  typeof(ProcessRunner))]
         [TestCase("x.dll",             "Separate",  typeof(ProcessRunner))]
-        [TestCase("EngineTests.nunit", "Multiple",  typeof(MultipleTestProcessRunner))]
+        [TestCase("x.nunit",           "Multiple",  typeof(MultipleTestProcessRunner))]
         [TestCase("x.dll",             "Multiple",  typeof(MultipleTestProcessRunner))]
         // Two files
         [TestCase("x.nunit y.nunit",   null,        typeof(AggregatingTestRunner))]
@@ -89,9 +89,6 @@ namespace NUnit.Engine.Services.Tests
         [TestCase("x.dll y.dll z.dll",     "Multiple", typeof(MultipleTestProcessRunner))]
         public void CorrectRunnerIsUsed(string files, string processModel, Type expectedType)
         {
-            if (files == "EngineTests.nunit")
-                files = Path.Combine(TestContext.CurrentContext.TestDirectory, files);
-
             var package = new TestPackage(files.Split(new char[] { ' ' }));
             if (processModel != null)
                 package.AddSetting("ProcessModel", processModel);

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -93,7 +93,7 @@ namespace NUnit.Engine.Services
                 case ProcessModel.Default:
                     if (projectCount > 0)
                         return new AggregatingTestRunner(ServiceContext, package);
-                    else if (package.SubPackages.Count > 1 || projectCount > 0)
+                    else if (package.SubPackages.Count > 1)
                         return new MultipleTestProcessRunner(this.ServiceContext, package);
                     else
                         return new ProcessRunner(this.ServiceContext, package);

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -79,15 +79,11 @@ namespace NUnit.Engine.Services
             // If we have multiple projects or a project plus assemblies
             // then defer to the AggregatingTestRunner, which will make
             // the decision on a file by file basis so that each project
-            // runs with its own settings.
+            // runs with its own settings. Note that bad extensions are
+            // ignored rather than assumed to be projects. This doesn't
+            // really matter since they will result in an error anyway.
             if (projectCount > 1 || projectCount > 0 && assemblyCount > 0)
                 return new AggregatingTestRunner(ServiceContext, package);
-
-            // If we have a single project by itself, make it the top level project.
-            if (projectCount > 0 && assemblyCount == 0)
-                package = package.SubPackages[0];
-
-            // TODO: What about bad extensions?
 
             ProcessModel processModel = GetTargetProcessModel(package);
 
@@ -95,7 +91,9 @@ namespace NUnit.Engine.Services
             {
                 default:
                 case ProcessModel.Default:
-                    if (package.SubPackages.Count > 1)
+                    if (projectCount > 0)
+                        return new AggregatingTestRunner(ServiceContext, package);
+                    else if (package.SubPackages.Count > 1 || projectCount > 0)
                         return new MultipleTestProcessRunner(this.ServiceContext, package);
                     else
                         return new ProcessRunner(this.ServiceContext, package);


### PR DESCRIPTION
Fixes #116

@CharliePoole:

> When neither the project file nor the command line specifies running in multiple processes, we should either default to multiple process or base the decision on whether the project file contains more than one assembly.

What I did is default to multiple process.

There is an issue where a project file that specifies the single process model gets a multiple process runner.
There will have to be some parsing of the project file.

Questions:

 * What does `AggregatingTestRunner` do? Is it a way to defer the process model decision? Should these tests that depend on parsing the project all be returning `AggregatingTestRunner` instead of `MultipleTestProcessRunner`?
 * How do I actually write a tests covering the end-to-end scenario in #116? Is testing the runner type good enough? (Probably not, if `AggregatingTestRunner` defers to other runners?)