### PR TITLE
Remove duplicate nunit.engine.api packaging

### DIFF
--- a/nuget/engine/nunit.engine.tool.nuspec
+++ b/nuget/engine/nunit.engine.tool.nuspec
@@ -21,7 +21,6 @@
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
     <file src="CHANGES.txt" />
-    <file src="bin\nunit.engine.api.dll" target="lib" />
     <file src="bin\nunit.engine.api.dll" target="tools" />
     <file src="bin\nunit.engine.dll" target="tools" />
     <file src="bin\Mono.Cecil.dll" target="tools" />


### PR DESCRIPTION
Noticed nunit.engine.api.dll is packaged in two places in the package.

@CharliePoole - you added this package - this reference has been in twice since the nuspec was added to the repo. Am I missing a subtlety, or is it just a copy and paste error?