### PR TITLE
Sticky Plaster fix for #370

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -25,7 +25,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Security;
-using System.Threading;
 using NUnit.Common;
 using NUnit.Engine;
 using NUnit.Engine.Agents;
@@ -140,17 +139,17 @@ namespace NUnit.Agent
                 else
                 {
                     log.Error("Failed to start RemoteTestAgent");
-                    ExitWithPause(AgentExitCodes.FAILED_TO_START_REMOTE_AGENT);
+                    Environment.Exit(AgentExitCodes.FAILED_TO_START_REMOTE_AGENT);
                 }
             }
             catch (Exception ex)
             {
                 log.Error("Exception in RemoteTestAgent", ex);
-                ExitWithPause(AgentExitCodes.UNEXPECTED_EXCEPTION);
+                Environment.Exit(AgentExitCodes.UNEXPECTED_EXCEPTION);
             }
             log.Info("Agent process {0} exiting cleanly", pid);
 
-            ExitWithPause(AgentExitCodes.OK);
+            Environment.Exit(AgentExitCodes.OK);
         }
 
         private static void WaitForStop()
@@ -162,7 +161,7 @@ namespace NUnit.Agent
                 if (AgencyProcess.HasExited)
                 {
                     log.Error("Parent process has been terminated.");
-                    ExitWithPause(AgentExitCodes.PARENT_PROCESS_TERMINATED);
+                    Environment.Exit(AgentExitCodes.PARENT_PROCESS_TERMINATED);
                 }
             }
 
@@ -184,7 +183,7 @@ namespace NUnit.Agent
                 {
                     log.Error($"System.Security.Permissions.UIPermission is not set to start the debugger. {se} {se.StackTrace}");
                 }
-                ExitWithPause(AgentExitCodes.DEBUGGER_SECURITY_VIOLATION);
+                Environment.Exit(AgentExitCodes.DEBUGGER_SECURITY_VIOLATION);
             }
             catch (NotImplementedException nie) //Debugger is not implemented on mono
             {
@@ -192,14 +191,8 @@ namespace NUnit.Agent
                 {
                     log.Error($"Debugger is not available on all platforms. {nie} {nie.StackTrace}");
                 }
-                ExitWithPause(AgentExitCodes.DEBUGGER_NOT_IMPLEMENTED);
+                Environment.Exit(AgentExitCodes.DEBUGGER_NOT_IMPLEMENTED);
             }
-        }
-
-        private static void ExitWithPause(int exitCode)
-        {
-            Thread.Sleep(TimeSpan.FromSeconds(2));
-            Environment.Exit(exitCode);
         }
     }
 }

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -25,6 +25,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Security;
+using System.Threading;
 using NUnit.Common;
 using NUnit.Engine;
 using NUnit.Engine.Agents;

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -139,17 +139,17 @@ namespace NUnit.Agent
                 else
                 {
                     log.Error("Failed to start RemoteTestAgent");
-                    Environment.Exit(AgentExitCodes.FAILED_TO_START_REMOTE_AGENT);
+                    ExitWithPause(AgentExitCodes.FAILED_TO_START_REMOTE_AGENT);
                 }
             }
             catch (Exception ex)
             {
                 log.Error("Exception in RemoteTestAgent", ex);
-                Environment.Exit(AgentExitCodes.UNEXPECTED_EXCEPTION);
+                ExitWithPause(AgentExitCodes.UNEXPECTED_EXCEPTION);
             }
             log.Info("Agent process {0} exiting cleanly", pid);
 
-            Environment.Exit(AgentExitCodes.OK);
+            ExitWithPause(AgentExitCodes.OK);
         }
 
         private static void WaitForStop()
@@ -161,7 +161,7 @@ namespace NUnit.Agent
                 if (AgencyProcess.HasExited)
                 {
                     log.Error("Parent process has been terminated.");
-                    Environment.Exit(AgentExitCodes.PARENT_PROCESS_TERMINATED);
+                    ExitWithPause(AgentExitCodes.PARENT_PROCESS_TERMINATED);
                 }
             }
 
@@ -183,7 +183,7 @@ namespace NUnit.Agent
                 {
                     log.Error($"System.Security.Permissions.UIPermission is not set to start the debugger. {se} {se.StackTrace}");
                 }
-                Environment.Exit(AgentExitCodes.DEBUGGER_SECURITY_VIOLATION);
+                ExitWithPause(AgentExitCodes.DEBUGGER_SECURITY_VIOLATION);
             }
             catch (NotImplementedException nie) //Debugger is not implemented on mono
             {
@@ -191,8 +191,14 @@ namespace NUnit.Agent
                 {
                     log.Error($"Debugger is not available on all platforms. {nie} {nie.StackTrace}");
                 }
-                Environment.Exit(AgentExitCodes.DEBUGGER_NOT_IMPLEMENTED);
+                ExitWithPause(AgentExitCodes.DEBUGGER_NOT_IMPLEMENTED);
             }
+        }
+
+        private static void ExitWithPause(int exitCode)
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+            Environment.Exit(exitCode);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -246,17 +246,17 @@ namespace NUnit.Engine.Runners
                         log.Debug("Stopping remote agent");
                         _agent.Stop();
                     }
