### PR TITLE
Add locking to AgentDatabase

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
@@ -44,13 +44,16 @@ namespace NUnit.Engine.Services.Tests
             _generatedGuids = new List<Guid>();
         }
 
-        [TestCaseSource(COUNTS)]
-        public void AddData(int count)
+        [Test]
+        public void AddData()
         {
-            AddRecords(count);
+            AddRecords(5);
 
-            Assert.That(_generatedGuids.Count, Is.EqualTo(count));
-            Assert.That(_data.GetGuids(), Is.EqualTo(_generatedGuids));
+            Assert.That(_generatedGuids.Count, Is.EqualTo(5));
+            Assert.That(_data.Count, Is.EqualTo(5));
+
+            var snap = _data.TakeSnapshot();
+            Assert.That(snap.Guids, Is.EqualTo(_generatedGuids));
         }
 
         [TestCaseSource(COUNTS)]
@@ -60,13 +63,16 @@ namespace NUnit.Engine.Services.Tests
             RunInParallel((g) => AddRecord((Guid)g));
 
             Assert.That(_generatedGuids.Count, Is.EqualTo(count));
-            Assert.That(_data.GetGuids(), Is.EqualTo(_generatedGuids));
+            Assert.That(_data.Count, Is.EqualTo(count));
+
+            var snap = _data.TakeSnapshot();
+            Assert.That(snap.Guids, Is.EqualTo(_generatedGuids));
         }
 
-        [TestCaseSource(COUNTS)]
-        public void ReadData(int count)
+        [Test]
+        public void ReadData()
         {
-            AddRecords(count);
+            AddRecords(5);
 
             foreach (var guid in _generatedGuids)
             {
@@ -88,6 +94,41 @@ namespace NUnit.Engine.Services.Tests
                 Assert.NotNull(r);
                 Assert.That(r.Id, Is.EqualTo(guid));
             });
