### PR TITLE
Improve missing agent error message

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -143,7 +143,7 @@ namespace NUnit.Engine.Services
             bool debugAgent = package.GetSetting(EnginePackageSettings.DebugAgent, false);
             string traceLevel = package.GetSetting(EnginePackageSettings.InternalTraceLevel, "Off");
             bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
-            
+
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
             string agentArgs = "--pid=" + Process.GetCurrentProcess().Id.ToString();
@@ -161,10 +161,9 @@ namespace NUnit.Engine.Services
 
             string agentExePath = GetTestAgentExePath(useX86Agent);
 
-            if (agentExePath == null)
-                throw new ArgumentException(
-                    string.Format("NUnit components for version {0} of the CLR are not installed",
-                    targetRuntime.ClrVersion.ToString()), "targetRuntime");
+            if (!File.Exists(agentExePath))
+                throw new FileNotFoundException(
+                    $"{Path.GetFileName(agentExePath)} for version {targetRuntime.ClrVersion.ToString()} of the CLR could not be found.", agentExePath);
 
             log.Debug("Using nunit-agent at " + agentExePath);
 
@@ -244,8 +243,7 @@ namespace NUnit.Engine.Services
                 ? "nunit-agent-x86.exe"
                 : "nunit-agent.exe";
 
-            string agentExePath = Path.Combine(engineDir, agentName);
-            return File.Exists(agentExePath) ? agentExePath : null;
+            return Path.Combine(engineDir, agentName);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -163,7 +163,7 @@ namespace NUnit.Engine.Services
 
             if (!File.Exists(agentExePath))
                 throw new FileNotFoundException(
-                    $"{Path.GetFileName(agentExePath)} for version {targetRuntime.ClrVersion.ToString()} of the CLR could not be found.", agentExePath);
+                    $"{Path.GetFileName(agentExePath)} could not be found.", agentExePath);
 
             log.Debug("Using nunit-agent at " + agentExePath);
 


### PR DESCRIPTION
A user on Gitter today encountered this error message:

    NUnit components for version 4.0.30319 of the CLR are not installed Parametername: targetRuntime

This error is thrown in the specific case where the agent executable can't be found. This PR improves that error message to something more targeted, which a user may be able to resolve without looking at source.