-                    catch (SocketException se) when (se.Message.Contains("An existing connection was forcibly closed by the remote host"))
+                    catch (SocketException se) when (se.Message.ToLower().Contains("an existing connection was forcibly closed by the remote host"))
                     {
                         var exitCode = _agency.GetAgentExitCode(_agent.Id);
 
-                        if (exitCode == 0)
+                        if (exitCode.HasValue && exitCode == 0)
                         {
                             log.Warning("Agent connection was forcibly closed. - Exit code was 0, so agent shutdown OK");
                         }
                         else
                         {
-                            string stopError = string.Format("Agent connection was forcibly closed. - Exit code was {0}. {1}{2}{3}", exitCode, se.Message, Environment.NewLine, se.StackTrace);
+                            string stopError = string.Format("Agent connection was forcibly closed. - Exit code was {0}. {1}{2}{3}", exitCode.GetValueOrDefault(-999), se.Message, Environment.NewLine, se.StackTrace);
                             log.Error(stopError);
 
                             // Stop error with no unload error, just rethrow

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -246,17 +246,18 @@ namespace NUnit.Engine.Runners
                         log.Debug("Stopping remote agent");
                         _agent.Stop();
                     }
-                    catch (SocketException se) when (se.Message.ToLower().Contains("an existing connection was forcibly closed by the remote host"))
+                    catch (SocketException se)
                     {
                         var exitCode = _agency.GetAgentExitCode(_agent.Id);
 
                         if (exitCode.HasValue && exitCode == 0)
                         {
-                            log.Warning("Agent connection was forcibly closed. - Exit code was 0, so agent shutdown OK");
+                            log.Warning("Agent connection was forcibly closed. Exit code was 0, so agent shutdown OK");
                         }
                         else
                         {
-                            string stopError = string.Format("Agent connection was forcibly closed. - Exit code was {0}. {1}{2}{3}", exitCode.GetValueOrDefault(-999), se.Message, Environment.NewLine, se.StackTrace);
+
+                            var stopError = $"Agent connection was forcibly closed. Exit code was {exitCode?.ToString() ?? "unknown"}. {ExceptionHelper.BuildMessage(se)}{Environment.NewLine}{ExceptionHelper.BuildStackTrace(se)}";
                             log.Error(stopError);
 
                             // Stop error with no unload error, just rethrow
@@ -264,12 +265,12 @@ namespace NUnit.Engine.Runners
                                 throw;
 
                             // Both kinds of errors, throw exception with combined message
-                            throw new NUnitEngineUnloadException(unloadException.Message + Environment.NewLine + stopError);
+                            throw new NUnitEngineUnloadException(ExceptionHelper.BuildMessage(unloadException) + Environment.NewLine + stopError);
                         }
                     }
                     catch (Exception e)
                     {
-                        string stopError = string.Format("Failed to stop the remote agent. {0}{1}{2}", e.Message, Environment.NewLine, e.StackTrace);
+                        var stopError = $"Failed to stop the remote agent. {ExceptionHelper.BuildMessage(e)}{Environment.NewLine}{ExceptionHelper.BuildStackTrace(e)}";
                         log.Error(stopError);
 
                         // Stop error with no unload error, just rethrow
@@ -277,7 +278,7 @@ namespace NUnit.Engine.Runners
                             throw;
 
                         // Both kinds of errors, throw exception with combined message
-                        throw new NUnitEngineUnloadException(unloadException.Message + Environment.NewLine + stopError);
+                        throw new NUnitEngineUnloadException(ExceptionHelper.BuildMessage(unloadException) + Environment.NewLine + stopError);
                     }
                     finally
                     {

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -248,7 +248,7 @@ namespace NUnit.Engine.Runners
                     }
                     catch (Exception e)
                     {
-                        string stopError = string.Format("Failed to stop the remote agent. {0}", e.Message);
+                        string stopError = string.Format("Failed to stop the remote agent. {0}{1}{2}", e.Message, Environment.NewLine, e.StackTrace);
                         log.Error(stopError);
                         _agent = null;
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -134,10 +134,10 @@ namespace NUnit.Engine.Services
             return agentRecord != null && agentRecord.Status != AgentStatus.Terminated;
         }
 
-        internal int GetAgentExitCode(Guid id)
+        internal int? GetAgentExitCode(Guid id)
         {
             var agentRecord = _agentData[id];
-            return agentRecord.Process.ExitCode;
+            return agentRecord?.Process.ExitCode;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -134,6 +134,12 @@ namespace NUnit.Engine.Services
             return agentRecord != null && agentRecord.Status != AgentStatus.Terminated;
         }
 
+        internal int GetAgentExitCode(Guid id)
+        {
+            var agentRecord = _agentData[id];
+            return agentRecord.Process.ExitCode;
+        }
+
         #endregion
 
         #region Helper Methods

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -25,7 +25,6 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Diagnostics;
-using System.Collections.Generic;
 using NUnit.Common;
 using NUnit.Engine.Agents;
 using NUnit.Engine.Internal;
@@ -137,7 +136,18 @@ namespace NUnit.Engine.Services
         internal int? GetAgentExitCode(Guid id)
         {
             var agentRecord = _agentData[id];
-            return agentRecord?.Process.ExitCode;
+            if (agentRecord?.Process != null && agentRecord.Process.HasExited)
+            {
+                try
+                {
+                    return agentRecord.Process.ExitCode;
+                }
+                catch (NotSupportedException)
+                {
+                    return null;
+                }
+            }
+            return null;
         }
 
         #endregion


### PR DESCRIPTION
Whilst this doesn't "solve" the communication issues between console and the agent, it will remove the problem until the communication channel is re-worked.

Adding a short sleep before exiting the agent & if we do get a socket exception, we check the exit code for the process.  If that exit code is 0, we warn and carry on.
If it is not zero, we throw an error like we would have before.