### PR TITLE
3.8 Release Changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-﻿NUnit 3.8 - February 27, 2018
+﻿NUnit 3.8 - January 27, 2018
 
 This release includes several fixes when unloading AppDomains and better error reporting. The
 aggregate NuGet packages also include updated versions of several extensions.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,40 @@
-﻿NUnit 3.7 - July 13, 2017
+﻿NUnit 3.8 - February 27, 2018
+
+This release includes several fixes when unloading AppDomains and better error reporting. The
+aggregate NuGet packages also include updated versions of several extensions.
+
+Issues Resolved
+
+ * 6 TypeLoadException in nunit3-console 3.0.1
+ * 93 Update Readme with information about the NuGet packages
+ * 111 Provide better info when AppDomain won't unload
+ * 116 NUnit 3.5.0 defaults to single agent process when using an nunit project file
+ * 191 Exception encountered unloading AppDomain
+ * 228 System.Reflection.TargetInvocationException with nunit3-console --debug on Mono
+ * 246 No way to specify app.config with console runner
+ * 256 Rewrite ConsoleRunnerTests.ThrowsNUnitEngineExceptionWhenTestResultsAreNotWriteable()
+ * 259 NUnit3 agent hangs after encountering an "CannotUnloadAppDomainException"
+ * 262 Transform file existence check should check current directory instead of WorkDirectory
+ * 267 Fix possible NRE
+ * 273 Insufficient error handling message in ProcessRunner -> RunTests method
+ * 275 Integrate chocolatey packages with build script
+ * 284 NUnit3: An exception occured in the driver while loading tests...   bei NUnit.Engine.Runners.ProcessRunner.RunTests(ITestEventListener listener, TestFilter filter)
+ * 285 ColorConsoleWriter.WriteLabel causes NullReferenceException
+ * 289 Warnings not displayed
+ * 298 Invalid --framework option throws exception
+ * 300 Agents do not respect the Console WORK parameter when writing log file
+ * 304 Catch agent debugger launch exceptions, and improve agent crash handling
+ * 309 No driver found if framework assembly reference has uppercase characters
+ * 314 Update NUnit.Extension.VSProjectLoader to 3.7.0
+ * 318 Update NUnit.Extension.TeamCityEventListener to 1.0.3
+ * 320 Return error code -5 when AppDomain fails to unload
+ * 323 Assertion should not be ordered in AgentDatabaseTests
+ * 343 Superfluous unload error shown in console
+ * 349 Get all TestEngine tests running under NUnitAdapter apart from those .
+ * 350 Invalid assemblies no longer give an error message
+ * 355 NuGet package links to outdated license
+
+NUnit 3.7 - July 13, 2017
 
 Engine
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2017 Charlie Poole, Rob Prouse
+Copyright (c) 2018 Charlie Poole, Rob Prouse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.cake
+++ b/build.cake
@@ -15,7 +15,7 @@ var ErrorDetail = new List<string>();
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "3.8.0";
+var version = "3.9.0";
 var modifier = "";
 
 var isAppveyor = BuildSystem.IsRunningOnAppVeyor;

--- a/choco/nunit-console-runner.nuspec
+++ b/choco/nunit-console-runner.nuspec
@@ -23,6 +23,6 @@
     <owners>Charlie Poole, Rob Prouse</owners>
     <language>en-US</language>
     <tags>nunit console runner test testing tdd</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
   </metadata>
 </package>

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -32,7 +32,7 @@
     <owners>Charlie Poole, Rob Prouse</owners>
     <language>en-US</language>
     <tags>nunit console runner test testing tdd</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
     <dependencies>
       <group>
           <dependency id="nunit-console-runner" version="$version$" />

--- a/nuget/engine/nunit.engine.api.nuspec
+++ b/nuget/engine/nunit.engine.api.nuspec
@@ -15,7 +15,7 @@
     <releaseNotes></releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd engine</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -15,7 +15,7 @@
     <releaseNotes></releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd engine</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/engine/nunit.engine.tool.nuspec
