### PR TITLE
Remove obsolete warnings

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -339,12 +339,12 @@ Task("PackageConsole")
 //////////////////////////////////////////////////////////////////////
 // SETUP AND TEARDOWN TASKS
 //////////////////////////////////////////////////////////////////////
-Setup(() =>
+Setup(context =>
 {
     // Executed BEFORE the first task.
 });
 
-Teardown(() =>
+Teardown(context =>
 {
     // Executed AFTER the last task.
     CheckForError(ref ErrorDetail);


### PR DESCRIPTION
Remove the two obsolete warnings regarding Setup and Teardown.