+        }
+
+        [Test]
+        public void RemoveData()
+        {
+            AddRecords(5);
+
+            foreach (var guid in _generatedGuids)
+                _data.Remove(guid);
+
+            Assert.That(_data.Count, Is.EqualTo(0));
+        }
+
+        [TestCaseSource(COUNTS)]
+        public void RemoveData_Parallel(int count)
+        {
+            AddRecords(count);
+
+            RunInParallel((g) =>
+            {
+                var guid = (Guid)g;
+                _data.Remove(guid);
+            });
+
+            Assert.That(_data.Count, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void ClearData()
+        {
+            AddRecords(5);
+
+            _data.Clear();
+
+            Assert.That(_data.Count, Is.EqualTo(0));
         }
 
         private void GenerateGuids(int count)

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
@@ -30,7 +30,9 @@ namespace NUnit.Engine.Services.Tests
 {
     public class AgentDataBaseTests
     {
+#pragma warning disable 414
         private static int[] Counts = new int[] { 1, 3, 10 };
+#pragma warning restore 414
 
         const string COUNTS = nameof(Counts);
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
@@ -1,0 +1,127 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Services.Tests
+{
+    public class AgentDataBaseTests
+    {
+        private static int[] Counts = new int[] { 1, 3, 10 };
+
+        const string COUNTS = nameof(Counts);
+
+        AgentDataBase _data;
+        List<Guid> _generatedGuids;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _data = new AgentDataBase();
+            _generatedGuids = new List<Guid>();
+        }
+
+        [TestCaseSource(COUNTS)]
+        public void AddData(int count)
+        {
+            AddRecords(count);
+
+            Assert.That(_generatedGuids.Count, Is.EqualTo(count));
+            Assert.That(_data.GetGuids(), Is.EqualTo(_generatedGuids));
+        }
+
+        [TestCaseSource(COUNTS)]
+        public void AddData_Parallel(int count)
+        {
+            GenerateGuids(count);
+            RunInParallel((g) => AddRecord((Guid)g));
+
+            Assert.That(_generatedGuids.Count, Is.EqualTo(count));
+            Assert.That(_data.GetGuids(), Is.EqualTo(_generatedGuids));
+        }
+
+        [TestCaseSource(COUNTS)]
+        public void ReadData(int count)
+        {
+            AddRecords(count);
+
+            foreach (var guid in _generatedGuids)
+            {
+                var r = _data[guid];
+                Assert.NotNull(r);
+                Assert.That(r.Id, Is.EqualTo(guid));
+            }
+        }
+
+        [TestCaseSource(COUNTS)]
+        public void ReadData_Parallel(int count)
+        {
+            AddRecords(count);
+
+            RunInParallel((g) =>
+            {
+                var guid = (Guid)g;
+                var r = _data[guid];
+                Assert.NotNull(r);
+                Assert.That(r.Id, Is.EqualTo(guid));
+            });
+        }
+
+        private void GenerateGuids(int count)
+        {
+            while (count-- > 0)
+                _generatedGuids.Add(Guid.NewGuid());
+        }
+
+        private void AddRecord(Guid guid)
+        {
+            _data.Add(new AgentRecord(guid, null, null, AgentStatus.Ready));
+        }
+        
+        private void AddRecords(int count)
+        {
+            GenerateGuids(count);
+
+            foreach (var guid in _generatedGuids)
+                AddRecord(guid);
+        }
+
+        // Run in parallel for each generated guid
+        private void RunInParallel(ParameterizedThreadStart start)
+        {
+            var threads = new List<Thread>();
+
+            for (int i = 0; i < _generatedGuids.Count; i++)
+                threads.Add(new Thread(start));
+
+            for (int i = 0; i < _generatedGuids.Count; i++)
+                threads[i].Start(_generatedGuids[i]);
+
+            foreach (var thread in threads)
+                thread.Join();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Runners\TestEngineRunnerTests.cs" />
     <Compile Include="Runners\ParallelTaskWorkerPoolTests.cs" />
     <Compile Include="RuntimeFrameworkTests.cs" />
+    <Compile Include="Services\AgentDataBaseTests.cs" />
     <Compile Include="Services\ExtensionAssemblyTests.cs" />
     <Compile Include="Services\ExtensionServiceTests.cs" />
     <Compile Include="Services\Fakes\FakeRuntimeService.cs" />

--- a/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
@@ -91,13 +91,13 @@ namespace NUnit.Engine.Services
             }
         }
 
-        //public void Remove(Guid agentId)
-        //{
-        //    lock (_lock)
-        //    {
-        //        _agentData.Remove(agentId);
-        //    }
-        //}
+        public void Remove(Guid agentId)
+        {
+            lock (_lock)
+            {
+                _agentData.Remove(agentId);
+            }
+        }
 
         //public void Clear()
         //{

--- a/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
@@ -65,23 +65,25 @@ namespace NUnit.Engine.Services
             }
         }
 
-        //public AgentRecord this[ITestAgent agent]
-        //{
-        //    get
-        //    {
-        //        lock (_lock)
-        //        {
-        //            foreach (var entry in _agentData)
-        //            {
-        //                AgentRecord r = entry.Value;
-        //                if (r.Agent == agent)
-        //                    return r;
-        //            }
-        //        }
+        public int Count
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _agentData.Count;
+                }
+            }
+        }
 
-        //        return null;
-        //    }
-        //}
+        // Take a snapshot of the database - used primarily in testing.
+        public Snapshot TakeSnapshot()
+        {
+            lock (_lock)
+            {
+                return new Snapshot(_agentData.Values);
+            }
+        }
 
         public void Add(AgentRecord r)
         {
@@ -91,6 +93,12 @@ namespace NUnit.Engine.Services
             }
         }
 
+        #region Methods not currently used
+
+        // These methods are not currently used, but are  being
+        // maintained (and tested) for now since TestAgency is 
+        // undergoing some changes and may need them again.
+
         public void Remove(Guid agentId)
         {
             lock (_lock)
@@ -99,26 +107,36 @@ namespace NUnit.Engine.Services
             }
         }
 
-        //public void Clear()
-        //{
-        //    lock (_lock)
-        //    {
-        //        _agentData.Clear();
-        //    }
-        //}
-
-        // Method used for testing - returns a snapshot of
-        // the guids currently in the database.
-        public ICollection<Guid> GetGuids()
+        public void Clear()
         {
-#if LOCKING
             lock (_lock)
             {
-                return new List<Guid>(_agentData.Keys);
+                _agentData.Clear();
             }
-#else
-            return new List<Guid>(_agentData.Keys);
-#endif
         }
