### PR TITLE
Provide additional debug information when AppDomain fails to unload

### DIFF
--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -71,7 +71,7 @@ namespace NUnit
         public const string DebugAgent = "DebugAgent";
 
         /// <summary>
-        /// Indicates how to load tests across AppDomains. Values are:
+        /// Indicates how to load tests across application domains. Values are:
         /// "Default", "None", "Single", "Multiple". Default is "Multiple"
         /// if more than one assembly is loaded in a process. Otherwise,
         /// it is "Single".
@@ -147,7 +147,7 @@ namespace NUnit
         public const string InternalTraceLevel = "InternalTraceLevel";
 
         /// <summary>
-        /// The PrincipalPolicy to set on the test AppDomain. Values are:
+        /// The PrincipalPolicy to set on the test application domain. Values are:
         /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
         /// </summary>
         public const string PrincipalPolicy = "PrincipalPolicy";

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -93,7 +93,7 @@ namespace NUnit.Engine
         /// Every test package gets a unique ID used to prefix test IDs within that package.
         /// </summary>
         /// <remarks>
-        /// The generated ID is only unique for packages created within the same AppDomain.
+        /// The generated ID is only unique for packages created within the same application domain.
         /// For that reason, NUnit pre-creates all test packages that will be needed.
         /// </remarks>
         public string ID { get; private set; }

--- a/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
@@ -29,7 +29,7 @@ namespace NUnit.Engine.Agents
     /// Abstract base for all types of TestAgents.
     /// A TestAgent provides services of locating,
     /// loading and running tests in a particular
