### PR TITLE
Catch agent debugger launch exceptions, and improve agent crash handling

### DIFF
--- a/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
+++ b/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
@@ -1,0 +1,36 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit.Common
+{
+    internal static class AgentExitCodes
+    {
+        public const int OK = 0;
+        public const int PARENT_PROCESS_TERMINATED = -1;
+        public const int UNEXPECTED_EXCEPTION = -2;
+        public const int FAILED_TO_START_AGENT = -3;
+        public const int NO_DEBUGGER_SECURITY = -4;
+        public const int NO_DEBUGGER_NOT_IMPLEMENTED = -5;
+
+    }
+}

--- a/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
+++ b/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
@@ -28,9 +28,9 @@ namespace NUnit.Common
         public const int OK = 0;
         public const int PARENT_PROCESS_TERMINATED = -1;
         public const int UNEXPECTED_EXCEPTION = -2;
-        public const int FAILED_TO_START_AGENT = -3;
-        public const int NO_DEBUGGER_SECURITY = -4;
-        public const int NO_DEBUGGER_NOT_IMPLEMENTED = -5;
+        public const int FAILED_TO_START_REMOTE_AGENT = -3;
+        public const int DEBUGGER_SECURITY_VIOLATION = -4;
+        public const int DEBUGGER_NOT_IMPLEMENTED = -5;
 
     }
 }

--- a/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
+++ b/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
@@ -27,10 +27,9 @@ namespace NUnit.Common
     {
         public const int OK = 0;
         public const int PARENT_PROCESS_TERMINATED = -1;
-        public const int UNEXPECTED_EXCEPTION = -2;
-        public const int FAILED_TO_START_REMOTE_AGENT = -3;
-        public const int DEBUGGER_SECURITY_VIOLATION = -4;
-        public const int DEBUGGER_NOT_IMPLEMENTED = -5;
-
+        public const int FAILED_TO_START_REMOTE_AGENT = -2;
+        public const int DEBUGGER_SECURITY_VIOLATION = -3;
+        public const int DEBUGGER_NOT_IMPLEMENTED = -4;
+        public const int UNEXPECTED_EXCEPTION = -100;
     }
 }

--- a/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
@@ -56,6 +56,7 @@
     <Compile Include="..\EngineVersion.cs">
       <Link>Properties\EngineVersion.cs</Link>
     </Compile>
+    <Compile Include="AgentExitCodes.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\EngineVersion.cs">
       <Link>Properties\EngineVersion.cs</Link>
     </Compile>
+    <Compile Include="AgentExitCodes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Program.cs" />
   </ItemGroup>

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -280,7 +280,7 @@ namespace NUnit.Engine.Runners
                 _agent = _agency.GetAgent(TestPackage, debug ? DEBUG_TIMEOUT : NORMAL_TIMEOUT);
 
                 if (_agent == null)
-                    throw new Exception("Unable to acquire remote process agent");
+                    throw new NUnitEngineException("Unable to acquire remote process agent");
             }
 
             if (_remoteRunner == null)

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -155,7 +155,7 @@ namespace NUnit.Engine.Services
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
             string agentArgs = "--pid=" + Process.GetCurrentProcess().Id.ToString();
-            if (traceLevel != "Off")                    //Pass --trace as first non-optional arg as it intialises log
+            if (traceLevel != "Off")
                 agentArgs += " --trace:" + traceLevel;
             if (debugAgent)
                 agentArgs += " --debug-agent";
@@ -275,13 +275,13 @@ namespace NUnit.Engine.Services
                     errorMsg = "Unhandled exception on remote test agent. " +
                                "To debug, try running with the --inprocess flag, or using --trace=debug to output logs.";
                     break;
-                case AgentExitCodes.FAILED_TO_START_AGENT:
+                case AgentExitCodes.FAILED_TO_START_REMOTE_AGENT:
                     errorMsg = "Failed to start remote test agent.";
                     break;
-                case AgentExitCodes.NO_DEBUGGER_SECURITY:
+                case AgentExitCodes.DEBUGGER_SECURITY_VIOLATION:
                     errorMsg = "Debugger could not be started on remote agent due to System.Security.Permissions.UIPermission not being set.";
                     break;
