### PR TITLE
Explicitly build release on CI servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ matrix:
   fast_finish: true
 
 script:
-  - ./build.sh --target "Travis"
+  - ./build.sh --target "Travis" --configuration "Release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ branches:
   except:
     - /travis-.*/
 
-build_script: 
-  - ps: .\build.ps1 -Target "Appveyor"
+build_script:
+  - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"
 
 # disable built-in tests.
 test: off

--- a/build.cake
+++ b/build.cake
@@ -92,7 +92,7 @@ Setup(context =>
     }
 
     // Executed BEFORE the first task.
-    Information("Building version {0} of NUnit.", packageVersion);
+    Information("Building {0} version {1} of NUnit.", configuration, packageVersion);
     IsDotNetCoreInstalled = CheckIfDotNetCoreInstalled();
 });
 
@@ -415,8 +415,8 @@ Task("PackageChocolatey")
 	.Does(() =>
 	{
 		EnsureDirectoryExists(PACKAGE_DIR);
-		
-		ChocolateyPack("choco/nunit-console-runner.nuspec", 
+
+		ChocolateyPack("choco/nunit-console-runner.nuspec",
 			new ChocolateyPackSettings()
 			{
 				Version = packageVersion,
@@ -441,8 +441,8 @@ Task("PackageChocolatey")
                     new ChocolateyNuSpecContent { Source = BIN_DIR + "Mono.Cecil.dll", Target="tools" }
                 }
 			});
-		
-		ChocolateyPack("choco/nunit-console-with-extensions.nuspec", 
+
+		ChocolateyPack("choco/nunit-console-with-extensions.nuspec",
 			new ChocolateyPackSettings()
 			{
 				Version = packageVersion,


### PR DESCRIPTION
@CharliePoole noticed that newer versions of the Cake build scripts to not pass in release by default, so I am making it explicit for Travis and AppVeyor to ensure that our CI servers always build in release.