### PR TITLE
Retrieve settings with invariant culture

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
@@ -22,6 +22,8 @@
 // ***********************************************************************
 
 using System;
+using System.ComponentModel;
+using System.Drawing;
 using NUnit.Framework;
 using Microsoft.Win32;
 
@@ -96,6 +98,20 @@ namespace NUnit.Engine.Internal.Tests
         {
             settings.SaveSetting( "X", "1y25" );
             Assert.AreEqual( 42, settings.GetSetting( "X", 42 ) );
+        }
+
+        [Test]
+        [SetCulture("da-DK")]
+        public void SaveAndGetSettingShouldReturnTheOriginalValue()
+        {
+            var settingName = "MySetting";
+            var settingValue = new Point(10, 20);
+            var typeConverter = TypeDescriptor.GetConverter(settingValue);
+            var settingsValue = typeConverter.ConvertToInvariantString(settingValue);
+
+            settings.SaveSetting(settingName, settingsValue);
+            var point = settings.GetSetting(settingName, new Point(30, 40));
+            Assert.That(point, Is.EqualTo(settingValue));
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
@@ -24,10 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Globalization;
-using System.IO;
-using System.Xml;
 
 namespace NUnit.Engine.Internal
 {
@@ -79,7 +76,7 @@ namespace NUnit.Engine.Internal
                 if (converter == null)
                     return defaultValue;
 
-                return (T)converter.ConvertFrom(result);
+                return (T)converter.ConvertFrom(null, CultureInfo.InvariantCulture, result);
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
As settings are saved with ConvertToInvariantString
we also need to read the settings using
CultureInfo.InvariantCulture.

Fixes #193