### PR TITLE
Create Chocolatey packages for console

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -64,7 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "notest-assembly", "src\NUni
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "choco", "choco", "{4FDF7BFA-A337-41D3-898D-C6A98278E6AD}"
 	ProjectSection(SolutionItems) = preProject
-		choco\nunit-console.nuspec = choco\nunit-console.nuspec
+		choco\nunit-console-runner.nuspec = choco\nunit-console-runner.nuspec
+		choco\nunit-console-with-extensions.nuspec = choco\nunit-console-with-extensions.nuspec
 	EndProjectSection
 EndProject
 Global

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -62,6 +62,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mock-assembly", "src\NUnitE
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "notest-assembly", "src\NUnitEngine\notest-assembly\notest-assembly.csproj", "{B1D90742-39BD-429C-8E87-C5CD2991DF27}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "choco", "choco", "{4FDF7BFA-A337-41D3-898D-C6A98278E6AD}"
+	ProjectSection(SolutionItems) = preProject
+		choco\nunit-console.nuspec = choco\nunit-console.nuspec
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -121,6 +126,7 @@ Global
 		{F3E87D0F-6F06-4C0B-AE06-42C0834C3C6E} = {A972031D-2F61-4183-AF75-99EE1A9F6B32}
 		{D2C80E4B-1117-4F02-AB02-E453BDA0C58E} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 		{B1D90742-39BD-429C-8E87-C5CD2991DF27} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
+		{4FDF7BFA-A337-41D3-898D-C6A98278E6AD} = {49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = src\NUnitFramework\tests\nunitlite.tests-2.0.csproj

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -64,6 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "notest-assembly", "src\NUni
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "choco", "choco", "{4FDF7BFA-A337-41D3-898D-C6A98278E6AD}"
 	ProjectSection(SolutionItems) = preProject
+		choco\nunit-agent-x86.exe.ignore = choco\nunit-agent-x86.exe.ignore
+		choco\nunit-agent.exe.ignore = choco\nunit-agent.exe.ignore
 		choco\nunit-console-runner.nuspec = choco\nunit-console-runner.nuspec
 		choco\nunit-console-with-extensions.nuspec = choco\nunit-console-with-extensions.nuspec
 	EndProjectSection

--- a/build.cake
+++ b/build.cake
@@ -482,7 +482,9 @@ Task("PackageChocolatey")
 		// Copy the nuspec files
 		CopyFileToDirectory("choco/nunit-console-runner.nuspec", currentImageDir);
 		CopyFileToDirectory("choco/nunit-console-with-extensions.nuspec", currentImageDir);
-		
+		CopyFileToDirectory("choco/nunit-agent.exe.ignore", currentImageDir + "bin/");
+		CopyFileToDirectory("choco/nunit-agent-x86.exe.ignore", currentImageDir + "bin");
+				
 		// Set the working directory
 		Context.Environment.WorkingDirectory = currentImageDir;
 		

--- a/build.cake
+++ b/build.cake
@@ -479,17 +479,24 @@ Task("PackageChocolatey")
 			});
 		}	
 				
-		// Copy the nuspec file
-		CopyFileToDirectory("choco/nunit-console.nuspec", currentImageDir);
+		// Copy the nuspec files
+		CopyFileToDirectory("choco/nunit-console-runner.nuspec", currentImageDir);
+		CopyFileToDirectory("choco/nunit-console-with-extensions.nuspec", currentImageDir);
 		
 		// Set the working directory
 		Context.Environment.WorkingDirectory = currentImageDir;
 		
-		ChocolateyPack("nunit-console.nuspec", 
+		ChocolateyPack("nunit-console-runner.nuspec", 
 			new ChocolateyPackSettings()
 			{
 				Version = packageVersion,
-				//WorkingDirectory = currentImageDir,
+				OutputDirectory = PACKAGE_DIR
+			});
+		
+		ChocolateyPack("nunit-console-with-extensions.nuspec", 
+			new ChocolateyPackSettings()
+			{
+				Version = packageVersion,
 				OutputDirectory = PACKAGE_DIR
 			});
 	}); 