+++ b/nuget/engine/nunit.engine.tool.nuspec
@@ -15,7 +15,7 @@
     <releaseNotes></releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd engine</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -26,7 +26,7 @@
     <releaseNotes>This release uses the latest version of the TeamCityEventListener extension.</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
     <dependencies>
       <group>
           <dependency id="NUnit.ConsoleRunner" version="$version$" />

--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -19,7 +19,7 @@
     <releaseNotes></releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole, Rob Prouse</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole, Rob Prouse</copyright>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -28,7 +28,7 @@
     <releaseNotes>This release uses the latest version of the TeamCityEventListener extension.</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
-    <copyright>Copyright (c) 2017 Charlie Poole</copyright>
+    <copyright>Copyright (c) 2018 Charlie Poole</copyright>
     <dependencies>
       <group>
         <dependency id="NUnit.ConsoleRunner" version="$version$" />

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Reflection;
 [assembly: AssemblyProduct("NUnit 3")]
 [assembly: AssemblyTrademark("NUnit is a trademark of NUnit Software")]
 [assembly: AssemblyCompany("NUnit Software")]
-[assembly: AssemblyCopyright("Copyright (c) 2017 Charlie Poole, Rob Prouse")]
+[assembly: AssemblyCopyright("Copyright (c) 2018 Charlie Poole, Rob Prouse")]
 
 #if PORTABLE
 [assembly: AssemblyMetadata("PCL", "True")]

--- a/src/NUnitConsole/ConsoleVersion.cs
+++ b/src/NUnitConsole/ConsoleVersion.cs
@@ -26,5 +26,5 @@ using System.Reflection;
 //
 // Current version for the NUnit Console
 //
-[assembly: AssemblyVersion("3.8.0.0")]
-[assembly: AssemblyFileVersion("3.8.0.0")]
+[assembly: AssemblyVersion("3.9.0.0")]
+[assembly: AssemblyFileVersion("3.9.0.0")]

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -164,7 +164,7 @@ namespace NUnit.ConsoleRunner
             string versionText = executingAssembly.GetName().Version.ToString(3);
 
             string programName = "NUnit Console Runner";
-            string copyrightText = "Copyright (C) 2017 Charlie Poole, Rob Prouse.\r\nAll Rights Reserved.";
+            string copyrightText = "Copyright (C) 2018 Charlie Poole, Rob Prouse.\r\nAll Rights Reserved.";
             string configText = String.Empty;
 
             object[] attrs = executingAssembly.GetCustomAttributes(typeof(AssemblyTitleAttribute), false);

--- a/src/NUnitEngine/EngineApiVersion.cs
+++ b/src/NUnitEngine/EngineApiVersion.cs
@@ -29,4 +29,4 @@ using System.Reflection;
 // as new releases of the engine itself are created.
 //
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.8.0.0")]
+[assembly: AssemblyFileVersion("3.9.0.0")]

--- a/src/NUnitEngine/EngineVersion.cs
+++ b/src/NUnitEngine/EngineVersion.cs
@@ -27,5 +27,5 @@ using System.Reflection;
 // Versioning for the NUnit Engine assemblies, with the exception
 // of nunit.engine.api, which uses a separate version file.
 //
-[assembly: AssemblyVersion("3.8.0.0")]
-[assembly: AssemblyFileVersion("3.8.0.0")]
+[assembly: AssemblyVersion("3.9.0.0")]
+[assembly: AssemblyFileVersion("3.9.0.0")]


### PR DESCRIPTION
This merges the 3.8 release changes back into master. It includes,

- Update to Changes.txt
- Update the copyright year to 2018
- Switch the version to 3.9 for ongoing development

Still outstanding in the release,

- [x] Create and upload the installer to the release
- [x] Update the website
- [ ] Upload the two Chocolatey packages
- [x] Notify users