### PR TITLE
Build choco package for the console runner

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -415,25 +415,29 @@ Task("PackageChocolatey")
 		
 		// Note: Since cake does not yet support a working directory and separate output directory for chocolatey, the following copying and hacks are needed.
 		
-		// List with the addins (addin name, primary dll, additional files)
-		var addins = new Tuple<string, string, string[]>[] {
-			new Tuple<string, string, string[]>(
+		// List with the addins (addin name, version, primary dll, additional files)
+		var addins = new Tuple<string, string, string, string[]>[] {
+			new Tuple<string, string, string, string[]>(
 				"NUnit.Extension.VSProjectLoader",
+				"3.5.0",
 				"vs-project-loader.dll",
 				null
 			),
-			new Tuple<string, string, string[]>(
+			new Tuple<string, string, string, string[]>(
 				"NUnit.Extension.NUnitProjectLoader",
+				"3.5.0",
 				"nunit-project-loader.dll",
 				null
 			),
-			new Tuple<string, string, string[]>(
+			new Tuple<string, string, string, string[]>(
 				"NUnit.Extension.NUnitV2ResultWriter",
+				"3.5.0",
 				"nunit-v2-result-writer.dll",
 				null
 			),
-			new Tuple<string, string, string[]>(
+			new Tuple<string, string, string, string[]>(
 				"NUnit.Extension.NUnitV2Driver",
+				"3.6.0",
 				"nunit.v2.driver.dll",
 				new [] {
 					"nunit.core.dll",
@@ -441,8 +445,9 @@ Task("PackageChocolatey")
 					"nunit.v2.driver.addins"
 				}
 			),
-			new Tuple<string, string, string[]>(
+			new Tuple<string, string, string, string[]>(
 				"NUnit.Extension.TeamCityEventListener",
+				"1.0.2",
 				"teamcity-event-listener.dll",
 				null
 			)
@@ -454,22 +459,24 @@ Task("PackageChocolatey")
 		var addinsDir = System.IO.Path.Combine(currentImageDir, "addins");
 		EnsureDirectoryExists(addinsDir);
 		foreach (var addin in addins) {
+			// Set the version
+			nugetInstallSettings.Version = addin.Item2;
 			// Install the extension
 			NuGetInstall(addin.Item1, nugetInstallSettings);
 			var addinToolsPath = System.IO.Path.Combine(toolsDir, addin.Item1, "tools");
 			// Copy primary dll
-			var primaryDllPath = System.IO.Path.Combine(addinToolsPath, addin.Item2);
+			var primaryDllPath = System.IO.Path.Combine(addinToolsPath, addin.Item3);
 			CopyFileToDirectory(primaryDllPath, addinsDir);
 			// Copy additional files
-			if (addin.Item3 != null) {
-				foreach (var additionalItem in addin.Item3) {
+			if (addin.Item4 != null) {
+				foreach (var additionalItem in addin.Item4) {
 					var additionalItemPath = System.IO.Path.Combine(addinToolsPath, additionalItem);
 					CopyFileToDirectory(additionalItemPath, addinsDir);
 				}
 			}
 			// Write the primary dll to the addins file
 			FileAppendLines(System.IO.Path.Combine(currentImageDir, "nunit.engine.addins"), new[] {
-				System.IO.Path.Combine("addins", addin.Item2)
+				System.IO.Path.Combine("addins", addin.Item3)
 			});
 		}	
 				

--- a/choco/nunit-console.nuspec
+++ b/choco/nunit-console.nuspec
@@ -2,10 +2,10 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>nunit-console.portable</id>
+    <id>nunit-console</id>
     <version>3.6.1</version>
-    <title>NUnit Console Runner Version 3 (No Extensions, Portable)</title>
-    <summary>Console runner for the NUnit 3 unit-testing framework, without any extensions.</summary>
+    <title>NUnit Console Runner Version 3</title>
+    <summary>Console runner for the NUnit 3 unit-testing framework.</summary>
     <description>
       This package includes the nunit3-console runner and test engine for version 3 of the NUnit unit-testing framework.
     </description>
@@ -40,13 +40,7 @@
     <file src="bin\nunit.engine.dll" target="tools" />
     <file src="bin\Mono.Cecil.dll" target="tools" />
     <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>
-	<file src="addins\nunit-project-loader.dll" target="tools\addins" />
-	<file src="addins\nunit.v2.driver.dll" target="tools\addins" />
-	<file src="addins\nunit.core.dll" target="tools\addins" />
-	<file src="addins\nunit.core.interfaces.dll" target="tools\addins" />
-	<file src="addins\nunit.v2.driver.addins" target="tools\addins" />
-	<file src="addins\nunit-v2-result-writer.dll" target="tools\addins" />
-	<file src="addins\teamcity-event-listener.dll" target="tools\addins" />
-	<file src="addins\vs-project-loader.dll" target="tools\addins" />
+	<file src="nunit.engine.addins" target="tools"/>	
+	<file src="addins\**\*.*" target="tools\addins" />
   </files>
 </package>

--- a/choco/nunit-console.nuspec
+++ b/choco/nunit-console.nuspec
@@ -19,11 +19,11 @@
 	<mailingListUrl>https://groups.google.com/forum/#!forum/nunit-discuss</mailingListUrl>
     <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <authors>nunit</authors>
-    <owners>nunit</owners>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
 	<language>en-US</language>
     <tags>nunit console runner test testing tdd</tags>
-    <copyright>Copyright (c) 2017 nunit</copyright>
+    <copyright>Copyright (c) 2017 Charlie Poole</copyright>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/choco/nunit-console.portable.nuspec
+++ b/choco/nunit-console.portable.nuspec
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>nunit-console.portable</id>
+    <version>3.6.1</version>
+    <title>NUnit Console Runner Version 3 (No Extensions, Portable)</title>
+    <summary>Console runner for the NUnit 3 unit-testing framework, without any extensions.</summary>
+    <description>
+      This package includes the nunit3-console runner and test engine for version 3 of the NUnit unit-testing framework.
+    </description>
+    <projectUrl>http://nunit.org</projectUrl>
+    <projectSourceUrl>https://github.com/nunit/nunit-console</projectSourceUrl>
+    <docsUrl>https://github.com/nunit/docs/wiki/Console-Command-Line</docsUrl>
+    <bugTrackerUrl>https://github.com/nunit/nunit-console/issues</bugTrackerUrl>
+    <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
+    <packageSourceUrl>https://github.com/nunit/nunit-console</packageSourceUrl>
+	<releaseNotes>https://raw.githubusercontent.com/nunit/nunit-console/master/CHANGES.txt</releaseNotes>
+	<mailingListUrl>https://groups.google.com/forum/#!forum/nunit-discuss</mailingListUrl>
+    <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>nunit</authors>
+    <owners>nunit</owners>
+	<language>en-US</language>
+    <tags>nunit console runner test testing tdd</tags>
+    <copyright>Copyright (c) 2017 nunit</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="NOTICES.txt" />
+    <file src="CHANGES.txt" />
+    <file src="bin\nunit-agent.exe" target="tools" />
+    <file src="bin\nunit-agent.exe.config" target="tools" />
+    <file src="bin\nunit-agent-x86.exe" target="tools" />
+    <file src="bin\nunit-agent-x86.exe.config" target="tools" />
+    <file src="bin\nunit3-console.exe" target="tools" />
+    <file src="bin\nunit3-console.exe.config" target="tools" />
+    <file src="bin\nunit.engine.api.dll" target="tools" />
+    <file src="bin\nunit.engine.api.xml" target="tools" />
+    <file src="bin\nunit.engine.dll" target="tools" />
+    <file src="bin\Mono.Cecil.dll" target="tools" />
+    <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>
+	<file src="addins\nunit-project-loader.dll" target="tools\addins" />
+	<file src="addins\nunit.v2.driver.dll" target="tools\addins" />
+	<file src="addins\nunit.core.dll" target="tools\addins" />
+	<file src="addins\nunit.core.interfaces.dll" target="tools\addins" />
+	<file src="addins\nunit.v2.driver.addins" target="tools\addins" />
+	<file src="addins\nunit-v2-result-writer.dll" target="tools\addins" />
+	<file src="addins\teamcity-event-listener.dll" target="tools\addins" />
+	<file src="addins\vs-project-loader.dll" target="tools\addins" />
+  </files>
+</package>


### PR DESCRIPTION
Since chocolate does not support things like BasePath and Cake does not support chocolateys Out parameter, there were a few "hacks" needed to bring it to work.