### PR TITLE
Improve Exception information on Console/Engine Crash

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ExceptionHelperTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ExceptionHelperTests.cs
@@ -1,0 +1,85 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using NUnit.Common;
+using NUnit.Engine;
+using NUnit.Engine.Internal;
+using NUnit.Framework;
+
+namespace NUnit.ConsoleRunner.Tests
+{
+    class ExceptionHelperTests
+    {
+        [TestCaseSource(nameof(TestCases))]
+        public void TestMessageContainsAllInnerExceptions(Exception ex, params Type[] expectedExceptions)
+        {
+            var message = ExceptionHelper.BuildMessage(ex);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var expectedException in expectedExceptions)
+                    Assert.That(message, Contains.Substring(expectedException.Name));
+            });
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void StackTraceContainsAllInnerExceptions(Exception ex, params Type[] expectedExceptions)
+        {
+            var stackTrace = ExceptionHelper.BuildStackTrace(ex);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var expectedException in expectedExceptions)
+                    Assert.That(stackTrace, Contains.Substring(expectedException.Name));
+            });
+        }
+
+        private static IEnumerable<TestCaseData> TestCases
+        {
+            get
+            {
+                yield return new TestCaseData(new FileNotFoundException(), new[] { typeof(FileNotFoundException) })
+                    .SetName("{m}(Simple Exception)");
+
+                var innerException = new NUnitEngineException("message", new InvalidOperationException());
+                yield return new TestCaseData(innerException, new[] { typeof(NUnitEngineException), typeof(InvalidOperationException) })
+                    .SetName("{m}(Single InnerException)");
+
+                var exception1 = new InvalidOperationException();
+                var exception2 = new FileNotFoundException("message", exception1);
+                var exception3 = new AccessViolationException("message", exception2);
+                yield return new TestCaseData(exception3, new[] { typeof(InvalidOperationException), typeof(FileNotFoundException), typeof(AccessViolationException) })
+                    .SetName("{m}(Multiple InnerExceptions)");
+
+                var relfectionException = new ReflectionTypeLoadException(new[] { typeof(ExceptionHelperTests) }, new[] { new FileNotFoundException() });
+                yield return new TestCaseData(relfectionException, new[] { typeof(ReflectionTypeLoadException), typeof(FileNotFoundException) })
+                    .SetName("{m}(LoaderException)");
+            }
+        }
+
+    }
+}

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="ConsoleOutputTests.cs" />
     <Compile Include="ConsoleRunnerTests.cs" />
     <Compile Include="DefaultOptionsProviderTests.cs" />
+    <Compile Include="ExceptionHelperTests.cs" />
     <Compile Include="ExtendedTextWrapperTests.cs" />
     <Compile Include="MakeTestPackageTests.cs" />
     <Compile Include="OutputSpecificationTests.cs" />

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -243,7 +243,7 @@ namespace NUnit.ConsoleRunner
 
                 // Since we got a result, we display any engine exception as a warning
                 if (engineException != null)
-                    writer.WriteLine(ColorStyle.Warning, Environment.NewLine + engineException.Message);
+                    writer.WriteLine(ColorStyle.Warning, Environment.NewLine + ExceptionHelper.BuildMessage(engineException));
 
                 if (reporter.Summary.UnexpectedError)
                     return ConsoleRunner.UNEXPECTED_ERROR;
@@ -258,7 +258,11 @@ namespace NUnit.ConsoleRunner
 
             // If we got here, it's because we had an exception, but check anyway
             if (engineException != null)
-                writer.WriteLine(ColorStyle.Error, engineException.Message);
+            {
+                writer.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessage(engineException));
+                writer.WriteLine();
+                writer.WriteLine(ColorStyle.Error, ExceptionHelper.BuildStackTrace(engineException));
+            }
 
             return ConsoleRunner.UNEXPECTED_ERROR;
         }

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -134,7 +134,9 @@ namespace NUnit.ConsoleRunner
                     }
                     catch (Exception ex)
                     {
-                        OutWriter.WriteLine(ColorStyle.Error, ex.ToString());
+                        OutWriter.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessage(ex));
+                        OutWriter.WriteLine();
+                        OutWriter.WriteLine(ColorStyle.Error, ExceptionHelper.BuildStackTrace(ex));
                         return ConsoleRunner.UNEXPECTED_ERROR;
                     }
                     finally
@@ -147,8 +149,6 @@ namespace NUnit.ConsoleRunner
                                 Console.ReadKey(true);
                             }
                         }
-
-                        //    log.Info( "NUnit3-console.exe terminating" );
                     }
                 }
             }

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -54,6 +54,9 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\NUnitEngine\nunit.engine\Internal\ExceptionHelper.cs">
+      <Link>Utilities\ExceptionHelper.cs</Link>
+    </Compile>
     <Compile Include="..\ConsoleVersion.cs">
       <Link>Properties\ConsoleVersion.cs</Link>
     </Compile>

