### PR TITLE
Add command-line option to specify configuration file

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -218,6 +218,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("Framework", "framework", new string[] { "net-4.0" }, new string[0])]
         [TestCase("OutFile", "output|out", new string[] { "output.txt" }, new string[0])]
         [TestCase("ErrFile", "err", new string[] { "error.txt" }, new string[0])]
+        [TestCase("ConfigurationFile", "configfile", new string[] { "mytest.config" }, new string[0] )]
         [TestCase("WorkDirectory", "work", new string[] { "results" }, new string[0])]
         [TestCase("DisplayTestLabels", "labels", new string[] { "Off", "On", "Before", "After", "All" }, new string[] { "JUNK" })]
         [TestCase("InternalTraceLevel", "trace", new string[] { "Off", "Error", "Warning", "Info", "Debug", "Verbose" }, new string[] { "JUNK" })]

--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -65,6 +65,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--domain=multiple", "DomainUsage", "Multiple")]
         [TestCase("--framework=net-4.0", "RuntimeFramework", "net-4.0")]
         [TestCase("--config=Release", "ActiveConfig", "Release")]
+        [TestCase("--configfile=mytest.config", "ConfigurationFile", "mytest.config")]
         [TestCase("--trace=Error", "InternalTraceLevel", "Error")]
         [TestCase("--trace=error", "InternalTraceLevel", "Error")]
         [TestCase("--seed=1234", "RandomSeed", 1234)]

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -67,6 +67,8 @@ namespace NUnit.Common
         public string Framework { get; private set; }
         public bool FrameworkSpecified { get { return Framework != null; } }
 
+        public string ConfigurationFile { get; private set; }
+
         public bool RunAsX86 { get; private set; }
 
         public bool DisposeRunners { get; private set; }
@@ -115,6 +117,9 @@ namespace NUnit.Common
 
             this.Add("config=", "{NAME} of a project configuration to load (e.g.: Debug).",
                 v => ActiveConfig = RequiredValue(v, "--config"));
+
+            this.Add("configfile=", "{NAME} of configuration file to use for this run.",
+                v => ConfigurationFile = RequiredValue(v, "--configfile"));
 
             // Where to Run Tests
             this.Add("process=", "{PROCESS} isolation for test assemblies.\nValues: InProcess, Separate, Multiple. If not specified, defaults to Separate for a single assembly or Multiple for more than one.",

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -459,6 +459,9 @@ namespace NUnit.ConsoleRunner
             if (options.TestParameters.Count != 0)
                 AddTestParametersSetting(package, options.TestParameters);
 
+            if (options.ConfigurationFile != null)
+                package.AddSetting(EnginePackageSettings.ConfigurationFile, options.ConfigurationFile);
+
             return package;
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -35,6 +35,9 @@ namespace NUnit.Engine.Services.Tests
         static string path2 = TestPath("/test/bin/debug/test2.dll");
         static string path3 = TestPath("/test/utils/test3.dll");
 
+        const string STANDARD_CONFIG_FILE = "nunit.engine.tests.dll.config";
+        const string ALTERNATE_CONFIG_FILE = "alt.config";
+
         [Test]
         public static void GetPrivateBinPath()
         {
@@ -88,15 +91,18 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public static void ProperConfigFileIsUsed()
         {
-            var configFileName = "nunit.engine.tests.dll.config";
-            var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, configFileName);
-            Assert.That(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile, Is.SamePath(expectedPath));
+            var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, STANDARD_CONFIG_FILE);
+            var alternatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, ALTERNATE_CONFIG_FILE);
+            Assert.That(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile, Is.SamePath(expectedPath).Or.SamePath(alternatePath));
         }
 
         [Test]
         public static void CanReadConfigFile()
         {
-            Assert.That(ConfigurationManager.AppSettings.Get("test.setting"), Is.EqualTo("54321"));
+            var expectedSetting = Path.GetFileName(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile) == ALTERNATE_CONFIG_FILE
+                ? "Alternate config used"
+                : "54321";
+            Assert.That(ConfigurationManager.AppSettings.Get("test.setting"), Is.EqualTo(expectedSetting));
         }
 
         [TestCase("/path/to/mytest.dll", null, "/path/to/")]

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -91,6 +91,9 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public static void ProperConfigFileIsUsed()
         {
+            // NOTE: The alternate config file, alt.config, is copied to the bin directory and
+            // may be specified from the command-line, using --configfile=alt.config. This allows
+            // manual testing of the option while permitting this test to still pass.
             var expectedPath = Path.Combine(TestContext.CurrentContext.TestDirectory, STANDARD_CONFIG_FILE);
             var alternatePath = Path.Combine(TestContext.CurrentContext.TestDirectory, ALTERNATE_CONFIG_FILE);
             Assert.That(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile, Is.SamePath(expectedPath).Or.SamePath(alternatePath));
@@ -99,6 +102,7 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public static void CanReadConfigFile()
         {
+            // NOTE: The alternate config file has a different value so we can see it being used
             var expectedSetting = Path.GetFileName(AppDomain.CurrentDomain.SetupInformation.ConfigurationFile) == ALTERNATE_CONFIG_FILE
                 ? "Alternate config used"
                 : "54321";

--- a/src/NUnitEngine/nunit.engine.tests/alt.config
+++ b/src/NUnitEngine/nunit.engine.tests/alt.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?> 
+<configuration>
+  <appSettings>
+    <add key="test.setting" value="Alternate config used"/>
+  </appSettings>
+</configuration>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -162,6 +162,9 @@
     <None Include="..\..\nunit.snk">
       <Link>nunit.snk</Link>
     </None>
+    <None Include="alt.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #246 

Adds the option to the console runner. The underlying capability has been there for some time and is already used by the NUnit 3 VS adapter.