### PR TITLE
Correct misprint ".con" -> ".com"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ NUnit is Open Source software and NUnit 3 is released under the [MIT license](ht
 
 ## Contributors ##
 
-NUnit 3 was created by [Charlie Poole](https://github.com/CharliePoole), [Rob Prouse](https://github.com/rprouse), [Simone Busoli](https://github.com/simoneb), [Neil Colvin](https://github.con/oznetmaster) and numerous community contributors. A complete list of contributors since NUnit migrated to GitHub can be [found on GitHub](https://github.com/nunit/nunit-console/graphs/contributors).
+NUnit 3 was created by [Charlie Poole](https://github.com/CharliePoole), [Rob Prouse](https://github.com/rprouse), [Simone Busoli](https://github.com/simoneb), [Neil Colvin](https://github.com/oznetmaster) and numerous community contributors. A complete list of contributors since NUnit migrated to GitHub can be [found on GitHub](https://github.com/nunit/nunit-console/graphs/contributors).
 
 Earlier versions of NUnit were developed by Charlie Poole, James W. Newkirk, Alexei A. Vorontsov, Michael C. Two and Philip A. Craig.


### PR DESCRIPTION
Corrected link to Neil Colvin's github account.