### PR TITLE
Fix possible NRE

### DIFF
--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -42,6 +42,8 @@ namespace NUnit.ConsoleRunner
             OverallResult = resultNode.GetAttribute("result");
             if (OverallResult == "Skipped")
                 OverallResult = "Warning";
+            if (OverallResult == null)
+                OverallResult = "Unknown";
 
             Summary = new ResultSummary(resultNode);
         }

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -104,7 +104,7 @@ namespace NUnit.ConsoleRunner
         {
             ColorStyle overall = OverallResult == "Passed"
                 ? ColorStyle.Pass
-                : OverallResult == "Failed" 
+                : OverallResult == "Failed"  || OverallResult == "Unknown"
                     ? ColorStyle.Failure
                     : OverallResult == "Warning"
                         ? ColorStyle.Warning


### PR DESCRIPTION
If for some reason NUnit.Engine.Runners.ProcessRunner failed to run task, in the resultNode there is no "result" attribute. Thus, OverallResult stays null and WriteSummaryReport() fails with NullReferenceException on line 112,  leaving user frustrated about reasons of fail and results of the test run.

Albeit main cause of this error is rethrowing exception in ProcessRunner.cs (See Dispose method, line 255) user should not see NullReference exception and must be infromed with a more meaningfull information.