-    /// context such as an AppDomain or Process.
+    /// context such as an application domain or process.
     /// </summary>
     public abstract class TestAgent : MarshalByRefObject, ITestAgent, IDisposable
     {

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -57,7 +57,7 @@ namespace NUnit.Engine.Drivers
         /// <summary>
         /// Construct an NUnit3FrameworkDriver
         /// </summary>
-        /// <param name="testDomain">The AppDomain in which to create the FrameworkController</param>
+        /// <param name="testDomain">The application domain in which to create the FrameworkController</param>
         public NUnit3FrameworkDriver(AppDomain testDomain)
         {
             _testDomain = testDomain;

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -71,7 +71,7 @@ namespace NUnit
         public const string DebugAgent = "DebugAgent";
 
         /// <summary>
-        /// Indicates how to load tests across AppDomains. Values are:
+        /// Indicates how to load tests across application domains. Values are:
         /// "Default", "None", "Single", "Multiple". Default is "Multiple"
         /// if more than one assembly is loaded in a process. Otherwise,
         /// it is "Single".
@@ -147,7 +147,7 @@ namespace NUnit
         public const string InternalTraceLevel = "InternalTraceLevel";
 
         /// <summary>
-        /// The PrincipalPolicy to set on the test AppDomain. Values are:
+        /// The PrincipalPolicy to set on the test application domain. Values are:
         /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
         /// </summary>
         public const string PrincipalPolicy = "PrincipalPolicy";

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -127,7 +127,7 @@ namespace NUnit.Engine.Extensibility
         #region Methods
 
         /// <summary>
-        /// Gets a newly created extension object, created in the domain specified
+        /// Gets a newly created extension object, created in the current application domain
         /// </summary>
         public object CreateExtensionObject(params object[] args)
         {

--- a/src/NUnitEngine/nunit.engine/IDriverService.cs
+++ b/src/NUnitEngine/nunit.engine/IDriverService.cs
@@ -35,7 +35,7 @@ namespace NUnit.Engine
         /// <summary>
         /// Get a driver suitable for loading and running tests in the specified assembly.
         /// </summary>
-        /// <param name="domain">The AppDomain in which to run the tests</param>
+        /// <param name="domain">The application domain in which to run the tests</param>
         /// <param name="assemblyPath">The path to the test assembly</param>
         /// <param name="targetFramework">The value of any TargetFrameworkAttribute on the assembly, or null</param>
         /// <returns></returns>

--- a/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
@@ -1,0 +1,81 @@
+﻿// ***********************************************************************
+// Copyright (c) 2017 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace NUnit.Engine.Internal
+{
+    /// <summary>
+    /// DomainDetailsBuilder provides human readable information on 
+    /// an AppDomain, to assist with debugging.
+    /// </summary>
+    internal static class DomainDetailsBuilder
+    {
+        /// <summary>
+        /// Get human readable string containing details of AppDomain.
+        /// </summary>
+        /// <param name="domain">AppDomain to get details on.</param>
+        /// <param name="errMsg">An optional overall error message e.g. The messaged from an AppDomainUnload exception.</param>
+        public static string DetailsFor(AppDomain domain, string errMsg = null)
+        {
+            var sb = new StringBuilder();
+            if (errMsg != null) sb.AppendLine(errMsg);
+
+            try
+            {
+                sb.AppendLine($"AppDomain Name: {domain.FriendlyName}");
+                sb.AppendLine($"AppDomain Base Directory: {domain.BaseDirectory}");
+
+                var reflectionLoadedAssemblies = new List<Assembly>(domain.ReflectionOnlyGetAssemblies());
+
+                if (reflectionLoadedAssemblies.Count != 0)
+                {
+                    sb.AppendLine("--- Assemblies loaded in current AppDomain via reflection ---");
+                    foreach (var assembly in reflectionLoadedAssemblies)
+                        WriteAssemblyInformation(sb, assembly);
+                }
+            }
+            catch (AppDomainUnloadedException)
+            {
+                sb.AppendLine("App Domain was unloaded before all details could be read.");
+            }
+            catch (Exception ex)
+            {
+                sb.AppendLine($"Error trying to read AppDomain details {ex.Message}");
+                sb.AppendLine($"{ex.StackTrace}");
+            }
+            return sb.ToString();
+        }
+
+        private static void WriteAssemblyInformation(StringBuilder sb, Assembly assembly)
+        {
+            sb.AppendLine(assembly.FullName);
+            sb.AppendLine(assembly.ImageRuntimeVersion);
+            sb.AppendLine(assembly.Location);
+            sb.AppendLine("-----------------");
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
@@ -30,15 +30,15 @@ namespace NUnit.Engine.Internal
 {
     /// <summary>
     /// DomainDetailsBuilder provides human readable information on 
-    /// an AppDomain, to assist with debugging.
+    /// an application domain, to assist with debugging.
     /// </summary>
     internal static class DomainDetailsBuilder
     {
         /// <summary>
-        /// Get human readable string containing details of AppDomain.
+        /// Get human readable string containing details of application domain.
         /// </summary>
-        /// <param name="domain">AppDomain to get details on.</param>
-        /// <param name="errMsg">An optional overall error message e.g. The messaged from an AppDomainUnload exception.</param>
+        /// <param name="domain">Application domain to get details on.</param>
+        /// <param name="errMsg">An optional overall error message.</param>
         public static string DetailsFor(AppDomain domain, string errMsg = null)
         {
             var sb = new StringBuilder();
@@ -46,25 +46,25 @@ namespace NUnit.Engine.Internal
 
             try
             {
-                sb.AppendLine($"AppDomain Name: {domain.FriendlyName}");
-                sb.AppendLine($"AppDomain Base Directory: {domain.BaseDirectory}");
+                sb.AppendLine($"Application domain name: {domain.FriendlyName}");
+                sb.AppendLine($"Application domain BaseDirectory: {domain.BaseDirectory}");
 
                 var reflectionLoadedAssemblies = new List<Assembly>(domain.ReflectionOnlyGetAssemblies());
 
                 if (reflectionLoadedAssemblies.Count != 0)
                 {
-                    sb.AppendLine("--- Assemblies loaded in current AppDomain via reflection ---");
+                    sb.AppendLine("--- Assemblies loaded in current application domain via reflection ---");
                     foreach (var assembly in reflectionLoadedAssemblies)
                         WriteAssemblyInformation(sb, assembly);
                 }
             }
             catch (AppDomainUnloadedException)
             {
-                sb.AppendLine("App Domain was unloaded before all details could be read.");
+                sb.AppendLine("Application domain was unloaded before all details could be read.");
             }
             catch (Exception ex)
             {
-                sb.AppendLine($"Error trying to read AppDomain details {ex.Message}");
+                sb.AppendLine($"Error trying to read application domain details: {ex.Message}");
                 sb.AppendLine($"{ex.StackTrace}");
             }
             return sb.ToString();

--- a/src/NUnitEngine/nunit.engine/Internal/DomainUsage.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DomainUsage.cs
@@ -25,7 +25,7 @@ namespace NUnit.Engine.Internal
 {
     /// <summary>
     /// Represents the manner in which test assemblies use
-    /// AppDomains to provide isolation
+    /// application domains to provide isolation
     /// </summary>
     public enum DomainUsage
     {
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Internal
         /// </summary>
         Default,
         /// <summary>
-        /// Don't create a test domain - run in the primary AppDomain.
+        /// Don't create a test domain - run in the primary application domain.
         /// Note that this requires the tests to be available in the
         /// NUnit appbase or probing path.
         /// </summary>

--- a/src/NUnitEngine/nunit.engine/InternalEnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/InternalEnginePackageSettings.cs
@@ -48,7 +48,7 @@ namespace NUnit.Engine
 
         /// <summary>
         /// True if any assembly in the package requires a special assembly resolution hook
-        /// in the default AppDomain in order to find dependent assemblies.
+        /// in the default application domain in order to find dependent assemblies.
         /// </summary>
         public const string ImageRequiresDefaultAppDomainAssemblyResolver = "ImageRequiresDefaultAppDomainAssemblyResolver";
 

--- a/src/NUnitEngine/nunit.engine/Runners/LocalTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/LocalTestRunner.cs
@@ -26,7 +26,7 @@ using System;
 namespace NUnit.Engine.Runners
 {
     /// <summary>
-    /// LocalTestRunner runs tests in the current AppDomain.
+    /// LocalTestRunner runs tests in the current application domain.
     /// </summary>
     public class LocalTestRunner : DirectTestRunner
     {

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestDomainRunner.cs
@@ -25,7 +25,7 @@ namespace NUnit.Engine.Runners
 {
     /// <summary>
     /// MultipleTestDomainRunner runs tests using separate
-    /// AppDomains for each assembly.
+    /// application domains for each assembly.
     /// </summary>
     public class MultipleTestDomainRunner : AggregatingTestRunner
     {

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -261,7 +261,7 @@ namespace NUnit.Engine.Runners
                 }
 
                 if (unloadError != null) // Add message line indicating we managed to stop agent anyway
-                    throw (new NUnitEngineException(unloadError + "\nAgent Process was terminated successfully after error."));
+                    throw (new NUnitEngineException(unloadError + Environment.NewLine + "Agent Process was terminated successfully after error."));
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -261,7 +261,7 @@ namespace NUnit.Engine.Runners
                 }
 
                 if (unloadError != null) // Add message line indicating we managed to stop agent anyway
-                    throw (new NUnitEngineException(unloadError + Environment.NewLine + "Agent Process was terminated successfully after error."));
+                    throw new NUnitEngineException(unloadError + Environment.NewLine + "Agent Process was terminated successfully after error.");
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/TestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestDomainRunner.cs
@@ -48,7 +48,7 @@ namespace NUnit.Engine.Runners
         }
 
         /// <summary>
-        /// Unload any loaded TestPackage as well as the AppDomain.
+        /// Unload any loaded TestPackage as well as the application domain.
         /// </summary>
         public override void UnloadPackage()
         {

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -75,7 +75,7 @@ namespace NUnit.Engine.Services
                 evidence.AddHost(hash);
             }
             
-            log.Info("Creating AppDomain " + domainName);
+            log.Info("Creating application domain " + domainName);
 
             AppDomain runnerDomain = AppDomain.CreateDomain(domainName, evidence, setup);
 
@@ -164,7 +164,7 @@ namespace NUnit.Engine.Services
                 if (!_unloadThread.Join((int)timeout.TotalMilliseconds))
                 {
                     var msg = DomainDetailsBuilder.DetailsFor(_domain,
-                        $"Unable to unload AppDomain: unload thread timed out after {timeout.TotalSeconds} seconds.");
+                        $"Unable to unload application domain: unload thread timed out after {timeout.TotalSeconds} seconds.");
 
                     log.Error(msg);
                     Kill(_unloadThread);
@@ -173,7 +173,7 @@ namespace NUnit.Engine.Services
                 }
 
                 if (_unloadException != null)
-                    throw new NUnitEngineUnloadException("Exception encountered unloading AppDomain", _unloadException);
+                    throw new NUnitEngineUnloadException("Exception encountered unloading application domain", _unloadException);
             }
 
             private void UnloadOnThread()
@@ -193,7 +193,7 @@ namespace NUnit.Engine.Services
                     // We assume that the tests did something bad and just leave
                     // the orphaned AppDomain "out there".
                     var msg = DomainDetailsBuilder.DetailsFor(_domain,
-                    $"Exception encountered unloading AppDomain: {ex.Message}");
+                        $"Exception encountered unloading application domain: {ex.Message}");
 
                     _unloadException = new NUnitEngineException(msg);
                     log.Error(msg);

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -45,7 +45,7 @@ namespace NUnit.Engine.Services
         /// <summary>
         /// Get a driver suitable for use with a particular test assembly.
         /// </summary>
-        /// <param name="domain">The AppDomain to use for the tests</param>
+        /// <param name="domain">The application domain to use for the tests</param>
         /// <param name="assemblyPath">The full path to the test assembly</param>
         /// <param name="targetFramework">The value of any TargetFrameworkAttribute on the assembly, or null</param>
         /// <param name="skipNonTestAssemblies">True if non-test assemblies should simply be skipped rather than reporting an error</param>

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Internal\CecilExtensions.cs" />
     <Compile Include="Internal\CurrentMessageCounter.cs" />
     <Compile Include="Internal\DirectoryFinder.cs" />
+    <Compile Include="Internal\DomainDetailsBuilder.cs" />
     <Compile Include="Internal\ExceptionHelper.cs" />
     <Compile Include="Internal\Logging\InternalTrace.cs" />
     <Compile Include="Internal\Logging\InternalTraceWriter.cs" />


### PR DESCRIPTION
Fixes #111. Debug information is displayed on the console, and intended for the user to better be able to debug the issue in their code.

It's fair to say that what's available at this point is pretty limited - open to any more useful ideas, if anyone has any.