### PR TITLE
Ensure that assembly-level errors are actually displayed by console runner

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/BadFileTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/BadFileTests.cs
@@ -34,8 +34,6 @@ namespace NUnit.ConsoleRunner.Tests
 {
     public class BadFileTests : ITestEventListener
     {
-        static string NL = Environment.NewLine;
-
         [TestCase("junk.dll", "File not found")]
         [TestCase("EngineTests.nunit", "File type is not supported")]
         public void MissingFileTest(string filename, string message)

--- a/src/NUnitConsole/nunit3-console.tests/BadFileTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/BadFileTests.cs
@@ -1,0 +1,73 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.IO;
+using System.Text;
+using NUnit.Common;
+using NUnit.Engine;
+using NUnit.Engine.Runners;
+using NUnit.Engine.Services;
+using NUnit.Framework;
+
+namespace NUnit.ConsoleRunner.Tests
+{
+    public class BadFileTests : ITestEventListener
+    {
+        static string NL = Environment.NewLine;
+
+        [TestCase("junk.dll", "File not found")]
+        [TestCase("EngineTests.nunit", "File type is not supported")]
+        public void MissingFileTest(string filename, string message)
+        {
+            var fullname = Path.Combine(TestContext.CurrentContext.TestDirectory, filename);
+
+            var services = new ServiceContext();
+            services.Add(new InProcessTestRunnerFactory());
+            services.Add(new ExtensionService());
+            services.Add(new RuntimeFrameworkService());
+            services.Add(new DriverService());
+
+            var package = new TestPackage(fullname);
+            package.AddSetting("ProcessModel", "InProcess");
+            package.AddSetting("DomainUsage", "None");
+
+            var runner = new MasterTestRunner(services, package);
+
+            var result = runner.Run(this, TestFilter.Empty);
+            var sb = new StringBuilder();
+            var writer = new ExtendedTextWrapper(new StringWriter(sb));
+            var reporter = new ResultReporter(result, writer, new ConsoleOptions());
+
+            reporter.WriteErrorsFailuresAndWarningsReport();
+            var report = sb.ToString();
+
+            Assert.That(report, Contains.Substring($"1) Invalid : {fullname}"));
+            Assert.That(report, Contains.Substring(message));
+        }
+
+        public void OnTestEvent(string report)
+        {
+        }
+    }
+}

--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -169,6 +169,12 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(report, Is.EqualTo(expected));
         }
 
+        [Test, Explicit("Displays failure behavior")]
+        public void WarningsOnlyDisplayOnce()
+        {
+            Assert.Warn("Just a warning");
+        }
+
         #region Helper Methods
 
         private TestEngineResult AddMetadata(TestEngineResult input)

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="..\ConsoleVersion.cs">
       <Link>Properties\ConsoleVersion.cs</Link>
     </Compile>
+    <Compile Include="BadFileTests.cs" />
     <Compile Include="ColorConsoleTests.cs" />
     <Compile Include="ColorStyleTests.cs" />
     <Compile Include="CommandLineTests.cs" />


### PR DESCRIPTION
Fixes #350 

This is the console part of the fix. I'll do the framework fix next.

As I envision this, the console should not need any changes once the framework fix is in. However, the console still has to deal with older framework versions and it is for those versions that this PR is targeted.

The problem is with failures, errors or warnings that come from child tests of a suite, but which do not have the `site` attribute set to `Child`. That means the runner assumes the suite itself is the cause of the error. A previous fix solved the problem by ignoring any suites without a `site` attribute but that causes the problem described in the issue. Assembly not found and similar errors don't use the site at all.

After experimenting with various approaches, including looking at the `type` attribute, I decided that the best way, although ugly, was to examine the message used. For all our releases, we have used constant messages for suites with a failed or warning status due to problems with the child tests. I'm using those messages to decide whether a suite with no site specified should actually have the `Child` value instead of the default `Test` value.

This is pretty adhoc, but fixes on top of existing framework releases often are. Please review with that in mind and try to see if you can think of any situations where this will not work.