--- a/build.cake
+++ b/build.cake
@@ -492,14 +492,52 @@ Task("PackageChocolatey")
 			new ChocolateyPackSettings()
 			{
 				Version = packageVersion,
-				OutputDirectory = PACKAGE_DIR
+				OutputDirectory = PACKAGE_DIR,
+				Files = new []
+				{
+					new ChocolateyNuSpecContent { Source = "LICENSE.txt" },
+					new ChocolateyNuSpecContent { Source = "NOTICES.txt" },
+					new ChocolateyNuSpecContent { Source = "CHANGES.txt" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent.exe", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent.exe.config", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent.exe.ignore", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent-x86.exe", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent-x86.exe.config", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent-x86.exe.ignore", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit3-console.exe", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit3-console.exe.config", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit.engine.api.dll", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit.engine.api.xml", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit.engine.dll", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/Mono.Cecil.dll", Target="tools" }
+				}
 			});
 		
 		ChocolateyPack("nunit-console-with-extensions.nuspec", 
 			new ChocolateyPackSettings()
 			{
 				Version = packageVersion,
-				OutputDirectory = PACKAGE_DIR
+				OutputDirectory = PACKAGE_DIR,
+				Files = new []
+				{
+					new ChocolateyNuSpecContent { Source = "LICENSE.txt" },
+					new ChocolateyNuSpecContent { Source = "NOTICES.txt" },
+					new ChocolateyNuSpecContent { Source = "CHANGES.txt" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent.exe", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent.exe.config", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent.exe.ignore", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent-x86.exe", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent-x86.exe.config", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit-agent-x86.exe.ignore", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit3-console.exe", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit3-console.exe.config", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit.engine.api.dll", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit.engine.api.xml", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/nunit.engine.dll", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "bin/Mono.Cecil.dll", Target="tools" },
+					new ChocolateyNuSpecContent { Source = "nunit.engine.addins", Target="tools" },	
+					new ChocolateyNuSpecContent { Source = "addins/**/*.*", Target="tools" }	
+				}
 			});
 	}); 
 

--- a/build.cake
+++ b/build.cake
@@ -405,17 +405,20 @@ Task("PackageConsole")
         });
     });
 
+// Unlike other tasks, this one does not depend on creation of the
+// image directory. I think this is the direction we want to go 
+// for all the different packages, but it's for a separate change.
 Task("PackageChocolatey")
 	.Description("Creates chocolatey packages of the console runner")
 	.Does(() =>
 	{
+	    // Using image dir just as a place to hold this one file for now
 		var currentImageDir = IMAGE_DIR + "NUnit-" + packageVersion + "/";
 		
 		EnsureDirectoryExists(PACKAGE_DIR);
 		
-		// Note: Since cake does not yet support a working directory and separate output directory for chocolatey, the following copying and hacks are needed.
-		
 		// List with the extensions (name, version, primary dll) we are installing
+		// We need this to download the extensions and to produce the addins file
 		var extensions = new Tuple<string, string, string>[] {
 			new Tuple<string, string, string>(
 				"NUnit.Extension.VSProjectLoader",
@@ -480,6 +483,8 @@ Task("PackageChocolatey")
 			new ChocolateyNuSpecContent { Source = BIN_DIR + "Mono.Cecil.dll", Target="tools" }
 		};
 
+		// Used for the creation of the package. Duplicates what is in the extensions
+		// structure, unfortunately. Should be changed.
 		var extensionContent = new []
 		{
 			new ChocolateyNuSpecContent { Source = BIN_DIR + "nunit.engine.addins", Target="tools" },	

--- a/build.cake
+++ b/build.cake
@@ -1,3 +1,5 @@
+#addin "Cake.FileHelpers"
+
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
@@ -402,6 +404,96 @@ Task("PackageConsole")
         });
     });
 
