### PR TITLE
Improve error message running .NET Standard assembly

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -60,8 +60,13 @@ namespace NUnit.Engine.Services
 
             if (targetFramework != null)
             {
-                var platform = targetFramework.Split(new char[] { ',' })[0];
-                if (platform == "Silverlight" || platform == ".NETPortable" || platform == ".NETCompactFramework")
+                // This takes care of an issue with Roslyn. It may get fixed, but we still 
+                // have to deal with assemblies having this setting. I'm assuming that
+                // any true Portable assembly would have a Profile as part of its name.
+                var platform = targetFramework == ".NETPortable,Version=v5.0"
+                    ? ".NETStandard"
+                    : targetFramework.Split(new char[] { ',' })[0];
+                if (platform == "Silverlight" || platform == ".NETPortable" || platform == ".NETStandard" || platform == ".NETCompactFramework")
                     return new InvalidAssemblyFrameworkDriver(assemblyPath, platform + " test assemblies are not yet supported by the engine");
             }
 


### PR DESCRIPTION
This is intended to mitigate issue #271, although it doesn't resolve it. People keep being confused by the error message that indicates the .NET standard tests are portable, when they are not. Turns out this is a problem with VS, which I try to compensate for in the message.