### PR TITLE
Add NSubstitute to rewrite ConsoleRunnerTests

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Xml;
+using NSubstitute;
 using NUnit.Common;
 using NUnit.Engine;
 using NUnit.Engine.Extensibility;
@@ -11,16 +12,14 @@ namespace NUnit.ConsoleRunner.Tests
 {
     class ConsoleRunnerTests
     {
-        [Test, Ignore("Needs to be rewritten")]
+        [Test]
         public void ThrowsNUnitEngineExceptionWhenTestResultsAreNotWriteable()
         {
             var testEngine = new TestEngine();
 
-            // This worked when we only needed one service. We now
-            // would need to create three fakes. We should find a
-            // better way to test this. Since it's a relatively
-            // minor test, I'm leaving it for the future.
             testEngine.Services.Add(new FakeResultService());
+            testEngine.Services.Add(new TestFilterService());
+            testEngine.Services.Add(Substitute.For<IService, IExtensionService>());
 
             var consoleRunner = new ConsoleRunner(testEngine, new ConsoleOptions("mock-assembly.dll"), new ColorConsoleWriter());
             

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -8,13 +8,14 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NUnit.ConsoleRunner.Tests</RootNamespace>
     <AssemblyName>nunit3-console.tests</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation />
     <LangVersion>6</LangVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +40,9 @@
     <NoWarn>1685</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\NSubstitute.2.0.3\lib\net35\NSubstitute.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\NUnit.3.6.0\lib\net20\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/src/NUnitConsole/nunit3-console.tests/packages.config
+++ b/src/NUnitConsole/nunit3-console.tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="NSubstitute" version="2.0.3" targetFramework="net35" />
   <package id="NUnit" version="3.6.0" targetFramework="net20" />
 </packages>


### PR DESCRIPTION
Fixes #256.

This just breaks the unrelated work out of #320. The purpose of this is to make more use of NSubstitute in #320 - this issue just 'might-as-well' be fixed as it's now trivial.

To use NSubstitue nunit.console.tests has to become .NET 3.5 - however, nunit.engine.tests is already doing the same - a .NET 3.5 test assembly testing the .NET 2.0 nunit.engine.