+Task("PackageChocolatey")
+	.Description("Creates chocolate packages of the console runner")
+    .IsDependentOn("CreateImage")
+	.Does(() =>
+	{
+		var currentImageDir = IMAGE_DIR + "NUnit-" + packageVersion + "/";
+		
+		EnsureDirectoryExists(PACKAGE_DIR);
+		
+		// Note: Since cake does not yet support a working directory and separate output directory for chocolatey, the following copying and hacks are needed.
+		
+		// List with the addins (addin name, version, primary dll, additional files)
+		var addins = new Tuple<string, string, string, string[]>[] {
+			new Tuple<string, string, string, string[]>(
+				"NUnit.Extension.VSProjectLoader",
+				"3.5.0",
+				"vs-project-loader.dll",
+				null
+			),
+			new Tuple<string, string, string, string[]>(
+				"NUnit.Extension.NUnitProjectLoader",
+				"3.5.0",
+				"nunit-project-loader.dll",
+				null
+			),
+			new Tuple<string, string, string, string[]>(
+				"NUnit.Extension.NUnitV2ResultWriter",
+				"3.5.0",
+				"nunit-v2-result-writer.dll",
+				null
+			),
+			new Tuple<string, string, string, string[]>(
+				"NUnit.Extension.NUnitV2Driver",
+				"3.6.0",
+				"nunit.v2.driver.dll",
+				new [] {
+					"nunit.core.dll",
+					"nunit.core.interfaces.dll"
+				}
+			),
+			new Tuple<string, string, string, string[]>(
+				"NUnit.Extension.TeamCityEventListener",
+				"1.0.2",
+				"teamcity-event-listener.dll",
+				null
+			)
+		};
+		
+		// Install and copy the addin files
+		var toolsDir = "tools";
+		var nugetInstallSettings = new NuGetInstallSettings { OutputDirectory = toolsDir, ExcludeVersion = true };
+		var addinsDir = System.IO.Path.Combine(currentImageDir, "addins");
+		EnsureDirectoryExists(addinsDir);
+		foreach (var addin in addins) {
+			// Set the version
+			nugetInstallSettings.Version = addin.Item2;
+			// Install the extension
+			NuGetInstall(addin.Item1, nugetInstallSettings);
+			var addinToolsPath = System.IO.Path.Combine(toolsDir, addin.Item1, "tools");
+			// Copy primary dll
+			var primaryDllPath = System.IO.Path.Combine(addinToolsPath, addin.Item3);
+			CopyFileToDirectory(primaryDllPath, addinsDir);
+			// Copy additional files
+			if (addin.Item4 != null) {
+				foreach (var additionalItem in addin.Item4) {
+					var additionalItemPath = System.IO.Path.Combine(addinToolsPath, additionalItem);
+					CopyFileToDirectory(additionalItemPath, addinsDir);
+				}
+			}
+			// Write the primary dll to the addins file
+			FileAppendLines(System.IO.Path.Combine(currentImageDir, "nunit.engine.addins"), new[] {
+				System.IO.Path.Combine("addins", addin.Item3)
+			});
+		}	
+				
+		// Copy the nuspec file
+		CopyFileToDirectory("choco/nunit-console.nuspec", currentImageDir);
+		
+		// Set the working directory
+		Context.Environment.WorkingDirectory = currentImageDir;
+		
+		ChocolateyPack("nunit-console.nuspec", 
+			new ChocolateyPackSettings()
+			{
+				Version = packageVersion,
+				//WorkingDirectory = currentImageDir,
+				OutputDirectory = PACKAGE_DIR
+			});
+	}); 
+
 //////////////////////////////////////////////////////////////////////
 // PACKAGE NETSTANDARD ENGINE
 //////////////////////////////////////////////////////////////////////
