### PR TITLE
Ensure we don't try to unload agent if the process already terminated

### DIFF
--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgentProxy.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgentProxy.cs
@@ -1,0 +1,62 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Engine.Agents
+{
+    /// <summary>
+    /// RemoteTestAgentProxy wraps a RemoteTestAgent so that certain 
+    /// of its properties may be accessed without remoting.
+    /// </summary>
+    internal class RemoteTestAgentProxy : ITestAgent
+    {
+        private ITestAgent _remoteAgent;
+
+        public RemoteTestAgentProxy(ITestAgent remoteAgent, Guid id)
+        {
+            _remoteAgent = remoteAgent;
+
+            Id = id;
+        }
+
+        public Guid Id { get; private set; }
+
+        public ITestEngineRunner CreateRunner(TestPackage package)
+        {
+            return _remoteAgent.CreateRunner(package);
+        }
+
+        public bool Start()
+        {
+            return _remoteAgent.Start();
+        }
+
+        public void Stop()
+        {
+            _remoteAgent.Stop();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -237,7 +237,7 @@ namespace NUnit.Engine.Runners
                     log.Error(unloadError);
                 }
 
-                if (_agent != null)
+                if (_agent != null && _agency.IsAgentRunning(_agent.Id))
                 {
                     try
                     {

--- a/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
@@ -54,13 +54,16 @@ namespace NUnit.Engine.Services
         private readonly Dictionary<Guid, AgentRecord> _agentData = new Dictionary<Guid, AgentRecord>();
         private readonly object _lock = new object();
 
+        // NOTE: Calling code is written to assume that an invalid id will result in
+        // null being returned, similar to how Hashtables worked in the past.
         public AgentRecord this[Guid id]
         {
             get
             {
                 lock (_lock)
                 {
-                    return _agentData[id];
+                    AgentRecord record;
+                    return _agentData.TryGetValue(id, out record) ? record : null;
                 }
             }
         }
@@ -90,6 +93,20 @@ namespace NUnit.Engine.Services
             lock (_lock)
             {
                 _agentData[r.Id] = r;
+            }
+        }
+
+        public AgentRecord GetDataForProcess(Process process)
+        {
+            lock (_lock)
+            {
+                foreach (var r in _agentData.Values)
+                {
+                    if (r.Process == process)
+                        return r;
+                }
+
+                return null;
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -265,7 +265,7 @@ namespace NUnit.Engine.Services
                 ? "nunit-agent-x86.exe"
                 : "nunit-agent.exe";
 
-            return Path.Combine(engineDir, agentName);//
+            return Path.Combine(engineDir, agentName);
         }
 
         private void OnAgentExit(object sender, EventArgs e)
@@ -304,9 +304,7 @@ namespace NUnit.Engine.Services
                     break;
             }
 
-            //_agentData[agentId]
             throw new NUnitEngineException(errorMsg);
-
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\nunit-agent\AgentExitCodes.cs">
       <Link>Agents\AgentExitCodes.cs</Link>
     </Compile>
+    <Compile Include="Agents\RemoteTestAgentProxy.cs" />
     <Compile Include="Drivers\NotRunnableFrameworkDriver.cs" />
     <Compile Include="Drivers\NUnit2DriverFactory.cs">
       <SubType>Code</SubType>


### PR DESCRIPTION
Fixes #343 

My original thought had been that the extra unload error didn't cause any problem but it turns out to be confusing to users who report that as the error rather than the original error. 

In order to suppress the attempt to unload the agent and runner when the agent process has terminated, the `ProcessRunner` needed to ask about the status of the process. In order to look that up, it had to use the agent id.

Since `RemoteTestAgent` is... remote 😄 ... accessing the Id property was causing an error in itself! Consequently, I created a `RemoteTestAgentProxy` that wraps the `RemoteTestAgent` and remembers its id. It doesn't do anything else, forwarding all calls to the remote agent, but it could be extended in the future.

I mention this, because I suspect that the access to the agent id may have caused some problems in the past and may still cause it if done by `TestAgency` directly on the `RemoteTestRunner`.

I tested this by forcing the agent to terminate and observing that only the initial termination message appeared in the console.