### PR TITLE
Return error code -5 when AppDomain fails to unload

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -224,7 +224,7 @@ namespace NUnit.Engine.Runners
             {
                 _disposed = true;
 
-                string unloadError = null;
+                Exception unloadException = null;
 
                 try
                 {
@@ -233,8 +233,9 @@ namespace NUnit.Engine.Runners
                 catch(Exception ex)
                 {
                     // Save and log the unload error
-                    unloadError = ex.Message;
-                    log.Error(unloadError);
+                    unloadException = ex;
+                    log.Error(ExceptionHelper.BuildMessage(ex));
+                    log.Error(ExceptionHelper.BuildStackTrace(ex));
                 }
 
                 if (_agent != null && _agency.IsAgentRunning(_agent.Id))
@@ -252,16 +253,16 @@ namespace NUnit.Engine.Runners
                         _agent = null;
 
                         // Stop error with no unload error, just rethrow
-                        if (unloadError == null)
+                        if (unloadException == null)
                             throw;
 
                         // Both kinds of errors, throw exception with combined message
-                        throw new NUnitEngineException(unloadError + Environment.NewLine + stopError);
+                        throw new NUnitEngineUnloadException(unloadException.Message + Environment.NewLine + stopError);
                     }
                 }
 
-                if (unloadError != null) // Add message line indicating we managed to stop agent anyway
-                    throw new NUnitEngineException(unloadError + Environment.NewLine + "Agent Process was terminated successfully after error.");
+                if (unloadException != null) // Add message line indicating we managed to stop agent anyway
+                    throw new NUnitEngineUnloadException("Agent Process was terminated successfully after error.", unloadException);
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -181,7 +181,7 @@ namespace NUnit.Engine.Services
                 try
                 {
                     // Uncomment to simulate an error in unloading
-                    //throw new Exception("Testing: simulated unload error");
+                    //throw new CannotUnloadAppDomainException("Testing: simulated unload error");
 
                     // Uncomment to simulate a timeout while unloading
                     //while (true) ;


### PR DESCRIPTION
This is the first of a few PRs to improve the experience when the appdomain fails to unload. I was hoping to get further that this - unfortunately mocking out the console took a few more hours than expected. 😬 

This implements part 4 of the solution proposed [here](https://github.com/nunit/nunit-console/pull/308#issuecomment-341934320) i.e. returning `-5` when the app domain fails to unload. Note this is a 'breaking change' - previously we issued a warning in the console, and then silently exited with code zero. I'm of the opinion that we shouldn't exit silently when these errors come up. With a specific error code, user's can chosoe to accept either 0 or -5 as a pass in their CI if they do wish to ignore the problem, but it will never silently slip by without the user taking action.

The reason there's been a few people cropping up over this issue is that, when using a `.nunit` project (i.e. everyone on TeamCity), behaviour seems to be different, and the process does crash mid-result if the appdomain fails to unload. I imagine that could be related to #116 - and will be looking at that as a separate issue.

Other than that, the remaining issue to do here is #111 - but I'll put these in as separate PRs, to be easier to review!

Also fixes #256 