### PR TITLE
Display warnings even when there are only warnings

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -127,7 +127,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "Warning Message",
                 "6) Invalid : NUnit.Tests.BadFixture" + nl +
                 "No suitable constructor was found"
-        };
+            };
             
             var actualErrorFailuresReport = GetReport(_reporter.WriteErrorsFailuresAndWarningsReport);
 

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -191,7 +191,7 @@ namespace NUnit.ConsoleRunner
                         else
                         {
                             var site = resultNode.GetAttribute("site");
-                            if (site != null && site != "Parent" && site != "Child")
+                            if (site == "SetUp" || site == "TearDown")
                                 new ConsoleTestResult(resultNode, ++ReportIndex).WriteResult(Writer);
                             if (site == "SetUp") return;
                         }

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -66,7 +66,7 @@ namespace NUnit.ConsoleRunner
             if (Summary.ExplicitCount + Summary.SkipCount + Summary.IgnoreCount > 0)
                 WriteNotRunReport();
 
-            if (OverallResult == "Failed")
+            if (OverallResult == "Failed" || Summary.WarningCount > 0)
                 WriteErrorsFailuresAndWarningsReport();
 
             WriteRunSettingsReport();
@@ -191,7 +191,7 @@ namespace NUnit.ConsoleRunner
                         else
                         {
                             var site = resultNode.GetAttribute("site");
-                            if (site != "Parent" && site != "Child")
+                            if (site != null && site != "Parent" && site != "Child")
                                 new ConsoleTestResult(resultNode, ++ReportIndex).WriteResult(Writer);
                             if (site == "SetUp") return;
                         }

--- a/src/NUnitEngine/nunit.engine.tests/ResultHelperTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/ResultHelperTests.cs
@@ -113,5 +113,34 @@ namespace NUnit.Engine.Internal.Tests
             Assert.That(combined.Attributes["skipped"].Value, Is.EqualTo("2"));
             Assert.That(combined.Attributes["asserts"].Value, Is.EqualTo("93"));
         }
+
+        [Test]
+        [TestCase("Skipped", "Skipped", "Skipped")]
+        [TestCase("Passed", "Passed", "Passed")]
+        [TestCase("Failed", "Failed", "Failed")]
+        [TestCase("Warning", "Warning", "Warning")]
+        [TestCase("Skipped", "Passed", "Passed")]
+        [TestCase("Passed", "Skipped", "Passed")]
+        [TestCase("Skipped", "Failed", "Failed")]
+        [TestCase("Failed", "Skipped", "Failed")]
+        [TestCase("Skipped", "Warning", "Warning")]
+        [TestCase("Warning", "Skipped", "Warning")]
+        [TestCase("Passed", "Failed", "Failed")]
+        [TestCase("Failed", "Passed", "Failed")]
+        [TestCase("Passed", "Warning", "Warning")]
+        [TestCase("Warning", "Passed", "Warning")]
+        [TestCase("Failed", "Warning", "Failed")]
+        [TestCase("Warning", "Failed", "Failed")]
+        public void Aggregate_CalculatesAggregateResultCorrectly(string firstResult, string secondResult, string aggregateResult)
+        {
+            string firstResultText = $"<test-assembly result=\"{firstResult}\" total=\"23\" passed=\"23\" failed=\"0\" inconclusive=\"0\" skipped=\"0\" asserts=\"40\" />";
+            string secondResultText = $"<test-assembly result=\"{secondResult}\" total=\"42\" passed=\"31\" failed=\"4\" inconclusive=\"5\" skipped=\"2\" asserts=\"53\" />";
+
+            var firstEngineResult = new TestEngineResult(firstResultText);
+            var secondEngineResult = new TestEngineResult(secondResultText);
+            var data = new XmlNode[]{ firstEngineResult.Xml, secondEngineResult.Xml };
+            XmlNode combined = ResultHelper.Aggregate("test-run", "NAME", "FULLNAME", data);
+            Assert.That(combined.Attributes["result"].Value, Is.EqualTo(aggregateResult));
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -175,7 +175,7 @@ namespace NUnit.Engine.Internal
                             }
                             break;
                         case "Passed":
-                            if (aggregateResult != "Failed" && aggregateLabel != "Ignored")
+                            if (aggregateResult != "Failed" && aggregateLabel != "Ignored" && aggregateResult != "Warning")
                                 aggregateResult = "Passed";
                             break;
                         case "Failed":
@@ -183,6 +183,10 @@ namespace NUnit.Engine.Internal
                             aggregateLabel = label;
                             if (elementName == "test-suite")
                                 aggregateSite = "Child";
+                            break;
+                        case "Warning":
+                            if (aggregateResult == "Inconclusive" || aggregateResult == "Passed" || aggregateResult == "Skipped")
+                                aggregateResult = "Warning";
                             break;
                     }
 


### PR DESCRIPTION
The "Errors, Failures and Warnings" section is now also written,
if there are tests with warnings, but no tests failed.

Note that we now only create ConsoleTestResult if the site is
different from `null` as warnings do not set the site.
Otherwise we will report warnings "One or more child tests had warnings"
for "test-suite"-elements above tests with warnings.

Fixes #289