### PR TITLE
Making some variables readonly to help document what's immutable

### DIFF
--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -36,14 +36,14 @@ namespace NUnit.Engine.Agents
     /// </summary>
     public class RemoteTestAgent : TestAgent, ITestEngineRunner
     {
-        static Logger log = InternalTrace.GetLogger(typeof(RemoteTestAgent));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(RemoteTestAgent));
 
         #region Fields
 
         private ITestEngineRunner _runner;
         private TestPackage _package;
 
-        private ManualResetEvent stopSignal = new ManualResetEvent(false);
+        private readonly ManualResetEvent stopSignal = new ManualResetEvent(false);
         
         #endregion
 

--- a/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
@@ -35,9 +35,9 @@ namespace NUnit.Engine.Agents
     {
         #region Private Fields
 
-        private ITestAgency agency;
-        private Guid agentId;
-        private IServiceLocator services;
+        private readonly ITestAgency agency;
+        private readonly Guid agentId;
+        private readonly IServiceLocator services;
 
         #endregion
 

--- a/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
@@ -29,8 +29,8 @@ namespace NUnit.Engine.Services
 {
     internal class AgentRecord
     {
-        public Guid Id;
-        public Process Process;
+        public readonly Guid Id;
+        public readonly Process Process;
         public ITestAgent Agent;
         public AgentStatus Status;
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -52,11 +52,11 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class TestAgency : ServerBase, ITestAgency, IService
     {
-        static Logger log = InternalTrace.GetLogger(typeof(TestAgency));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(TestAgency));
 
         #region Private Fields
 
-        private AgentDataBase _agentData = new AgentDataBase();
+        private readonly AgentDataBase _agentData = new AgentDataBase();
 
         #endregion
 


### PR DESCRIPTION
I'm a big fan of being explicit in code and calling out what state is immutable.  It helps me to make safer changes.  Especially in areas where thread safety matters.