### PR TITLE
Update --labels with additional options.

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -126,7 +126,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("OutFile", "output|out", new string[] { "output.txt" }, new string[0])]
         [TestCase("ErrFile", "err", new string[] { "error.txt" }, new string[0])]
         [TestCase("WorkDirectory", "work", new string[] { "results" }, new string[0])]
-        [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "All" }, new string[] { "JUNK" })]
+        [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "Before", "After", "All" }, new string[] { "JUNK" })]
         [TestCase("InternalTraceLevel", "trace", new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" }, new string[] { "JUNK" })]
         [TestCase("DefaultTestNamePattern", "test-name-format", new string[] { "{m}{a}" }, new string[0])]
         [TestCase("ConsoleEncoding", "encoding", new string[] { "utf-8", "ascii", "unicode" }, new string[0])]
@@ -167,7 +167,7 @@ namespace NUnit.ConsoleRunner.Tests
 
         [TestCase("ProcessModel", "process", new string[] { "InProcess", "Separate", "Multiple" })]
         [TestCase("DomainUsage", "domain", new string[] { "None", "Single", "Multiple" })]
-        [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "All" })]
+        [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "Before", "After", "All" })]
         [TestCase("InternalTraceLevel", "trace", new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" })]
         public void CanRecognizeLowerCaseOptionValues(string propertyName, string optionName, string[] canonicalValues)
         {

--- a/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
@@ -62,8 +62,12 @@ namespace NUnit.ConsoleRunner.Tests
             foreach (string report in reports)
                 handler.OnTestEvent(report);
 
-            if (Environment.NewLine != "\r\n")
-                expected = expected.Replace("\r\n", Environment.NewLine);
+            // Make sure all newlines are the same
+            expected = expected.Replace("\r\n", "\n");
+
+            // Replace with current newline before comparing
+            expected = expected.Replace("\n", Environment.NewLine);
+
             Assert.That(Output, Is.EqualTo(expected));
         }
 

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -347,8 +347,8 @@ namespace NUnit.Common
             this.Add("noresult", "Don't save any test results.",
                 v => noresult = v != null);
 
-            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, All",
-                v => DisplayTestLabels = RequiredValue(v, "--labels", "Off", "On", "All"));
+            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, Before, After, All",
+                v => DisplayTestLabels = RequiredValue(v, "--labels", "Off", "On", "Before", "After", "All"));
 
             this.Add("test-name-format=", "Non-standard naming pattern to use in generating test names.",
                 v => DefaultTestNamePattern = RequiredValue(v, "--test-name-format"));


### PR DESCRIPTION
Fixes #24 

@constructor-igor spent a lot of time on this issue, but the branch was never merged. As part of cleaning up my old work in the framework, I decided to recreate the branch and try to get it finished.

Since the issue had a lot of comments over time, some conflicting, I'll summarize how the new labels values work in this PR. I use "normal" output to mean output through `Console.Out` or `TestContext.Out` and "immediate" for output through `Console.Error`, `TestContext.Progress` or `TestContext.Error`.

**--labels:Off** 
No labeling is used. Both normal and immediate output appear in the order produced - i.e. immediate first.

**--labels:On**
A label appears before each sequence of output lines from the same test. Since tests may be run in parallel, output from different tests may be intermixed.

**--labels:All**
A label appears at the start of every test, whether it produces output or not. Additional labels are produced as needed if interspersed output takes place, just as for `--labels:On`. Synonym for `--labels:Before`.

**--labels:Before**
A label appears at the start of every test, whether it produces output or not. Additional labels are produced as needed if interspersed output takes place, just as for `--labels:On`. Synonym for `--labels:All`.

**--labels:After**
A label appears at the end of every test, whether it produced output or not. This label includes the pass/fail status of the test in addition to its name. Additional labels are produced as needed if there is any output, just as for `--labels:On`.
