### PR TITLE
Added a continue-on-unload-error option

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -62,6 +62,8 @@ namespace NUnit.Common
         public string DomainUsage { get; private set; }
         public bool DomainUsageSpecified { get { return DomainUsage != null; } }
 
+        public bool ContinueOnUnloadError { get; private set; }
+
         // How to Run Tests
 
         public string Framework { get; private set; }
@@ -159,6 +161,9 @@ namespace NUnit.Common
 
             this.Add("pause", "Pause before running to allow attaching a debugger.",
                 v => PauseBeforeRun = v != null);
+
+            this.Add("continue-on-unload-error", "Continue if unload errors happen.",
+                v => ContinueOnUnloadError = v != null);
 
             this.Add("list-extensions", "List all extension points and the extensions for each.",
                 v => ListExtensions = v != null);

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -287,8 +287,8 @@ namespace NUnit.ConsoleRunner
                     var unixVariant = Marshal.PtrToStringAnsi(buf);
                     if (unixVariant.Equals("Darwin"))
                         unixVariant = "MacOSX";
-                    
-                    osString = string.Format("{0} {1} {2}", unixVariant, os.Version, os.ServicePack); 
+
+                    osString = string.Format("{0} {1} {2}", unixVariant, os.Version, os.ServicePack);
                 }
                 Marshal.FreeHGlobal(buf);
             }
@@ -385,6 +385,9 @@ namespace NUnit.ConsoleRunner
 
             if (options.DomainUsageSpecified)
                 package.AddSetting(EnginePackageSettings.DomainUsage, options.DomainUsage);
+
+            if (options.ContinueOnUnloadError)
+                package.AddSetting(EnginePackageSettings.ContinueOnUnloadError, options.ContinueOnUnloadError);
 
             if (options.FrameworkSpecified)
                 package.AddSetting(EnginePackageSettings.RuntimeFramework, options.Framework);

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -25,7 +25,7 @@ namespace NUnit
 {
     /// <summary>
     /// EngineSettings contains constant values that
-    /// are used as keys in setting up a TestPackage. 
+    /// are used as keys in setting up a TestPackage.
     /// Values here are used in the engine, and set by the runner.
     /// Setting values may be a string, int or bool.
     /// </summary>
@@ -47,7 +47,7 @@ namespace NUnit
         public const string AutoBinPath = "AutoBinPath";
 
         /// <summary>
-        /// The ApplicationBase to use in loading the tests. If not 
+        /// The ApplicationBase to use in loading the tests. If not
         /// specified, and each assembly has its own process, then the
         /// location of the assembly is used. For multiple  assemblies
         /// in a single process, the closest common root directory is used.
@@ -55,7 +55,7 @@ namespace NUnit
         public const string BasePath = "BasePath";
 
         /// <summary>
-        /// Path to the config file to use in running the tests. 
+        /// Path to the config file to use in running the tests.
         /// </summary>
         public const string ConfigurationFile = "ConfigurationFile";
 
@@ -65,7 +65,7 @@ namespace NUnit
         public const string DebugTests = "DebugTests";
 
         /// <summary>
-        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// Bool flag indicating whether a debugger should be launched at agent
         /// startup. Used only for debugging NUnit itself.
         /// </summary>
         public const string DebugAgent = "DebugAgent";
@@ -86,7 +86,7 @@ namespace NUnit
         public const string PrivateBinPath = "PrivateBinPath";
 
         /// <summary>
-        /// The maximum number of test agents permitted to run simultaneously. 
+        /// The maximum number of test agents permitted to run simultaneously.
         /// Ignored if the ProcessModel is not set or defaulted to Multiple.
         /// </summary>
         public const string MaxAgents = "MaxAgents";
@@ -99,14 +99,14 @@ namespace NUnit
         public const string ProcessModel = "ProcessModel";
 
         /// <summary>
-        /// Indicates the desired runtime to use for the tests. Values 
+        /// Indicates the desired runtime to use for the tests. Values
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
         public const string RuntimeFramework = "RuntimeFramework";
 
         /// <summary>
-        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// Bool flag indicating that the test should be run in a 32-bit process
         /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
         /// a 64-bit system. Ignored if set on a 32-bit system.
         /// </summary>
@@ -118,7 +118,7 @@ namespace NUnit
         public const string DisposeRunners = "DisposeRunners";
 
         /// <summary>
-        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Bool flag indicating that the test assemblies should be shadow copied.
         /// Defaults to false.
         /// </summary>
         public const string ShadowCopyFiles = "ShadowCopyFiles";
@@ -151,6 +151,12 @@ namespace NUnit
         /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
         /// </summary>
         public const string PrincipalPolicy = "PrincipalPolicy";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to continue if unloading test assemblies fail. The default is false,
+        /// in which case an exception is thrown.
+        /// </summary>
+        public const string ContinueOnUnloadError = "ContinueOnUnloadError";
 
         #endregion
     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -109,6 +109,18 @@ namespace NUnit.Engine.Services.Tests
 
             CheckDomainIsUnloaded(domain);
         }
