### PR TITLE
Display subnodes of settings nodes in Console Run Summary

### DIFF
--- a/NUnitConsole.sln.DotSettings
+++ b/NUnitConsole.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTIPLE_DECLARATION/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTLINE_TYPE_PARAMETER_LIST/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER_SAME_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_WITHING_EMPTY_BRACES/@EntryValue">True</s:Boolean>
@@ -36,7 +37,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.&#xD;
 </s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="aaBb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=1256596694514F41A4D79DB082E50E51/@KeyIndexDefined">True</s:Boolean>

--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -190,8 +190,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "    TestParameters: 1=d;2=c",
                 "    TestParametersDictionary:",
                 "        1 -> d",
-                "        2 -> c",
-                "    NumberOfTestWorkers: 8"
+                "        2 -> c"
             };
 
             var report = GetReportLines(_reporter.WriteRunSettingsReport);

--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -46,7 +46,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void CreateResult()
         {
             var mockAssembly = typeof(MockAssembly).Assembly;
-            var emptySettings = new Dictionary<string, object>
+            var frameworkSettings = new Dictionary<string, object>
             {
                 { "TestParameters", "1=d;2=c" },
                 { "TestParametersDictionary", new Dictionary<string, string>
@@ -56,7 +56,7 @@ namespace NUnit.ConsoleRunner.Tests
                 }}
             };
 
-            var controller = new FrameworkController(mockAssembly, "id", emptySettings);
+            var controller = new FrameworkController(mockAssembly, "id", frameworkSettings);
 
             controller.LoadTests();
             var xmlText = controller.RunTests(null);

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -43,13 +43,8 @@
     <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.2.0.3\lib\net35\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\NUnit.System.Linq.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net35\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/NUnitConsole/nunit3-console.tests/packages.config
+++ b/src/NUnitConsole/nunit3-console.tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="2.0.3" targetFramework="net35" />
-  <package id="NUnit" version="3.6.0" targetFramework="net20" />
+  <package id="NUnit" version="3.9.0" targetFramework="net20" />
 </packages>

--- a/src/NUnitConsole/nunit3-console/ColorConsoleWriter.cs
+++ b/src/NUnitConsole/nunit3-console/ColorConsoleWriter.cs
@@ -24,6 +24,7 @@
 using System;
 using System.IO;
 using System.Text;
+using NUnit.Common;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit3-console/ColorConsoleWriter.cs
+++ b/src/NUnitConsole/nunit3-console/ColorConsoleWriter.cs
@@ -108,6 +108,8 @@ namespace NUnit.ConsoleRunner
         /// <param name="valueStyle">The color to display the value with</param>
         public override void WriteLabel(string label, object option, ColorStyle valueStyle)
         {
+            Guard.ArgumentNotNull(option, nameof(option));
+
             Write(ColorStyle.Label, label);
             Write(valueStyle, option.ToString());
         }

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -76,7 +76,7 @@ namespace NUnit.ConsoleRunner
 
         #region Summary Report
 
-        public void WriteRunSettingsReport()
+        internal void WriteRunSettingsReport()
         {
             var firstSuite = ResultNode.SelectSingleNode("test-suite");
             if (firstSuite != null)
@@ -88,15 +88,26 @@ namespace NUnit.ConsoleRunner
                     Writer.WriteLine(ColorStyle.SectionHeader, "Run Settings");
 
                     foreach (XmlNode node in settings)
-                    {
-                        string name = node.GetAttribute("name");
-                        string val = node.GetAttribute("value");
-                        string label = string.Format("    {0}: ", name);
-                        Writer.WriteLabelLine(label, val);
-                    }
+                        WriteSettingsNode(node);
 
                     Writer.WriteLine();
                 }
+            }
+        }
+
+        private void WriteSettingsNode(XmlNode node)
+        {
+            var items = node.SelectNodes("item");
+            var name = node.GetAttribute("name");
+            var val = node.GetAttribute("value") ?? string.Empty;
+
+            Writer.WriteLabelLine($"    {name}:", items.Count > 0 ? string.Empty : $" {val}");
+
+            foreach (XmlNode item in items)
+            {
+                var key = item.GetAttribute("key");
+                var value = item.GetAttribute("value");
+                Writer.WriteLine(ColorStyle.Value, $"        {key} -> {value}");
             }
         }
 

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -54,6 +54,9 @@
     <Compile Include="..\..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\NUnitEngine\nunit.engine\Guard.cs">
