### PR TITLE
Pass Work parameter to agents

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Security;
 using NUnit.Common;
 using NUnit.Engine;
@@ -52,6 +53,7 @@ namespace NUnit.Agent
             InternalTraceLevel traceLevel = InternalTraceLevel.Off;
             int pid = Process.GetCurrentProcess().Id;
             bool debugArgPassed = false;
+            string workDirectory = string.Empty;
 
             for (int i = 2; i < args.Length; i++)
             {
@@ -72,9 +74,14 @@ namespace NUnit.Agent
                     int agencyProcessId = int.Parse(arg.Substring(6));
                     AgencyProcess = Process.GetProcessById(agencyProcessId);
                 }
+                else if (arg.StartsWith("--work="))
+                {
+                    workDirectory = arg.Substring(7);
+                }
             }
 
-            InternalTrace.Initialize($"nunit-agent_{pid}.log", traceLevel);
+            var logName = $"nunit-agent_{pid}.log";
+            InternalTrace.Initialize(Path.Combine(workDirectory, logName), traceLevel);
             log = InternalTrace.GetLogger(typeof(NUnitTestAgent));
 
             if (debugArgPassed)

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -152,6 +152,12 @@ namespace NUnit
         /// </summary>
         public const string PrincipalPolicy = "PrincipalPolicy";
 
+        /// <summary>
+        /// Full path of the directory to be used for work and result files.
+        /// This path is provided to tests by the framework TestContext.
+        /// </summary>
+        public const string WorkDirectory = "WorkDirectory";
+
         #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -151,6 +151,7 @@ namespace NUnit.Engine.Services
             bool debugAgent = package.GetSetting(EnginePackageSettings.DebugAgent, false);
             string traceLevel = package.GetSetting(EnginePackageSettings.InternalTraceLevel, "Off");
             bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
+            string workDirectory = package.GetSetting(EnginePackageSettings.WorkDirectory, string.Empty);
 
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
@@ -159,6 +160,8 @@ namespace NUnit.Engine.Services
                 agentArgs += " --trace:" + traceLevel;
             if (debugAgent)
                 agentArgs += " --debug-agent";
+            if (workDirectory != string.Empty)
+                agentArgs += " --work=" + workDirectory;
 
             log.Info("Getting {0} agent for use under {1}", useX86Agent ? "x86" : "standard", targetRuntime);
 


### PR DESCRIPTION
Note that WorkDirectory is always set in the settings, but I've decided to
keep the guards just in case this is changed in the future.

Fixes #300