-                case AgentExitCodes.NO_DEBUGGER_NOT_IMPLEMENTED:
+                case AgentExitCodes.DEBUGGER_NOT_IMPLEMENTED:
                     errorMsg = "Debugger could not be started on remote agent as not available on platform.";
                     break;
                 default:

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -155,10 +155,10 @@ namespace NUnit.Engine.Services
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
             string agentArgs = "--pid=" + Process.GetCurrentProcess().Id.ToString();
+            if (traceLevel != "Off")                    //Pass --trace as first non-optional arg as it intialises log
+                agentArgs += " --trace:" + traceLevel;
             if (debugAgent)
                 agentArgs += " --debug-agent";
-            if (traceLevel != "Off")
-                agentArgs += " --trace:" + traceLevel;
 
             log.Info("Getting {0} agent for use under {1}", useX86Agent ? "x86" : "standard", targetRuntime);
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Threading;
 using System.Diagnostics;
 using System.Collections.Generic;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services
@@ -177,6 +178,8 @@ namespace NUnit.Engine.Services
             Process p = new Process();
             p.StartInfo.UseShellExecute = false;
             p.StartInfo.CreateNoWindow = true;
+            p.EnableRaisingEvents = true;
+            p.Exited += OnAgentExit;
             Guid agentId = Guid.NewGuid();
             string arglist = agentId.ToString() + " " + ServerUrl + " " + agentArgs;
 
@@ -251,6 +254,42 @@ namespace NUnit.Engine.Services
                 : "nunit-agent.exe";
 
             return Path.Combine(engineDir, agentName);
+        }
+
+        private static void OnAgentExit(object sender, EventArgs e)
+        {
+            var process = sender as Process;
+            if (process == null)
+                return;
+
+            string errorMsg;
+
+            switch (process.ExitCode)
+            {
+                case AgentExitCodes.OK:
+                    return;
+                case AgentExitCodes.PARENT_PROCESS_TERMINATED:
+                    errorMsg = "Remote test agent believes agency process has exited.";
+                    break;
+                case AgentExitCodes.UNEXPECTED_EXCEPTION:
+                    errorMsg = "Unhandled exception on remote test agent. " +
+                               "To debug, try running with the --inprocess flag, or using --trace=debug to output logs.";
+                    break;
+                case AgentExitCodes.FAILED_TO_START_AGENT:
+                    errorMsg = "Failed to start remote test agent.";
+                    break;
+                case AgentExitCodes.NO_DEBUGGER_SECURITY:
+                    errorMsg = "Debugger could not be started on remote agent due to System.Security.Permissions.UIPermission not being set.";
+                    break;
+                case AgentExitCodes.NO_DEBUGGER_NOT_IMPLEMENTED:
+                    errorMsg = "Debugger could not be started on remote agent as not available on platform.";
+                    break;
+                default:
+                    errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
+                    break;
+            }
+            throw new NUnitEngineException(errorMsg);
+
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\EngineVersion.cs">
       <Link>Properties\EngineVersion.cs</Link>
     </Compile>
+    <Compile Include="..\nunit-agent\AgentExitCodes.cs">
+      <Link>Agents\AgentExitCodes.cs</Link>
+    </Compile>
     <Compile Include="Drivers\NotRunnableFrameworkDriver.cs" />
     <Compile Include="Drivers\NUnit2DriverFactory.cs">
       <SubType>Code</SubType>


### PR DESCRIPTION
This primarily fixes #228 - by catching exceptions thrown by launching the debugger in mono.

The solution is possibly a little over-architected, however I've attempted to use this problem as a way to improve our error handling for situations where the agent crashes.

I've introduced a number of agent exit codes, which can be read by the engine process and converted to an NUnitEngineException with suitable Debug information. The drawback is that this is triggered by the agent process `Exited` event.

This causes two issues that I can see.
1. We crash the engine. That said, once the agent has crashed, I think we're already at worst case scenario - so in this situation I think we can only help by providing additional debug information? In the console runner this terminates the application with a stack trace - I don't know about other runners, but I imagine it would be possible to hook into `AppDomain.UnhandledException`? @OsirisTerje - would this affect the adapter, or does it already handle unhandledexceptions?
2. There seems to be something of a slight race condition, in that exceptions that happen at the end of the agent process won't raise the event in time, and therefore won't be displayed. I don't think this is anything new, but by putting this additional functionality in, we should probably acknowledge it doesn't cover all scenarios.