--- a/src/NUnitEngine/nunit.engine/Internal/ExceptionHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ExceptionHelper.cs
@@ -1,0 +1,135 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace NUnit.Common
+{
+    internal static class ExceptionHelper
+    {
+        /// <summary>
+        /// Builds up a message, using the Message field of the specified exception
+        /// as well as any InnerExceptions.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <returns>A combined message string.</returns>
+        public static string BuildMessage(Exception exception)
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("{0} : ", exception.GetType());
+            sb.Append(GetExceptionMessage(exception));
+
+            foreach (Exception inner in FlattenExceptionHierarchy(exception))
+            {
+                sb.Append(Environment.NewLine);
+                sb.Append("  ----> ");
+                sb.AppendFormat("{0} : ", inner.GetType());
+                sb.Append(GetExceptionMessage(inner));
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Builds up a message, using the Message field of the specified exception
+        /// as well as any InnerExceptions.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <returns>A combined stack trace.</returns>
+        public static string BuildStackTrace(Exception exception)
+        {
+            var sb = new StringBuilder("--");
+            sb.Append(exception.GetType().Name);
+            sb.Append(Environment.NewLine);
+            sb.Append(GetSafeStackTrace(exception));
+
+            foreach (Exception inner in FlattenExceptionHierarchy(exception))
+            {
+                sb.Append(Environment.NewLine);
+                sb.Append("--");
+                sb.Append(inner.GetType().Name);
+                sb.Append(Environment.NewLine);
+                sb.Append(GetSafeStackTrace(inner));
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Gets the stack trace of the exception. If no stack trace
+        /// is provided, returns "No stack trace available".
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <returns>A string representation of the stack trace.</returns>
+        private static string GetSafeStackTrace(Exception exception)
+        {
+            try
+            {
+                return exception.StackTrace;
+            }
+            catch (Exception)
+            {
+                return "No stack trace available";
+            }
+        }
+
+        private static List<Exception> FlattenExceptionHierarchy(Exception exception)
+        {
+            var result = new List<Exception>();
+
+            if (exception is ReflectionTypeLoadException)
+            {
+                var reflectionException = exception as ReflectionTypeLoadException;
+                result.AddRange(reflectionException.LoaderExceptions);
+
+                foreach (var innerException in reflectionException.LoaderExceptions)
+                    result.AddRange(FlattenExceptionHierarchy(innerException));
+            }
+
+            if (exception.InnerException != null)
+            {
+                result.Add(exception.InnerException);
+                result.AddRange(FlattenExceptionHierarchy(exception.InnerException));
+            }
+
+            return result;
+        }
+
+        private static string GetExceptionMessage(Exception ex)
+        {
+            if (string.IsNullOrEmpty(ex.Message))
+            {
+                // Special handling for Mono 5.0, which returns an empty message
+                var fnfEx = ex as System.IO.FileNotFoundException;
+                return fnfEx != null
+                    ? "Could not load assembly. File not found: " + fnfEx.FileName
+                    : "No message provided";
+            }
+
+            return ex.Message;
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using NUnit.Engine.Extensibility;
 using NUnit.Engine.Internal;
 

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Services;
 
@@ -308,8 +309,8 @@ namespace NUnit.Engine.Runners
             XmlHelper.AddAttribute(suite, "asserts", "0");
 
             var failure = suite.AddElement("failure");
-            failure.AddElementWithCDataSection("message", e.Message);
-            failure.AddElementWithCDataSection("stack-trace", e.StackTrace);
+            failure.AddElementWithCDataSection("message", ExceptionHelper.BuildMessage(e));
+            failure.AddElementWithCDataSection("stack-trace", ExceptionHelper.BuildStackTrace(e));
 
             return new TestEngineResult(suite);
         }

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Internal\CecilExtensions.cs" />
     <Compile Include="Internal\CurrentMessageCounter.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />
+    <Compile Include="Internal\ExceptionHelper.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceWriter.cs" />
     <Compile Include="Internal\Logging\Logger.cs" />


### PR DESCRIPTION
Fixes #284, and covers the error-reporting side of #273.

The NUnit Console hasn't recently had the best error reporting for unexpected crashes. Exceptions generally are wrapped up inside an NUnitEngineException - which obscures the original exception and makes debugging problematic for the user.

This PR brings the framework's Exception hierachy flattening logic over to the console/engine. It assumes that any unexpected NUnitEngineException which would return a -100 from the console should display as much information as possible.

The problem is tackled in multiple places, as inprocess tests and out of process tests report the exceptions differently. I'll comment on the code diff as to what comes through where.

Looking in particular at the case in #273, the changes look as such:

**Old Message running in process**
```
An exception occured in the driver while loading tests.
```

**New Message running in process**
![image](https://user-images.githubusercontent.com/4837132/31783060-d2ccc6de-b4f4-11e7-860b-b70404f4e057.png)

**Old Message running out of process**
![image](https://user-images.githubusercontent.com/4837132/31783145-2188bcba-b4f5-11e7-9fcc-83984cc0a7d8.png)

**New Message running out of process**
![image](https://user-images.githubusercontent.com/4837132/31783109-0391f352-b4f5-11e7-9120-d057b6795863.png)