+      <Link>Utilities\Guard.cs</Link>
+    </Compile>
     <Compile Include="..\..\NUnitEngine\nunit.engine\Internal\ExceptionHelper.cs">
       <Link>Utilities\ExceptionHelper.cs</Link>
     </Compile>

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -66,13 +66,11 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net20\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\NUnit.System.Linq.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net20\NUnit.System.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/src/NUnitEngine/mock-assembly/packages.config
+++ b/src/NUnitEngine/mock-assembly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0" targetFramework="net20" />
+  <package id="NUnit" version="3.9.0" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/notest-assembly/notest-assembly.csproj
+++ b/src/NUnitEngine/notest-assembly/notest-assembly.csproj
@@ -32,13 +32,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net20\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="NUnit.System.Linq, Version=0.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\NUnit.System.Linq.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net20\NUnit.System.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/NUnitEngine/notest-assembly/packages.config
+++ b/src/NUnitEngine/notest-assembly/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.0" targetFramework="net20" />
+  <package id="NUnit" version="3.9.0" targetFramework="net20" />
 </packages>

--- a/src/NUnitEngine/nunit.engine.netstandard/Drivers/NUnitNetStandardDriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.netstandard/Drivers/NUnitNetStandardDriverFactory.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Reflection;
+using NUnit.Common;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Drivers

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -50,9 +50,8 @@
     <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NSubstitute.2.0.3\lib\net35\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NUnit.3.9.0\lib\net35\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/NUnitEngine/nunit.engine.tests/packages.config
+++ b/src/NUnitEngine/nunit.engine.tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net20" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net35" />
-  <package id="NUnit" version="3.6.0" targetFramework="net20" />
+  <package id="NUnit" version="3.9.0" targetFramework="net35" />
 </packages>

--- a/src/NUnitEngine/nunit.engine/AsyncTestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine/AsyncTestEngineResult.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Threading;
 using System.Xml;
+using NUnit.Common;
 
 namespace NUnit.Engine
 {

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3DriverFactory.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Reflection;
+using NUnit.Common;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Drivers

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Extensibility;
 

--- a/src/NUnitEngine/nunit.engine/Guard.cs
+++ b/src/NUnitEngine/nunit.engine/Guard.cs
@@ -23,7 +23,7 @@
 
 using System;
 
-namespace NUnit.Engine
+namespace NUnit.Common
 {
     /// <summary>
     /// Class used to guard against unexpected argument values

--- a/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using NUnit.Common;
 
 namespace NUnit.Engine.Internal
 {

--- a/src/NUnitEngine/nunit.engine/Runners/ParallelTaskWorkerPool.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ParallelTaskWorkerPool.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using NUnit.Common;
 
 namespace NUnit.Engine.Runners
 {

--- a/src/NUnitEngine/nunit.engine/Runners/TestExecutionTask.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestExecutionTask.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using NUnit.Common;
 
 namespace NUnit.Engine.Runners
 {

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -31,6 +31,7 @@ using System.Diagnostics;
 using System.Security;
 using System.Security.Policy;
 using System.Security.Principal;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Mono.Cecil;
+using NUnit.Common;
 using NUnit.Engine.Drivers;
 using NUnit.Engine.Extensibility;
 using NUnit.Engine.Internal;

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using NUnit.Common;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -26,6 +26,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 using System.Xml.Xsl;
+using NUnit.Common;
 using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Mono.Cecil;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services


### PR DESCRIPTION
Fixes #285 - now reads/displays the subnodes of the TestParamsDictionary settingnode from the framework, as opposed to reading the `value` attribute we added for legacy runners. 

The new output looks like this. Do we approve of the arrows? I wanted to avoid characters users may be likely to use in their own params.

![image](https://user-images.githubusercontent.com/4837132/35122832-0309eea4-fc98-11e7-89a5-9dc02eb6bb97.png)

This involved a couple of other changes - I suggest reviewing the two commits separately. I'll line-comment some of the unexpected bits.

Also involved:
- Adding the Guard.cs utility class to the console, to guard the method which previously crashed. Involved moving it to the NUnit.Common namespace
- Updating the NUnit framework version referenced by the tests, to remove a reference to the NUnit.Framework.Internal namespace. (Commented further inline.)