@@ -554,7 +646,8 @@ Task("Package")
     .IsDependentOn("CheckForError")
     .IsDependentOn("PackageEngine")
     .IsDependentOn("PackageConsole")
-    .IsDependentOn("PackageNetStandardEngine");
+    .IsDependentOn("PackageNetStandardEngine")
+	.IsDependentOn("PackageChocolatey");
 
 Task("Appveyor")
     .Description("Builds, tests and packages on AppVeyor")

--- a/choco/nunit-console-runner.nuspec
+++ b/choco/nunit-console-runner.nuspec
@@ -31,8 +31,10 @@
     <file src="CHANGES.txt" />
     <file src="bin\nunit-agent.exe" target="tools" />
     <file src="bin\nunit-agent.exe.config" target="tools" />
+    <file src="bin\nunit-agent.exe.ignore" target="tools" />
     <file src="bin\nunit-agent-x86.exe" target="tools" />
     <file src="bin\nunit-agent-x86.exe.config" target="tools" />
+    <file src="bin\nunit-agent-x86.exe.ignore" target="tools" />
     <file src="bin\nunit3-console.exe" target="tools" />
     <file src="bin\nunit3-console.exe.config" target="tools" />
     <file src="bin\nunit.engine.api.dll" target="tools" />

--- a/choco/nunit-console-runner.nuspec
+++ b/choco/nunit-console-runner.nuspec
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>nunit-console-runner</id>
+    <version>0.0.0</version>
+    <title>NUnit 3 Console Runner</title>
+    <summary>Console runner for the NUnit 3 unit-testing framework.</summary>
+    <description>
+      This package includes the nunit3-console runner and test engine for version 3 of the NUnit unit-testing framework.
+    </description>
+    <projectUrl>http://nunit.org</projectUrl>
+    <projectSourceUrl>https://github.com/nunit/nunit-console</projectSourceUrl>
+    <docsUrl>https://github.com/nunit/docs/wiki/Console-Command-Line</docsUrl>
+    <bugTrackerUrl>https://github.com/nunit/nunit-console/issues</bugTrackerUrl>
+    <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
+    <packageSourceUrl>https://github.com/nunit/nunit-console</packageSourceUrl>
+    <releaseNotes>https://raw.githubusercontent.com/nunit/nunit-console/master/CHANGES.txt</releaseNotes>
+    <mailingListUrl>https://groups.google.com/forum/#!forum/nunit-discuss</mailingListUrl>
+    <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+    <language>en-US</language>
+    <tags>nunit console runner test testing tdd</tags>
+    <copyright>Copyright (c) 2017 Charlie Poole</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="NOTICES.txt" />
+    <file src="CHANGES.txt" />
+    <file src="bin\nunit-agent.exe" target="tools" />
+    <file src="bin\nunit-agent.exe.config" target="tools" />
+    <file src="bin\nunit-agent-x86.exe" target="tools" />
+    <file src="bin\nunit-agent-x86.exe.config" target="tools" />
+    <file src="bin\nunit3-console.exe" target="tools" />
+    <file src="bin\nunit3-console.exe.config" target="tools" />
+    <file src="bin\nunit.engine.api.dll" target="tools" />
+    <file src="bin\nunit.engine.api.xml" target="tools" />
+    <file src="bin\nunit.engine.dll" target="tools" />
+    <file src="bin\Mono.Cecil.dll" target="tools" />
+  </files>
+</package>

--- a/choco/nunit-console-runner.nuspec
+++ b/choco/nunit-console-runner.nuspec
@@ -25,21 +25,4 @@
     <tags>nunit console runner test testing tdd</tags>
     <copyright>Copyright (c) 2017 Charlie Poole</copyright>
   </metadata>
