### PR TITLE
Calling Unregister on the test agency when stopping

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Agents/RemoteTestAgentTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Agents/RemoteTestAgentTests.cs
@@ -1,0 +1,95 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Agents.Tests
+{
+    [TestFixture]
+    public sealed class RemoteTestAgentTests
+    {
+        [Test]
+        public void Stop_ShouldUnregisterWithAgency()
+        {
+            List<Guid> unregisteredAgents = new List<Guid>();
+
+            ITestAgency agency = new MockAgency(
+                register: agent => { Assert.Fail("Should not be invoked"); },
+                unregister: unregisteredAgents.Add
+            );
+
+            Guid agentId = Guid.NewGuid();
+
+            using (RemoteTestAgent testAgent = new RemoteTestAgent(agentId, agency, services: null))
+            {
+                testAgent.Stop();
+                CollectionAssert.AreEqual(new[] { agentId }, unregisteredAgents, "Agent should be unregistered");
+            }
+
+            CollectionAssert.AreEqual(new[] { agentId }, unregisteredAgents, "Agent should only unregistered once");
+        }
+
+        [Test]
+        public void Stop_WhenAgencyThrows_ShouldNotThrow()
+        {
+            ITestAgency agency = new MockAgency(
+                register: agent => { Assert.Fail("Should not be invoked"); },
+                unregister: agentId => { throw new Exception("Boom"); }
+            );
+
+            using (RemoteTestAgent testAgent = new RemoteTestAgent(Guid.NewGuid(), agency, services: null))
+            {
+                Assert.DoesNotThrow(() => testAgent.Stop(), "Agent should catch and log exception");
+            }
+        }
+
+        #region MockAgency Definition
+
+        private sealed class MockAgency : ITestAgency
+        {
+            private readonly Action<ITestAgent> _register;
+            private readonly Action<Guid> _unregister;
+
+            public MockAgency(Action<ITestAgent> register, Action<Guid> unregister)
+            {
+                _register = register;
+                _unregister = unregister;
+            }
+
+            void ITestAgency.Register(ITestAgent agent)
+            {
+                _register(agent);
+            }
+
+            void ITestAgency.Unregister(Guid agentId)
+            {
+                _unregister(agentId);
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="..\EngineVersion.cs">
       <Link>Properties\EngineVersion.cs</Link>
     </Compile>
+    <Compile Include="Agents\RemoteTestAgentTests.cs" />
     <Compile Include="Api\ServiceLocatorTests.cs" />
     <Compile Include="Api\TestFilterTests.cs" />
     <Compile Include="Api\TestPackageTests.cs" />

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -44,6 +44,7 @@ namespace NUnit.Engine.Agents
         private TestPackage _package;
 
         private ManualResetEvent stopSignal = new ManualResetEvent(false);
+        private bool _stopped = false;
         
         #endregion
 
@@ -95,14 +96,25 @@ namespace NUnit.Engine.Agents
 
         public override void Stop()
         {
-            log.Info("Stopping");
-            // This causes an error in the client because the agent 
-            // database is not thread-safe.
-            //if (agency != null)
-            //    agency.ReportStatus(this.ProcessId, AgentStatus.Stopping);
+            if (_stopped)
+            {
+                return;
+            }
 
+            log.Info("Stopping");
+
+            try
+            {
+                this.Agency.Unregister(this.Id);
+                log.Debug("Unregistered with TestAgency");
+            }
+            catch (Exception ex)
+            {
+                log.Error("RemoteTestAgent: Failed to unregister with TestAgency", ex);
+            }
 
             stopSignal.Set();
+            _stopped = true;
         }
 
         public bool WaitForStop(int timeout)

--- a/src/NUnitEngine/nunit.engine/ITestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/ITestAgency.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+
 namespace NUnit.Engine
 {
     /// <summary>
@@ -34,5 +36,11 @@ namespace NUnit.Engine
         /// </summary>
         /// <param name="agent"></param>
         void Register(ITestAgent agent);
+
+        /// <summary>
+        /// Unregisters an agent with an agency
+        /// </summary>
+        /// <param name="agentId"></param>
+        void Unregister(Guid agentId);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -103,6 +103,11 @@ namespace NUnit.Engine.Services
             r.Agent = agent;
         }
 
+        public void Unregister(Guid agentId)
+        {
+            _agentData.Remove(agentId);
+        }
+
         #endregion
 
         #region Public Methods - Called by Clients


### PR DESCRIPTION
This is really just a follow up to the work @ChrisMaddock did recently on AgentDataBase: https://github.com/nunit/nunit-console/commit/6fef1f3574cdfd2e21cd484ca142e34b2a03fd84

Now that it's thread safe, we can unregister the agents.

In our use case, we have lots of assemblies and we've been getting OutOfMemoryException errors from the console runner.  I was doing some profiling with .NET Memory Profiler (http://memprofiler.com/) last night and came across this leak.  This something I'm sure you're aware of @CharliePoole giving your existing comments in RemoteTestAgent.Stop

https://github.com/nunit/nunit-console/blob/dc655ce241994f5a3664fe034b19d7be04035b64/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs#L99