+
+        [Test]
+        public void UnloadingTwiceDoesNotThrowNUnitEngineExceptionIfContinueOnUnloadErrorIsSet()
+        {
+            var domain = _domainManager.CreateDomain(_package);
+            _domainManager.Unload(domain, true);
+
+            Assert.That(() => _domainManager.Unload(domain, true), Throws.Nothing);
+
+            CheckDomainIsUnloaded(domain);
+        }
+
 
         #region Helper Methods
 

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -25,7 +25,7 @@ namespace NUnit
 {
     /// <summary>
     /// EngineSettings contains constant values that
-    /// are used as keys in setting up a TestPackage. 
+    /// are used as keys in setting up a TestPackage.
     /// Values here are used in the engine, and set by the runner.
     /// Setting values may be a string, int or bool.
     /// </summary>
@@ -47,7 +47,7 @@ namespace NUnit
         public const string AutoBinPath = "AutoBinPath";
 
         /// <summary>
-        /// The ApplicationBase to use in loading the tests. If not 
+        /// The ApplicationBase to use in loading the tests. If not
         /// specified, and each assembly has its own process, then the
         /// location of the assembly is used. For multiple  assemblies
         /// in a single process, the closest common root directory is used.
@@ -55,7 +55,7 @@ namespace NUnit
         public const string BasePath = "BasePath";
 
         /// <summary>
-        /// Path to the config file to use in running the tests. 
+        /// Path to the config file to use in running the tests.
         /// </summary>
         public const string ConfigurationFile = "ConfigurationFile";
 
@@ -65,7 +65,7 @@ namespace NUnit
         public const string DebugTests = "DebugTests";
 
         /// <summary>
-        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// Bool flag indicating whether a debugger should be launched at agent
         /// startup. Used only for debugging NUnit itself.
         /// </summary>
         public const string DebugAgent = "DebugAgent";
@@ -86,7 +86,7 @@ namespace NUnit
         public const string PrivateBinPath = "PrivateBinPath";
 
         /// <summary>
-        /// The maximum number of test agents permitted to run simultaneously. 
+        /// The maximum number of test agents permitted to run simultaneously.
         /// Ignored if the ProcessModel is not set or defaulted to Multiple.
         /// </summary>
         public const string MaxAgents = "MaxAgents";
@@ -99,14 +99,14 @@ namespace NUnit
         public const string ProcessModel = "ProcessModel";
 
         /// <summary>
-        /// Indicates the desired runtime to use for the tests. Values 
+        /// Indicates the desired runtime to use for the tests. Values
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
         public const string RuntimeFramework = "RuntimeFramework";
 
         /// <summary>
-        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// Bool flag indicating that the test should be run in a 32-bit process
         /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
         /// a 64-bit system. Ignored if set on a 32-bit system.
         /// </summary>
@@ -118,7 +118,7 @@ namespace NUnit
         public const string DisposeRunners = "DisposeRunners";
 
         /// <summary>
-        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Bool flag indicating that the test assemblies should be shadow copied.
         /// Defaults to false.
         /// </summary>
         public const string ShadowCopyFiles = "ShadowCopyFiles";
@@ -151,6 +151,13 @@ namespace NUnit
         /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
         /// </summary>
         public const string PrincipalPolicy = "PrincipalPolicy";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to continue if unloading test assemblies fail. The default is false,
+        /// in which case an exception is thrown.
+        /// </summary>
+        public const string ContinueOnUnloadError = "ContinueOnUnloadError";
+
 
         #endregion
     }

--- a/src/NUnitEngine/nunit.engine/Runners/TestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestDomainRunner.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -32,10 +32,12 @@ namespace NUnit.Engine.Runners
     public class TestDomainRunner : DirectTestRunner
     {
         private DomainManager _domainManager;
+        private bool _continueOnUnloadError;
 
-        public TestDomainRunner(IServiceLocator services, TestPackage package) : base(services, package) 
+        public TestDomainRunner(IServiceLocator services, TestPackage package) : base(services, package)
         {
             _domainManager = Services.GetService<DomainManager>();
+            _continueOnUnloadError = package.GetSetting(EnginePackageSettings.ContinueOnUnloadError, false);
         }
 
         #region DirectTestRunner Overrides
@@ -54,7 +56,7 @@ namespace NUnit.Engine.Runners
         {
             if (this.TestDomain != null)
             {
-                _domainManager.Unload(this.TestDomain);
+                _domainManager.Unload(this.TestDomain, _continueOnUnloadError);
                 this.TestDomain = null;
             }
         }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -8,10 +8,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -208,7 +208,7 @@ namespace NUnit.Engine.Services
                     p.StartInfo.Arguments = arglist;
                     break;
             }
-            
+
             p.Start();
             log.Debug("Launched Agent process {0} - see nunit-agent_{0}.log", p.Id);
             log.Debug("Command line: \"{0}\" {1}", p.StartInfo.FileName, p.StartInfo.Arguments);


### PR DESCRIPTION
This is a cleaned up version of a fork I have been testing on our rather large build chain for some time. It logs errors in the internal trace and continues if an unload errors occur instead of throwing exceptions if the flag is set. I left it disabled by default so that people have to knowingly choose to ignore the unload errors.

It's not ideal as once activated it becomes hard to see that errors are happening at all, requiring the users to look into the agent log files which, admittedly, no one does unless there's a problem...

If anyone has suggestions for ways to make the errors more apparent, let me know.

Sorry for the whitespace diffs, I have a VS plugin that removes trailing whitespace when saving a file in VS and forgot to turn it off before porting the changes to the branch.