### PR TITLE
Assertion should not be ordered in AgentDatabaseTests

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
@@ -55,7 +55,7 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(_data.Count, Is.EqualTo(5));
 
             var snap = _data.TakeSnapshot();
-            Assert.That(snap.Guids, Is.EqualTo(_generatedGuids));
+            Assert.That(snap.Guids, Is.EquivalentTo(_generatedGuids));
         }
 
         [TestCaseSource(COUNTS)]
@@ -68,7 +68,7 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(_data.Count, Is.EqualTo(count));
 
             var snap = _data.TakeSnapshot();
-            Assert.That(snap.Guids, Is.EqualTo(_generatedGuids));
+            Assert.That(snap.Guids, Is.EquivalentTo(_generatedGuids));
         }
 
         [Test]


### PR DESCRIPTION
This test just failed in CI in #322.

The test that failed ran multiple operations in parallel, so the assertion should be unordered. Additionally, the collection being tested comes from dictionary values, where order is unspecified - so the non-parallel test of the collection contents should also be unordered.