### PR TITLE
Fixing SocketException caused by --explore

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -95,7 +95,7 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new [] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-                "  Test Count: 29, Passed: 15, Failed: 5, Warnings: 1, Inconclusive: 1, Skipped: 7",
+               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 5, Warnings: 1, Inconclusive: 1, Skipped: 7",
                 "    Failed Tests - Failures: 1, Errors: 1, Invalid: 3",
                 "    Skipped Tests - Ignored: 4, Explicit: 3, Other: 0",
                 "  Start time: 2015-10-19 02:12:28Z",

--- a/src/NUnitEngine/mock-assembly.netstandard/mock-assembly.netstandard.csproj
+++ b/src/NUnitEngine/mock-assembly.netstandard/mock-assembly.netstandard.csproj
@@ -17,6 +17,7 @@
     <Compile Include="..\EngineVersion.cs" Link="Properties\EngineVersion.cs" />
     <Compile Include="..\mock-assembly\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
     <Compile Include="..\mock-assembly\MockAssembly.cs" Link="MockAssembly.cs" />
+    <Compile Include="..\mock-assembly\AccessesCurrentTestContextDuringDiscovery.cs" Link="AccessesCurrentTestContextDuringDiscovery.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NUnitEngine/mock-assembly/AccessesCurrentTestContextDuringDiscovery.cs
+++ b/src/NUnitEngine/mock-assembly/AccessesCurrentTestContextDuringDiscovery.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+
+namespace NUnit.Tests
+{
+    public class AccessesCurrentTestContextDuringDiscovery
+    {
+        public const int Tests = 2;
+        public const int Suites = 1;
+
+        public static int[] TestCases()
+        {
+            var _ = TestContext.CurrentContext;
+            return new[] { 0 };
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void Access_by_TestCaseSource(int arg) { }
+
+        [Test]
+        public void Access_by_ValueSource([ValueSource(nameof(TestCases))] int arg) { }
+    }
+}

--- a/src/NUnitEngine/mock-assembly/MockAssembly.cs
+++ b/src/NUnitEngine/mock-assembly/MockAssembly.cs
@@ -56,7 +56,8 @@ namespace NUnit.Tests
                         + BadFixture.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
-                        + GenericFixtureConstants.Tests;
+                        + GenericFixtureConstants.Tests
+                        + AccessesCurrentTestContextDuringDiscovery.Tests;
 
             public const int Suites = MockTestFixture.Suites
                         + Singletons.OneTestCase.Suites
@@ -67,6 +68,7 @@ namespace NUnit.Tests
                         + FixtureWithTestCases.Suites
                         + ParameterizedFixture.Suites
                         + GenericFixtureConstants.Suites
+                        + AccessesCurrentTestContextDuringDiscovery.Suites
                         + NamespaceSuites;
 
             public const int TestStartedEvents = Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests;
@@ -84,7 +86,8 @@ namespace NUnit.Tests
                         + TestAssembly.MockTestFixture.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
-                        + GenericFixtureConstants.Tests;
+                        + GenericFixtureConstants.Tests
+                        + AccessesCurrentTestContextDuringDiscovery.Tests;
 
             public const int Skipped_Ignored = MockTestFixture.Skipped_Ignored + IgnoredFixture.Tests;
             public const int Skipped_Explicit = MockTestFixture.Skipped_Explicit + ExplicitFixture.Tests;

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -95,6 +95,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="AccessesCurrentTestContextDuringDiscovery.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/ProcessUtils.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/ProcessUtils.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace NUnit.Engine.Tests.Helpers
+{
+    public static class ProcessUtils
+    {
+        public static ProcessResult Run(ProcessStartInfo startInfo)
+        {
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.CreateNoWindow = true;
+
+            using (var process = new Process { StartInfo = startInfo })
+            {
+                var standardStreamData = new List<StandardStreamData>();
+                var currentData = new StringBuilder();
+                var currentDataIsError = false;
+
+                process.OutputDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null) return;
+                    if (currentDataIsError)
+                    {
+                        if (currentData.Length != 0)
+                            standardStreamData.Add(new StandardStreamData(currentDataIsError, currentData.ToString()));
+                        currentData = new StringBuilder();
+                        currentDataIsError = false;
+                    }
+                    currentData.AppendLine(e.Data);
+                };
+                process.ErrorDataReceived += (sender, e) =>
+                {
+                    if (e.Data == null) return;
+                    if (!currentDataIsError)
+                    {
+                        if (currentData.Length != 0)
+                            standardStreamData.Add(new StandardStreamData(currentDataIsError, currentData.ToString()));
+                        currentData = new StringBuilder();
+                        currentDataIsError = true;
+                    }
+                    currentData.AppendLine(e.Data);
+                };
+
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit();
+
+                if (currentData.Length != 0)
+                    standardStreamData.Add(new StandardStreamData(currentDataIsError, currentData.ToString()));
+
+                return new ProcessResult(process.ExitCode, standardStreamData.ToArray());
+            }
+        }
+
+        [DebuggerDisplay("{ToString(),nq}")]
+        public struct ProcessResult
+        {
+            public ProcessResult(int exitCode, StandardStreamData[] standardStreamData)
+            {
+                ExitCode = exitCode;
+                StandardStreamData = standardStreamData;
+            }
+
+            public int ExitCode { get; }
+            public StandardStreamData[] StandardStreamData { get; }
+
+            public override string ToString() => ToString(true);
+
+            /// <param name="showStreamSource">If true, appends "[stdout] " or "[stderr] " to the beginning of each line.</param>
+            public string ToString(bool showStreamSource)
+            {
+                var r = new StringBuilder("Exit code ").Append(ExitCode);
+
+                if (StandardStreamData.Length != 0) r.AppendLine();
+
+                foreach (var data in StandardStreamData)
+                {
+                    if (showStreamSource)
+                    {
+                        var lines = data.Data.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+
+                        // StandardStreamData.Data always ends with a blank line, so skip that
+                        for (var i = 0; i < lines.Length - 1; i++)
+                            r.Append(data.IsError ? "[stderr] " : "[stdout] ").AppendLine(lines[i]);
+                    }
+                    else
+                    {
+                        r.Append(data.Data);
+                    }
+                }
+
+                return r.ToString();
+            }
+        }
+
+        [DebuggerDisplay("{ToString(),nq}")]
+        public struct StandardStreamData
+        {
+            public StandardStreamData(bool isError, string data)
+            {
+                IsError = isError;
+                Data = data;
+            }
+
+            public bool IsError { get; }
+            public string Data { get; }
+
+            public override string ToString() => (IsError ? "[stderr] " : "[stdout] ") + Data;
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/ShadowCopyUtils.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/ShadowCopyUtils.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace NUnit.Engine.Tests.Helpers
+{
+    public static class ShadowCopyUtils
+    {
+        /// <summary>
+        /// Returns the transitive closure of assemblies needed to copy.
+        /// Deals with assembly names rather than paths to work with runners that shadow copy.
+        /// </summary>
+        public static ICollection<string> GetAllNeededAssemblyPaths(params string[] assemblyNames)
+        {
+            var r = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var dependencies = StackEnumerator.Create(
+                from assemblyName in assemblyNames
+                select new AssemblyName(assemblyName));
+
+            foreach (var dependencyName in dependencies)
+            {
+                var dependency = Assembly.ReflectionOnlyLoad(dependencyName.FullName);
+
+                if (!dependency.GlobalAssemblyCache && r.Add(Path.GetFullPath(dependency.Location)))
+                {
+                    dependencies.Recurse(dependency.GetReferencedAssemblies());
+                }
+            }
+
+            return r;
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/StackEnumerator.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/StackEnumerator.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace NUnit.Engine.Tests.Helpers
+{
+    public static class StackEnumerator
+    {
+        public static StackEnumerator<T> Create<T>(params T[] initial) => new StackEnumerator<T>(initial);
+        public static StackEnumerator<T> Create<T>(IEnumerable<T> initial) => new StackEnumerator<T>(initial);
+        public static StackEnumerator<T> Create<T>(IEnumerator<T> initial) => new StackEnumerator<T>(initial);
+    }
+
+    public sealed class StackEnumerator<T> : IDisposable
+    {
+        private readonly Stack<IEnumerator<T>> stack = new Stack<IEnumerator<T>>();
+        private IEnumerator<T> current;
+
+        public bool MoveNext()
+        {
+            while (!current.MoveNext())
+            {
+                current.Dispose();
+                if (stack.Count == 0) return false;
+                current = stack.Pop();
+            }
+
+            return true;
+        }
+
+        public T Current => current.Current;
+
+        public void Recurse(IEnumerator<T> newCurrent)
+        {
+            if (newCurrent == null) return;
+            stack.Push(current);
+            current = newCurrent;
+        }
+        public void Recurse(IEnumerable<T> newCurrent)
+        {
+            if (newCurrent == null) return;
+            Recurse(newCurrent.GetEnumerator());
+        }
+        public void Recurse(params T[] newCurrent)
+        {
+            Recurse((IEnumerable<T>)newCurrent);
+        }
+
+        public StackEnumerator(IEnumerator<T> initial)
+        {
+            current = initial ?? Enumerable.Empty<T>().GetEnumerator();
+        }
+        public StackEnumerator(IEnumerable<T> initial) : this(initial?.GetEnumerator())
+        {
+        }
+        public StackEnumerator(params T[] initial) : this((IEnumerable<T>)initial)
+        {
+        }
+
+        // Foreach support
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public StackEnumerator<T> GetEnumerator()
+        {
+            return this;
+        }
+
+        public void Dispose()
+        {
+            current.Dispose();
+            foreach (var item in stack)
+                item.Dispose();
+            stack.Clear();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Integration/DirectoryWithNeededAssemblies.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/DirectoryWithNeededAssemblies.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+using NUnit.Engine.Tests.Helpers;
+
+namespace NUnit.Engine.Tests.Integration
+{
+    internal sealed class DirectoryWithNeededAssemblies : IDisposable
+    {
+        public string Directory { get; }
+
+        /// <summary>
+        /// Returns the transitive closure of assemblies needed to copy.
+        /// Deals with assembly names rather than paths to work with runners that shadow copy.
+        /// </summary>
+        public DirectoryWithNeededAssemblies(params string[] assemblyNames)
+        {
+            Directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            System.IO.Directory.CreateDirectory(Directory);
+
+            foreach (var neededAssembly in ShadowCopyUtils.GetAllNeededAssemblyPaths(assemblyNames))
+            {
+                File.Copy(neededAssembly, Path.Combine(Directory, Path.GetFileName(neededAssembly)));
+            }
+        }
+
+        public void Dispose()
+        {
+            System.IO.Directory.Delete(Directory, true);
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Integration/IntegrationTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/IntegrationTests.cs
@@ -1,0 +1,9 @@
+﻿using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Integration
+{
+    [TestFixture, Category("Integration")]
+    public abstract class IntegrationTests
+    {
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Integration/MockAssemblyInDirectoryWithFramework.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/MockAssemblyInDirectoryWithFramework.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Integration
+{
+    internal sealed class MockAssemblyInDirectoryWithFramework : IDisposable
+    {
+        private readonly DirectoryWithNeededAssemblies directory;
+
+        public string MockAssemblyDll => Path.Combine(directory.Directory, "mock-assembly.dll");
+
+        public MockAssemblyInDirectoryWithFramework()
+        {
+            directory = new DirectoryWithNeededAssemblies("mock-assembly");
+
+            Assert.That(Path.Combine(directory.Directory, "nunit.framework.dll"), Does.Exist, "This test must be run with nunit.framework.dll in the same directory as the mock assembly.");
+        }
+
+        public void Dispose()
+        {
+            directory.Dispose();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Integration/RemoteAgentTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/RemoteAgentTests.cs
@@ -1,0 +1,25 @@
+﻿using System.Diagnostics;
+using NUnit.Engine.Tests.Helpers;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Integration
+{
+    public sealed class RemoteAgentTests : IntegrationTests
+    {
+        [Test]
+        public void Explore_does_not_throw_SocketException()
+        {
+            using (var runner = new RunnerInDirectoryWithoutFramework())
+            using (var test = new MockAssemblyInDirectoryWithFramework())
+            {
+                for (var times = 0; times < 3; times++)
+                {
+                    var result = ProcessUtils.Run(new ProcessStartInfo(runner.ConsoleExe, $"--explore \"{test.MockAssemblyDll}\""));
+                    Assert.That(result.StandardStreamData, Has.None.With.Property("Data").Contains("System.Net.Sockets.SocketException"));
+                    Assert.That(result.StandardStreamData, Has.None.With.Property("IsError").True);
+                    Assert.That(result, Has.Property("ExitCode").Zero);
+                }
+            }
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Integration/RunnerInDirectoryWithoutFramework.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/RunnerInDirectoryWithoutFramework.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Integration
+{
+    internal sealed class RunnerInDirectoryWithoutFramework : IDisposable
+    {
+        private readonly DirectoryWithNeededAssemblies directory;
+
+        public string ConsoleExe => Path.Combine(directory.Directory, "nunit3-console.exe");
+        public string AgentExe => Path.Combine(directory.Directory, "nunit-agent.exe");
+        public string AgentX86Exe => Path.Combine(directory.Directory, "nunit-agent-x86.exe");
+
+        public RunnerInDirectoryWithoutFramework()
+        {
+            directory = new DirectoryWithNeededAssemblies("nunit3-console", "nunit-agent", "nunit-agent-x86");
+
+            Assert.That(Path.Combine(directory.Directory, "nunit.framework.dll"), Does.Not.Exist, "This test must be run without nunit.framework.dll in the same directory as the console runner.");
+        }
+
+        public void Dispose()
+        {
+            for (;;) try
+            {
+                File.Delete(AgentExe);
+                File.Delete(AgentX86Exe);
+                break;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Thread.Sleep(100);
+            }
+
+            directory.Dispose();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -79,6 +79,14 @@
     <Compile Include="Drivers\NUnit3FrameworkDriverTests.cs" />
     <Compile Include="DummyExtensions.cs" />
     <Compile Include="HangingAppDomainFixture.cs" />
+    <Compile Include="Helpers\ProcessUtils.cs" />
+    <Compile Include="Helpers\ShadowCopyUtils.cs" />
+    <Compile Include="Integration\DirectoryWithNeededAssemblies.cs" />
+    <Compile Include="Integration\IntegrationTests.cs" />
+    <Compile Include="Integration\MockAssemblyInDirectoryWithFramework.cs" />
+    <Compile Include="Integration\RemoteAgentTests.cs" />
+    <Compile Include="Helpers\StackEnumerator.cs" />
+    <Compile Include="Integration\RunnerInDirectoryWithoutFramework.cs" />
     <Compile Include="Internal\AssemblyHelperTests.cs" />
     <Compile Include="Internal\DirectoryFinderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/NUnitEngine/nunit.engine/Internal/CurrentMessageCounter.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/CurrentMessageCounter.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+
+namespace NUnit.Engine.Internal
+{
+    public sealed class CurrentMessageCounter
+    {
+        private readonly ManualResetEvent _noMessages = new ManualResetEvent(true);
+        private int _currentMessageCount;
+
+        public void OnMessageStart()
+        {
+            if (Interlocked.Increment(ref _currentMessageCount) == 1)
+                _noMessages.Reset();
+        }
+
+        public void OnMessageEnd()
+        {
+            if (Interlocked.Decrement(ref _currentMessageCount) == 0)
+                _noMessages.Set();
+        }
+
+        public void WaitForAllCurrentMessages()
+        {
+            _noMessages.WaitOne();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Internal/ServerUtilities.ObservableServerChannelSinkProvider.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ServerUtilities.ObservableServerChannelSinkProvider.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections;
+using System.IO;
+using System.Runtime.Remoting.Channels;
+using System.Runtime.Remoting.Messaging;
+
+namespace NUnit.Engine.Internal
+{
+    partial class ServerUtilities
+    {
+        private sealed class ObservableServerChannelSinkProvider : IServerChannelSinkProvider
+        {
+            private readonly CurrentMessageCounter _currentMessageCounter;
+
+            public ObservableServerChannelSinkProvider(CurrentMessageCounter currentMessageCounter)
+            {
+                if (currentMessageCounter == null) throw new ArgumentNullException(nameof(currentMessageCounter));
+                _currentMessageCounter = currentMessageCounter;
+            }
+
+            public void GetChannelData(IChannelDataStore channelData)
+            {
+            }
+
+            public IServerChannelSink CreateSink(IChannelReceiver channel)
+            {
+                if (Next == null)
+                    throw new InvalidOperationException("Cannot create a sink without setting the next provider.");
+                return new ObservableServerChannelSink(_currentMessageCounter, Next.CreateSink(channel));
+            }
+
+            public IServerChannelSinkProvider Next { get; set; }
+
+
+            private sealed class ObservableServerChannelSink : IServerChannelSink
+            {
+                private readonly IServerChannelSink _next;
+                private readonly CurrentMessageCounter _currentMessageCounter;
+
+                public ObservableServerChannelSink(CurrentMessageCounter currentMessageCounter, IServerChannelSink next)
+                {
+                    if (next == null) throw new ArgumentNullException(nameof(next));
+                    _currentMessageCounter = currentMessageCounter;
+                    _next = next;
+                }
+
+                public IDictionary Properties => _next.Properties;
+
+                public ServerProcessing ProcessMessage(IServerChannelSinkStack sinkStack, IMessage requestMsg,
+                    ITransportHeaders requestHeaders, Stream requestStream, out IMessage responseMsg,
+                    out ITransportHeaders responseHeaders, out Stream responseStream)
+                {
+                    _currentMessageCounter.OnMessageStart();
+                    var isAsync = false;
+                    try
+                    {
+                        var processing = _next.ProcessMessage(sinkStack, requestMsg, requestHeaders, requestStream,
+                            out responseMsg, out responseHeaders, out responseStream);
+                        isAsync = processing == ServerProcessing.Async;
+                        return processing;
+                    }
+                    finally
+                    {
+                        if (!isAsync) _currentMessageCounter.OnMessageEnd();
+                    }
+                }
+
+                public void AsyncProcessResponse(IServerResponseChannelSinkStack sinkStack, object state, IMessage msg,
+                    ITransportHeaders headers, Stream stream)
+                {
+                    try
+                    {
+                        _next.AsyncProcessResponse(sinkStack, state, msg, headers, stream);
+                    }
+                    finally
+                    {
+                        _currentMessageCounter.OnMessageEnd();
+                    }
+                }
+
+                public Stream GetResponseStream(IServerResponseChannelSinkStack sinkStack, object state, IMessage msg,
+                    ITransportHeaders headers)
+                {
+                    return _next.GetResponseStream(sinkStack, state, msg, headers);
+                }
+
+                public IServerChannelSink NextChannelSink => _next.NextChannelSink;
+            }
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Internal/ServerUtilities.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ServerUtilities.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -22,11 +22,12 @@
 // ***********************************************************************
 
 using System;
-using System.Collections;
+using System.Collections.Generic;
 using System.Runtime.Remoting;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
-using System.Reflection;
+using System.Runtime.Serialization.Formatters;
+using System.Threading;
 
 namespace NUnit.Engine.Internal
 {
@@ -36,49 +37,55 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class ServerUtilities
     {
-        static Logger log = InternalTrace.GetLogger(typeof(ServerUtilities));
+        private static readonly Logger Log = InternalTrace.GetLogger(typeof(ServerUtilities));
 
         /// <summary>
-        ///  Create a <see cref="TcpChannel"/> with a given name on a given port.
+        /// Create a <see cref="TcpChannel"/> with a given name on a given port.
         /// </summary>
         /// <param name="name">The name of the channel to create.</param>
         /// <param name="port">The port number of the channel to create.</param>
         /// <param name="limit">The rate limit of the channel to create.</param>
         /// <returns>A <see cref="TcpChannel"/> configured with the given name and port.</returns>
-        private static TcpChannel CreateTcpChannel( string name, int port, int limit )
+        private static TcpChannel CreateTcpChannel(string name, int port, int limit)
         {
-            Hashtable props = new Hashtable();
-            props.Add( "port", port );
-            props.Add( "name", name );
-            props.Add( "bindTo", "127.0.0.1" );
-
-            BinaryServerFormatterSinkProvider serverProvider =
-                new BinaryServerFormatterSinkProvider();
-
-            // NOTE: TypeFilterLevel and "clientConnectionLimit" property don't exist in .NET 1.0.
-            Type typeFilterLevelType = typeof(object).Assembly.GetType("System.Runtime.Serialization.Formatters.TypeFilterLevel");
-            if (typeFilterLevelType != null)
+            var props = new Dictionary<string, object>
             {
-                PropertyInfo typeFilterLevelProperty = serverProvider.GetType().GetProperty("TypeFilterLevel");
-                object typeFilterLevel = Enum.Parse(typeFilterLevelType, "Full");
-                typeFilterLevelProperty.SetValue(serverProvider, typeFilterLevel, null);
+                { "port", port },
+                { "name", name },
+                { "bindTo", "127.0.0.1" },
+                //{ "clientConnectionLimit", limit }
+            };
 
-//                props.Add("clientConnectionLimit", limit);
-            }
+            var serverProvider = new BinaryServerFormatterSinkProvider
+            {
+                TypeFilterLevel = TypeFilterLevel.Full
+            };
 
-            BinaryClientFormatterSinkProvider clientProvider =
-                new BinaryClientFormatterSinkProvider();
+            var clientProvider = new BinaryClientFormatterSinkProvider();
 
-            return new TcpChannel( props, clientProvider, serverProvider );
+            return new TcpChannel(props, clientProvider, serverProvider);
         }
 
         /// <summary>
         /// Get a default channel. If one does not exist, then one is created and registered.
         /// </summary>
-        /// <returns>The specified <see cref="TcpChannel"/> or null if it cannot be found and created</returns>
+        /// <returns>The specified <see cref="TcpChannel"/> or <see langword="null"/> if it cannot be found and created.</returns>
         public static TcpChannel GetTcpChannel()
         {
-            return GetTcpChannel( "", 0, 2 );
+            return GetTcpChannel("", 0, 2);
+        }
+
+        /// <summary>
+        /// Get a channel by name, casting it to a <see cref="TcpChannel"/>.
+        /// Otherwise, create, register and return a <see cref="TcpChannel"/> with
+        /// that name, on the port provided as the second argument.
+        /// </summary>
+        /// <param name="name">The name of the channel.</param>
+        /// <param name="port">The port to use if the channel must be created.</param>
+        /// <returns>The specified <see cref="TcpChannel"/> or <see langword="null"/> if it cannot be found and created.</returns>
+        public static TcpChannel GetTcpChannel(string name, int port)
+        {
+            return GetTcpChannel(name, port, 2);
         }
 
         /// <summary>
@@ -87,63 +94,47 @@ namespace NUnit.Engine.Internal
         /// that name, on the port provided as the second argument.
         /// </summary>
         /// <param name="name">The name of the channel</param>
-        /// <param name="port">The port to use if the channel must be created</param>
-        /// <returns>The specified <see cref="TcpChannel"/> or null if it cannot be found and created</returns>
-        public static TcpChannel GetTcpChannel( string name, int port )
-        {
-            return GetTcpChannel( name, port, 2 );
-        }
-        
-        /// <summary>
-        /// Get a channel by name, casting it to a <see cref="TcpChannel"/>.
-        /// Otherwise, create, register and return a <see cref="TcpChannel"/> with
-        /// that name, on the port provided as the second argument.
-        /// </summary>
-        /// <param name="name">The name of the channel</param>
-        /// <param name="port">The port to use if the channel must be created</param>
-        /// <param name="limit">The client connection limit or negative for the default</param>
-        /// <returns>The specified <see cref="TcpChannel"/> or null if it cannot be found and created</returns>
+        /// <param name="port">The port to use if the channel must be created.</param>
+        /// <param name="limit">The client connection limit or negative for the default.</param>
+        /// <returns>The specified <see cref="TcpChannel"/> or <see langword="null"/> if it cannot be found and created.</returns>
         public static TcpChannel GetTcpChannel(string name, int port, int limit)
         {
-            TcpChannel channel = ChannelServices.GetChannel( name ) as TcpChannel;
+            var existingChannel = ChannelServices.GetChannel(name) as TcpChannel;
+            if (existingChannel != null) return existingChannel;
 
-            if ( channel == null )
-            {
-                // NOTE: Retries are normally only needed when rapidly creating
-                // and destroying channels, as in running the NUnit tests.
-                int retries = 10;
-                while( --retries > 0 )
-                    try
-                    {
-                        channel = CreateTcpChannel( name, port, limit );
-                        ChannelServices.RegisterChannel( channel, false );
-                        break;
-                    }
-                    catch( Exception e )
-                    {
-                        log.Error("Failed to create/register channel", e);
-                        System.Threading.Thread.Sleep(300);
-                    }
-            }
+            // NOTE: Retries are normally only needed when rapidly creating
+            // and destroying channels, as in running the NUnit tests.
+            for (var retries = 0; retries < 10; retries++)
+                try
+                {
+                    var newChannel = CreateTcpChannel(name, port, limit);
+                    ChannelServices.RegisterChannel(newChannel, false);
+                    return newChannel;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("Failed to create/register channel", ex);
+                    Thread.Sleep(300);
+                }
 
-            return channel;
+            return null;
         }
 
         /// <summary>
         /// Unregisters the <see cref="IChannel"/> from the <see cref="ChannelServices"/> registry.
         /// </summary>
         /// <param name="channel">The channel to unregister.</param>
-        public static void SafeReleaseChannel( IChannel channel )
+        public static void SafeReleaseChannel(IChannel channel)
         {
-            if( channel != null )
-                try
-                {
-                    ChannelServices.UnregisterChannel( channel );
-                }
-                catch( RemotingException )
-                {
-                    // Channel was not registered - ignore
-                }
+            if (channel == null) return;
+            try
+            {
+                ChannelServices.UnregisterChannel(channel);
+            }
+            catch (RemotingException)
+            {
+                // Channel was not registered - ignore
+            }
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -77,10 +77,12 @@
     <Compile Include="InternalEnginePackageSettings.cs" />
     <Compile Include="Internal\AssemblyHelper.cs" />
     <Compile Include="Internal\CecilExtensions.cs" />
+    <Compile Include="Internal\CurrentMessageCounter.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceWriter.cs" />
     <Compile Include="Internal\Logging\Logger.cs" />
+    <Compile Include="Internal\ServerUtilities.ObservableServerChannelSinkProvider.cs" />
     <Compile Include="Internal\ProvidedPathsAssemblyResolver.cs" />
     <Compile Include="ITestAgency.cs" />
     <Compile Include="ITestAgent.cs" />


### PR DESCRIPTION
Fixes #225, and probably #171 and #219 and nunit/nunit#2027 and #175 as well so we should check them.

Remote caller == console runner
Callee == agent

### Cause of the bug

Every remoting call has three necessary stages:
 1. Transfer the information necessary to make the call from the caller to the callee over the communication channel. (For example, instance ID and marshaled parameters.)
 2. Perform the requested code execution in the callee.
 3. Transfer the result of the code execution from the callee to the caller over the communication channel. (For instance, return value and successful completion or exception.)

The agent's main thread starts the remoting TcpChannel listener. Then it blocks, waiting for a stop signal from another thread.

The agent's TcpChannel receives calls from the console runner and handles the three stages of each call on a threadpool thread.

The last call is the console runner telling the agent to shut down. The agent's code implementing the stop command is executed during stage 2. The agent can't shut down before stage 3 is complete without causing a SocketException in the remote caller which expects all three stages to complete normally for every call. So what the agent does is set the stop signal to unblock the agent's main thread and let the main thread handle the shutdown.

As soon as the agent's main thread is unblocked, the very next thing on its agenda is shutting itself down. Sometimes it shuts itself down so fast that the third stage of the stop call on the background thread is not complete. The main thread closes the socket while the background thread is still in the process of responding to the remote caller. This is the race condition [@lsem was talking about](https://github.com/nunit/nunit-console/issues/219#issuecomment-300953995).

So the stop signal really isn't useful on its own.

### The repeatable repro (the test commit)

For some reason, none of us could reliably reproduce this race condition unless we:
 * Run the console runner and agent from a folder which does not contain nunit.framework.dll
 * Use the --explore option
 * Have tests with dynamic test cases requiring execution of the user code at discovery time, when that code involves accessing TestContext.Current.

As far as I can tell, these are not related logically to the actual bug. They only shift timings.
If it doesn't repro the first time, it almost certainly will the second time. My test runs it up to three times.
I did see it pass all tests in AppVeyor once which it shouldn't have. On @tom-dudley's and my machines it repros every time in every runner we tried. (I tried build.cake, VS runner, and ReSharper.)


### The fix commit

Swallowing SocketExceptions is the least palatable option because it foists responsibility for the agent's internal problem onto the remote caller. Also you don't want to miss a legit and identical SocketException if do you lose your network connection. I will continue to assume this option is not on the table.

So what we need is to be sure that the three stages of the stop call have finished before shutting the TcpChannel down.

`Thread.Delay(1000)` is no guarantee. Due to thread scheduling or network delays, the stop call response may take an arbitrarily long time.

After researching and stepping through .NET Framework code in the debugger, it is evident we must shut down no sooner than this line completing:
http://referencesource.microsoft.com/#System.Runtime.Remoting/channels/tcp/tcpserverchannel.cs,613

Since we want to shut down as soon as possible after that line completes, we need a hook or event of some sort to let us know. As far as I can tell this leaves us with only one possible option: implement an `IServerChannelSink` which spies on all remoting calls and decorates the `TcpServerTransportSink`.

That is what the newly added `ObservableServerChannelSinkProvider` does. Every time you create a `TcpChannel` now you have an option to pass a `CurrentMessageCounter` which it will then use to keep track of how many calls are in flight at any given moment. Before the `TcpServerTransportSink` sees each message, the counter is incremented, and the counter is not decremented until the `TcpServerTransportSink` is completely finished all three stages of the call.

The `CurrentMessageCounter` also provides a method allowing you to wait until the number of in-flight messages is down to zero. So after the main thread receives the shutdown signal from the background thread, the main thread now waits for all concurrent messages (not just the stop message) to finish before shutting down.

This solution seems to be working well. There is now an absolute guarantee that every existing remote call has finished using the socket before we close the socket.

#### Edge cases

 * If the remote caller tries to send a remoting call after the stop call has finished, the remote caller will (and should) still get a SocketException.

 * If the remote caller sends more remoting calls overlapping with the stop call in such a way that the number of concurrent messages being handled does not get back to zero, the agent will not shut down until there are no more remote calls in flight. This would be bizarre behavior from the remote caller, but if it happened, this would likely be a useful feature rather than a bug.