+
+        #endregion
+
+        #region Nested Snapshot Class used in Testing
+
+        public class Snapshot
+        {
+            public Snapshot(IEnumerable<AgentRecord> data)
+            {
+                Guids = new List<Guid>();
+                Records = new List<AgentRecord>();
+
+                foreach(var record in data)
+                {
+                    Guids.Add(record.Id);
+                    Records.Add(record);
+                }
+            }
+
+            public ICollection<Guid> Guids { get; private set; }
+            public ICollection<AgentRecord> Records { get; private set; }
+        }
+
+        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
@@ -1,0 +1,124 @@
+﻿// ***********************************************************************
+// Copyright (c) 2011-2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace NUnit.Engine.Services
+{
+    internal class AgentRecord
+    {
+        public Guid Id;
+        public Process Process;
+        public ITestAgent Agent;
+        public AgentStatus Status;
+
+        public AgentRecord(Guid id, Process p, ITestAgent a, AgentStatus s)
+        {
+            this.Id = id;
+            this.Process = p;
+            this.Agent = a;
+            this.Status = s;
+        }
+
+    }
+
+    /// <summary>
+    ///  A simple class that tracks data about this
+    ///  agencies active and available agents.
+    ///  This class is required to be multi-thread safe.
+    /// </summary>
+    internal class AgentDataBase
+    {
+        private readonly Dictionary<Guid, AgentRecord> _agentData = new Dictionary<Guid, AgentRecord>();
+        private readonly object _lock = new object();
+
+        public AgentRecord this[Guid id]
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _agentData[id];
+                }
+            }
+        }
+
+        //public AgentRecord this[ITestAgent agent]
+        //{
+        //    get
+        //    {
+        //        lock (_lock)
+        //        {
+        //            foreach (var entry in _agentData)
+        //            {
+        //                AgentRecord r = entry.Value;
+        //                if (r.Agent == agent)
+        //                    return r;
+        //            }
+        //        }
+
+        //        return null;
+        //    }
+        //}
+
+        public void Add(AgentRecord r)
+        {
+            lock (_lock)
+            {
+                _agentData[r.Id] = r;
+            }
+        }
+
+        //public void Remove(Guid agentId)
+        //{
+        //    lock (_lock)
+        //    {
+        //        _agentData.Remove(agentId);
+        //    }
+        //}
+
+        //public void Clear()
+        //{
+        //    lock (_lock)
+        //    {
+        //        _agentData.Clear();
+        //    }
+        //}
+
+        // Method used for testing - returns a snapshot of
+        // the guids currently in the database.
+        public ICollection<Guid> GetGuids()
+        {
+#if LOCKING
+            lock (_lock)
+            {
+                return new List<Guid>(_agentData.Keys);
+            }
+#else
+            return new List<Guid>(_agentData.Keys);
+#endif
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -1,5 +1,5 @@
 // ***********************************************************************
-// Copyright (c) 2011 Charlie Poole
+// Copyright (c) 2011-2016 Charlie Poole
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -381,58 +381,6 @@ namespace NUnit.Engine.Services
             {
                 Status = ServiceStatus.Error;
                 throw;
-            }
-        }
-
-        #endregion
-
-        #region Nested Class - AgentRecord
-        private class AgentRecord
-        {
-            public Guid Id;
-            public Process Process;
-            public ITestAgent Agent;
-            public AgentStatus Status;
-
-            public AgentRecord( Guid id, Process p, ITestAgent a, AgentStatus s )
-            {
-                this.Id = id;
-                this.Process = p;
-                this.Agent = a;
-                this.Status = s;
-            }
-
-        }
-        #endregion
-
-        #region Nested Class - AgentDataBase
-        /// <summary>
-        ///  A simple class that tracks data about this
-        ///  agencies active and available agents.
-        ///  This class is required to be multi-thread safe.
-        /// </summary>
-        private class AgentDataBase
-        {
-            private readonly Dictionary<Guid, AgentRecord> _agentData = new Dictionary<Guid, AgentRecord>();
-            private readonly object _lock = new object();
-
-            public AgentRecord this[Guid id]
-            {
-                get
-                {
-                    lock (_lock)
-                    {
-                        return _agentData[id];
-                    }
-                }
-            }
-
-            public void Add(AgentRecord r)
-            {
-                lock (_lock)
-                {
-                    _agentData[r.Id] = r;
-                }
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -408,60 +408,32 @@ namespace NUnit.Engine.Services
         #region Nested Class - AgentDataBase
         /// <summary>
         ///  A simple class that tracks data about this
-        ///  agencies active and available agents
+        ///  agencies active and available agents.
+        ///  This class is required to be multi-thread safe.
         /// </summary>
         private class AgentDataBase
         {
-            private Dictionary<Guid, AgentRecord> agentData = new Dictionary<Guid, AgentRecord>();
+            private readonly Dictionary<Guid, AgentRecord> _agentData = new Dictionary<Guid, AgentRecord>();
+            private readonly object _lock = new object();
 
             public AgentRecord this[Guid id]
             {
-                get { return agentData[id]; }
-                set
-                {
-                    if ( value == null )
-                        agentData.Remove( id );
-                    else
-                        agentData[id] = value;
-                }
-            }
-
-            public AgentRecord this[ITestAgent agent]
-            {
                 get
                 {
-                    foreach( KeyValuePair<Guid, AgentRecord> entry in agentData)
+                    lock (_lock)
                     {
-                        AgentRecord r = entry.Value;
-                        if ( r.Agent == agent )
-                            return r;
+                        return _agentData[id];
                     }
-
-                    return null;
                 }
             }
 
-            public void Add( AgentRecord r )
+            public void Add(AgentRecord r)
             {
-                agentData[r.Id] = r;
+                lock (_lock)
+                {
+                    _agentData[r.Id] = r;
+                }
             }
-
-            public void Remove(Guid agentId)
-            {
-                agentData.Remove(agentId);
-            }
-
-            public void Clear()
-            {
-                agentData.Clear();
-            }
-
-            //#region IEnumerable Members
-            //public IEnumerator<KeyValuePair<Guid,AgentRecord>> GetEnumerator()
-            //{
-            //    return agentData.GetEnumerator();
-            //}
-            //#endregion
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -103,17 +103,6 @@ namespace NUnit.Engine.Services
             r.Agent = agent;
         }
 
-        public void ReportStatus( Guid agentId, AgentStatus status )
-        {
-            AgentRecord r = _agentData[agentId];
-
-            if ( r == null )
-                throw new ArgumentException(
-                    string.Format("Agent {0} is not in the agency database", agentId),
-                    "agentId" );
-
-            r.Status = status;
-        }
         #endregion
 
         #region Public Methods - Called by Clients
@@ -214,7 +203,6 @@ namespace NUnit.Engine.Services
                     break;
             }
             
-            //p.Exited += new EventHandler(OnProcessExit);
             p.Start();
             log.Debug("Launched Agent process {0} - see nunit-agent_{0}.log", p.Id);
             log.Debug("Command line: \"{0}\" {1}", p.StartInfo.FileName, p.StartInfo.Arguments);

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Runners\TestEventDispatcher.cs" />
     <Compile Include="Runners\TestExecutionTask.cs" />
     <Compile Include="RuntimeType.cs" />
+    <Compile Include="Services\AgentDataBase.cs" />
     <Compile Include="Services\ExtensionAssembly.cs" />
     <Compile Include="Services\ExtensionService.cs" />
     <Compile Include="Services\ResultWriters\NUnit3XmlResultWriter.cs" />


### PR DESCRIPTION
Fixes #168 . This is targeting release/3.6 as I think it may need to be a hotfix - although I don't think that decisions been made yet, so will move it over if not.

This adds a lock object to the AgentDatabase, to allow access in parallel. This was introduced by the just-in-time agent loading fixed in 3.5, and will be required if we parallelise load/explore etc. 

Many of the methods in AgentDatabase were no longer used - so I took the liberty of removing them rather than making them safe. The class is now solely additive.

I wanted to add a test to ensure agent creation can be parallelised, but wasn't able to reproduce the error. The test I had (and removed) is below - open to any ideas as to how we might be able to put something in to prevent regression here. (Note the below additionally doesn't work due to #173 - but once I'd hacked around that, I still wasn't able to reproduce the error from #168.)

```
        [Test]
        public void CanCreateAgentsInParallel()
        {
            const int agents = 10;
            var workerPool = new ParallelTaskWorkerPool(agents);

            for (var i = 0; i < agents; i++)
            {
                var task = new LaunchAgentTask(_testAgency);
                workerPool.Enqueue(task);
            }

            TestDelegate createAgents = () =>
            {
                workerPool.Start();
                workerPool.WaitAll();
            };
            Assert.That(createAgents, Throws.Nothing);
        }

        private class LaunchAgentTask : ITestExecutionTask
        {
            private readonly TestAgency _agency;

            public LaunchAgentTask(TestAgency agency)
            {
                _agency = agency;
            }

            public void Execute()
            {
                _agency.GetAgent(new TestPackage("."), Timeout.Infinite);
            }
        }
```