### PR TITLE
Integrate chocolatey package in build script

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -411,6 +411,7 @@ Task("PackageConsole")
 // for all the different packages, but it's for a separate change.
 Task("PackageChocolatey")
 	.Description("Creates chocolatey packages of the console runner")
+	.IsDependentOn("Build")
 	.Does(() =>
 	{
 		EnsureDirectoryExists(PACKAGE_DIR);
@@ -424,8 +425,8 @@ Task("PackageChocolatey")
                     new ChocolateyNuSpecContent { Source = PROJECT_DIR + "LICENSE.txt", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = PROJECT_DIR + "NOTICES.txt", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = PROJECT_DIR + "CHANGES.txt", Target = "tools" },
-			        new ChocolateyNuSpecContent { Source = CHOCO_DIR + "VERIFICATION.txt", Target = "tools" },
-			        new ChocolateyNuSpecContent { Source = CHOCO_DIR + "nunit.choco.addins", Target = "tools" },
+                    new ChocolateyNuSpecContent { Source = CHOCO_DIR + "VERIFICATION.txt", Target = "tools" },
+                    new ChocolateyNuSpecContent { Source = CHOCO_DIR + "nunit.choco.addins", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = BIN_DIR + "nunit-agent.exe", Target="tools" },
                     new ChocolateyNuSpecContent { Source = BIN_DIR + "nunit-agent.exe.config", Target="tools" },
                     new ChocolateyNuSpecContent { Source = CHOCO_DIR + "nunit-agent.exe.ignore", Target="tools" },
@@ -449,7 +450,7 @@ Task("PackageChocolatey")
                 Files = new [] {
                     new ChocolateyNuSpecContent { Source = PROJECT_DIR + "LICENSE.txt", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = PROJECT_DIR + "NOTICES.txt", Target = "tools" },
-			        new ChocolateyNuSpecContent { Source = CHOCO_DIR + "VERIFICATION.txt", Target = "tools" }
+                    new ChocolateyNuSpecContent { Source = CHOCO_DIR + "VERIFICATION.txt", Target = "tools" }
                 }
 			});
 	});

--- a/choco/VERIFICATION.txt
+++ b/choco/VERIFICATION.txt
@@ -1,0 +1,7 @@
+VERIFICATION
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+This package is published by the NUnit Project itself. The binaries are 
+identical to other package types published by the project, in particular
+the NUnit.ConsoleRunner and NUNit.Console nuget packages.

--- a/choco/VERIFICATION.txt
+++ b/choco/VERIFICATION.txt
@@ -2,6 +2,6 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-This package is published by the NUnit Project itself. The binaries are 
+This package is published by the NUnit Project itself. Any binaries will be 
 identical to other package types published by the project, in particular
-the NUnit.ConsoleRunner and NUNit.Console nuget packages.
+the NUnit.ConsoleRunner and NUnit.Console NuGet packages.

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -40,7 +40,7 @@
           <dependency id="nunit-extension-vs-project-loader" version="3.5.0" />
           <dependency id="nunit-extension-nunit-v2-result-writer" version="3.5.0" />
           <dependency id="nunit-extension-nunit-v2-driver" version="3.6.0" />
-        <dependency id="nunit-extension-teamcity-event-listener" version="1.0.2" />
+          <dependency id="nunit-extension-teamcity-event-listener" version="1.0.2" />
       </group>
     </dependencies>
   </metadata>

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -33,5 +33,15 @@
 	<language>en-US</language>
     <tags>nunit console runner test testing tdd</tags>
     <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <dependencies>
+      <group>
+          <dependency id="nunit-console-runner" version="$version$" />
+          <dependency id="nunit-extension-nunit-project-loader" version="3.5.0" />
+          <dependency id="nunit-extension-vs-project-loader" version="3.5.0" />
+          <dependency id="nunit-extension-nunit-v2-result-writer" version="3.5.0" />
+          <dependency id="nunit-extension-nunit-v2-driver" version="3.6.0" />
+        <dependency id="nunit-extension-teamcity-event-listener" version="1.0.2" />
+      </group>
+    </dependencies>
   </metadata>
 </package>

--- a/choco/nunit.choco.addins
+++ b/choco/nunit.choco.addins
@@ -1,0 +1,1 @@
+../../nunit-extension-*/tools/     # find extensions installed under chocolatey


### PR DESCRIPTION
Fixes #275 

This fixes the current script, which was producing packages that do not meet the chocolatey.org validation standards. The new nunit-console-with-extensions package uses references to the other packages rather than including the binaries as was done previously.