### PR TITLE
Use Environment Exit in Agent to ensure all threads are terminated

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -34,18 +34,17 @@ namespace NUnit.Agent
 {
     public class NUnitTestAgent
     {
-        static Logger log = InternalTrace.GetLogger(typeof(NUnitTestAgent));
-
         static Guid AgentId;
         static string AgencyUrl;
         static Process AgencyProcess;
         static RemoteTestAgent Agent;
+        private static Logger log;
 
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        public static int Main(string[] args)
+        public static void Main(string[] args)
         {
             AgentId = new Guid(args[0]);
             AgencyUrl = args[1];
@@ -76,6 +75,7 @@ namespace NUnit.Agent
             }
 
             InternalTrace.Initialize($"nunit-agent_{pid}.log", traceLevel);
+            log = InternalTrace.GetLogger(typeof(NUnitTestAgent));
 
             if (debugArgPassed)
                 TryLaunchDebugger();
@@ -132,17 +132,17 @@ namespace NUnit.Agent
                 else
                 {
                     log.Error("Failed to start RemoteTestAgent");
-                    return AgentExitCodes.FAILED_TO_START_REMOTE_AGENT;
+                    Environment.Exit(AgentExitCodes.FAILED_TO_START_REMOTE_AGENT);
                 }
             }
             catch (Exception ex)
             {
                 log.Error("Exception in RemoteTestAgent", ex);
-                return AgentExitCodes.UNEXPECTED_EXCEPTION;
+                Environment.Exit(AgentExitCodes.UNEXPECTED_EXCEPTION);
             }
             log.Info("Agent process {0} exiting cleanly", pid);
 
-            return AgentExitCodes.OK;
+            Environment.Exit(AgentExitCodes.OK);
         }
 
         private static void WaitForStop()

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -129,14 +129,19 @@ namespace NUnit.Engine.Agents
             // including the message which is waiting for this method to return so it can report back.
             ThreadPool.QueueUserWorkItem(_ =>
             {
+                log.Info("Waiting for messages to complete");
+
                 // Wait till all messages are finished
                 _currentMessageCounter.WaitForAllCurrentMessages();
+
+                log.Info("Attempting shut down channel");
 
                 // Shut down nicely
                 _channel.StopListening(null);
                 ChannelServices.UnregisterChannel(_channel);
 
                 // Signal to other threads that it's okay to exit the process or start a new channel, etc.
+                log.Info("Set stop signal");
                 stopSignal.Set();
             });
         }


### PR DESCRIPTION
Fixes #259 (In combination with #320 and #321 - although this PR can be merged independently.)

At the point where the agent exits the main method, we've tried everything possible to shut down nicely. If the AppDomain does fail to unload, after the specified timeout, we may reach this point in the code with some threads still running. Using `Environment.Exit()` as opposed to `return` ensures these will be cleaned up, and the process will definitely terminate.

The additional noise is just because the logging in Program.cs wasn't working - the log was declared in a static variable, and then a new log re-initialised later.