### PR TITLE
Improve error catching around OutputSpecifications

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -475,7 +475,7 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void ResultOptionWithFilePathAndTransform()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml;transform=transform.xslt");
+            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml;transform=TextSummary.xslt");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -483,7 +483,7 @@ namespace NUnit.ConsoleRunner.Tests
             OutputSpecification spec = options.ResultOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
             Assert.AreEqual("user", spec.Format);
-            Assert.AreEqual("transform.xslt", spec.Transform);
+            Assert.AreEqual("TextSummary.xslt", spec.Transform);
         }
 
         [Test]
@@ -506,7 +506,7 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void ResultOptionMayBeRepeated()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml", "-result:nunit2results.xml;format=nunit2", "-result:myresult.xml;transform=mytransform.xslt");
+            ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml", "-result:nunit2results.xml;format=nunit2", "-result:myresult.xml;transform=TextSummary.xslt");
             Assert.True(options.Validate(), "Should be valid");
 
             var specs = options.ResultOutputSpecifications;
@@ -525,7 +525,7 @@ namespace NUnit.ConsoleRunner.Tests
             var spec3 = specs[2];
             Assert.AreEqual("myresult.xml", spec3.OutputPath);
             Assert.AreEqual("user", spec3.Format);
-            Assert.AreEqual("mytransform.xslt", spec3.Transform);
+            Assert.AreEqual("TextSummary.xslt", spec3.Transform);
         }
 
         [Test]
@@ -552,6 +552,27 @@ namespace NUnit.ConsoleRunner.Tests
         {
             var options = new ConsoleOptions("test.dll", "-result:results.xml", "-noresult", "-result:nunit2results.xml;format=nunit2");
             Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
+        }
+
+        [Test]
+        public void InvalidResultSpecRecordsError()
+        {
+            var options = new ConsoleOptions("test.dll", "-result:userspecifed.xml;format=nunit2;format=nunit3");
+            Assert.That(options.ResultOutputSpecifications, Has.Exactly(1).Items
+                .And.Exactly(1).Property(nameof(OutputSpecification.OutputPath)).EqualTo("TestResult.xml"));
+            Assert.That(options.ErrorMessages, Has.Exactly(1).Contains("conflicting format options").IgnoreCase);
+        }
+
+        [Test]
+        public void MissingXsltFileRecordsError()
+        {
+            const string missingXslt = "missing.xslt";
+            Assert.That(missingXslt, Does.Not.Exist);
+
+            var options = new ConsoleOptions("test.dll", $"-result:userspecifed.xml;transform={missingXslt}");
+            Assert.That(options.ResultOutputSpecifications, Has.Exactly(1).Items
+                                                               .And.Exactly(1).Property(nameof(OutputSpecification.Transform)).Null);
+            Assert.That(options.ErrorMessages, Has.Exactly(1).Contains($"{missingXslt} could not be found").IgnoreCase);
         }
 
         #endregion
@@ -599,7 +620,7 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void ExploreOptionWithFilePathAndTransform()
         {
-            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml;transform=myreport.xslt");
+            ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml;transform=TextSummary.xslt");
             Assert.True(options.Validate());
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
@@ -608,7 +629,7 @@ namespace NUnit.ConsoleRunner.Tests
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
             Assert.AreEqual("user", spec.Format);
-            Assert.AreEqual("myreport.xslt", spec.Transform);
+            Assert.AreEqual("TextSummary.xslt", spec.Transform);
         }
 
         [Test]

--- a/src/NUnitConsole/nunit3-console.tests/OutputSpecificationTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/OutputSpecificationTests.cs
@@ -33,7 +33,7 @@ namespace NUnit.Common.Tests
         {
             Assert.That(
                 () => new OutputSpecification(null),
-                Throws.TypeOf<NullReferenceException>());
+                Throws.TypeOf<ArgumentNullException>());
         }
 
 

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -171,9 +171,21 @@ namespace NUnit.ConsoleRunner
             foreach (var spec in _options.ResultOutputSpecifications)
             {
                 var outputPath = Path.Combine(_workDirectory, spec.OutputPath);
+
+                IResultWriter resultWriter;
+
                 try
                 {
-                    GetResultWriter(spec).CheckWritability(outputPath);
+                    resultWriter = GetResultWriter(spec);
+                }
+                catch (Exception ex)
+                {
+                    throw new NUnitEngineException($"Error encountered in resolving output specification: {spec}", ex);
+                }
+
+                try
+                {
+                    resultWriter.CheckWritability(outputPath);
                 }
                 catch (SystemException ex)
                 {

--- a/src/NUnitConsole/nunit3-console/OutputSpecification.cs
+++ b/src/NUnitConsole/nunit3-console/OutputSpecification.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Text;
 
 namespace NUnit.Common
 {
@@ -40,7 +41,7 @@ namespace NUnit.Common
         public OutputSpecification(string spec)
         {
             if (spec == null)
-                throw new NullReferenceException("Output spec may not be null");
+                throw new ArgumentNullException(nameof(spec), "Output spec may not be null");
 
             string[] parts = spec.Split(';');
             this.OutputPath = parts[0];
@@ -50,7 +51,7 @@ namespace NUnit.Common
                 string[] opt = parts[i].Split('=');
 
                 if (opt.Length != 2)
-                    throw new ArgumentException();
+                    throw new ArgumentException($"Invalid output specification: {spec}");
 
                 switch (opt[0].Trim())
                 {
@@ -105,5 +106,13 @@ namespace NUnit.Common
         public string Transform { get; private set; }
 
         #endregion
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder($"OutputPath: {OutputPath}");
+            if (Format != null) sb.Append($", Format: {Format}");
+            if (Transform != null) sb.Append($", Transform: {Transform}");
+            return sb.ToString();
+        }
     }
 }


### PR DESCRIPTION
Fixes #252.

As well as fixing the original crash, this also generally improves error catching in this area.

1. Fixes crash when an invalid `--result` format is passed.
2. Fixes NUnit Engine returning misleading error message when transform can not be loaded.
3. ConsoleOptions now validates for existence of transform, so we can provide a neat error message, rather than stack trace from the engine.