-  <files>
-    <file src="LICENSE.txt" />
-    <file src="NOTICES.txt" />
-    <file src="CHANGES.txt" />
-    <file src="bin\nunit-agent.exe" target="tools" />
-    <file src="bin\nunit-agent.exe.config" target="tools" />
-    <file src="bin\nunit-agent.exe.ignore" target="tools" />
-    <file src="bin\nunit-agent-x86.exe" target="tools" />
-    <file src="bin\nunit-agent-x86.exe.config" target="tools" />
-    <file src="bin\nunit-agent-x86.exe.ignore" target="tools" />
-    <file src="bin\nunit3-console.exe" target="tools" />
-    <file src="bin\nunit3-console.exe.config" target="tools" />
-    <file src="bin\nunit.engine.api.dll" target="tools" />
-    <file src="bin\nunit.engine.api.xml" target="tools" />
-    <file src="bin\nunit.engine.dll" target="tools" />
-    <file src="bin\Mono.Cecil.dll" target="tools" />
-  </files>
 </package>

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -34,23 +34,4 @@
     <tags>nunit console runner test testing tdd</tags>
     <copyright>Copyright (c) 2017 Charlie Poole</copyright>
   </metadata>
-  <files>
-    <file src="LICENSE.txt" />
-    <file src="NOTICES.txt" />
-    <file src="CHANGES.txt" />
-    <file src="bin\nunit-agent.exe" target="tools" />
-    <file src="bin\nunit-agent.exe.config" target="tools" />
-    <file src="bin\nunit-agent.exe.ignore" target="tools" />
-    <file src="bin\nunit-agent-x86.exe" target="tools" />
-    <file src="bin\nunit-agent-x86.exe.config" target="tools" />
-    <file src="bin\nunit-agent-x86.exe.ignore" target="tools" />
-    <file src="bin\nunit3-console.exe" target="tools" />
-    <file src="bin\nunit3-console.exe.config" target="tools" />
-    <file src="bin\nunit.engine.api.dll" target="tools" />
-    <file src="bin\nunit.engine.api.xml" target="tools" />
-    <file src="bin\nunit.engine.dll" target="tools" />
-    <file src="bin\Mono.Cecil.dll" target="tools" />
-	<file src="nunit.engine.addins" target="tools"/>	
-	<file src="addins\**\*.*" target="tools\addins" />
-  </files>
 </package>

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -40,8 +40,10 @@
     <file src="CHANGES.txt" />
     <file src="bin\nunit-agent.exe" target="tools" />
     <file src="bin\nunit-agent.exe.config" target="tools" />
+    <file src="bin\nunit-agent.exe.ignore" target="tools" />
     <file src="bin\nunit-agent-x86.exe" target="tools" />
     <file src="bin\nunit-agent-x86.exe.config" target="tools" />
+    <file src="bin\nunit-agent-x86.exe.ignore" target="tools" />
     <file src="bin\nunit3-console.exe" target="tools" />
     <file src="bin\nunit3-console.exe.config" target="tools" />
     <file src="bin\nunit.engine.api.dll" target="tools" />

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -2,12 +2,21 @@
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>nunit-console</id>
-    <version>3.6.1</version>
-    <title>NUnit Console Runner Version 3</title>
-    <summary>Console runner for the NUnit 3 unit-testing framework.</summary>
+    <id>nunit-console-with-extensions</id>
+    <version>0.0.0</version>
+    <title>NUnit 3 Console Runner Plus Extensions</title>
+    <summary>Console runner for the NUnit 3 unit-testing framework with selected extensions.</summary>
     <description>
       This package includes the nunit3-console runner and test engine for version 3 of the NUnit unit-testing framework.
+
+      The following extensions are included with this package:
+      * NUnitProjectLoader     - loads tests from NUnit projects
+      * VSProjectLoader        - loads tests from Visual Studio projects
+      * NUnitV2ResultWriter    - saves results in NUnit V2 format.
+      * NUnitV2FrameworkDriver - runs NUnit V2 tests.
+      * TeamCityEventListener - supports special progress messages used by teamcity.
+
+      Other extensions, if needed, must be installed separately.
     </description>
     <projectUrl>http://nunit.org</projectUrl>
     <projectSourceUrl>https://github.com/nunit/nunit-console</projectSourceUrl>

--- a/choco/nunit-console.nuspec
+++ b/choco/nunit-console.nuspec
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>nunit-console</id>
+    <version>3.6.1</version>
+    <title>NUnit Console Runner Version 3</title>
+    <summary>Console runner for the NUnit 3 unit-testing framework.</summary>
+    <description>
+      This package includes the nunit3-console runner and test engine for version 3 of the NUnit unit-testing framework.
+    </description>
+    <projectUrl>http://nunit.org</projectUrl>
+    <projectSourceUrl>https://github.com/nunit/nunit-console</projectSourceUrl>
+    <docsUrl>https://github.com/nunit/docs/wiki/Console-Command-Line</docsUrl>
+    <bugTrackerUrl>https://github.com/nunit/nunit-console/issues</bugTrackerUrl>
+    <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
+    <packageSourceUrl>https://github.com/nunit/nunit-console</packageSourceUrl>
+	<releaseNotes>https://raw.githubusercontent.com/nunit/nunit-console/master/CHANGES.txt</releaseNotes>
+	<mailingListUrl>https://groups.google.com/forum/#!forum/nunit-discuss</mailingListUrl>
+    <licenseUrl>http://nunit.org/nuget/nunit3-license.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Charlie Poole</authors>
+    <owners>Charlie Poole</owners>
+	<language>en-US</language>
+    <tags>nunit console runner test testing tdd</tags>
+    <copyright>Copyright (c) 2017 Charlie Poole</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="NOTICES.txt" />
+    <file src="CHANGES.txt" />
+    <file src="bin\nunit-agent.exe" target="tools" />
+    <file src="bin\nunit-agent.exe.config" target="tools" />
+    <file src="bin\nunit-agent-x86.exe" target="tools" />
+    <file src="bin\nunit-agent-x86.exe.config" target="tools" />
+    <file src="bin\nunit3-console.exe" target="tools" />
+    <file src="bin\nunit3-console.exe.config" target="tools" />
+    <file src="bin\nunit.engine.api.dll" target="tools" />
+    <file src="bin\nunit.engine.api.xml" target="tools" />
+    <file src="bin\nunit.engine.dll" target="tools" />
+    <file src="bin\Mono.Cecil.dll" target="tools" />
+	<file src="nunit.engine.addins" target="tools"/>	
+	<file src="addins\**\*.*" target="tools\addins" />
+  </files>
+</package>

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>NUnit.Console</id>
-    <title>NUnit Console Runner Version 3 Plus Extensions</title>
+    <title>NUnit 3 Console Runner Plus Extensions</title>
     <version>$version$</version>
     <authors>Charlie Poole</authors>
     <owners>Charlie Poole</owners>


### PR DESCRIPTION
Fixes #207 

This PR incorporates work from PR #234 by @Roemer and adds the following:
* There are now two packages, one for console only and one with extensions
* File names and package ids are changed
* Creation of shims for the agent exes is suppressed - we don't want users to be executing them directly.

I marked this as "Do Not Merge" because I'd really prefer to see the extensions referenced as packages, the way we do for NuGet, rather than actually copied into the package with extensions. I can see the way to do that with Chocolatey, but it will take some more experimentation. Alternatively, we could release what we have and improve it later.

Improving would mean first trying to use the existing nuget packages for the extensions. I know chocolatey will install them, but I don't know how whether it will do so in a way that is useful for us. The fallback would be to modify the nuget packages, creating chocolatey packages. In either case, there would be a file installed with the engine, similar to `nunit.nuget.addins`, i.e. `nunit.choco.addins`, which would allow the engine to find the extensions.

So the question is whether to wait for the better solution or just go with what we have now. @rprouse what do you prefer?