### PR TITLE
Remove -5 UNLOAD_ERROR exit code

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -47,7 +47,7 @@ namespace NUnit.ConsoleRunner
         public static readonly int INVALID_ASSEMBLY = -2;
         //public static readonly int FIXTURE_NOT_FOUND = -3;    //No longer in use
         public static readonly int INVALID_TEST_FIXTURE = -4;
-        public static readonly int UNLOAD_ERROR = -5;
+        //public static readonly int UNLOAD_ERROR = -5;         //No longer in use
         public static readonly int UNEXPECTED_ERROR = -100;
 
         #endregion
@@ -248,7 +248,6 @@ namespace NUnit.ConsoleRunner
                 if (unloadException != null)
                 {
                     writer.WriteLine(ColorStyle.Warning, Environment.NewLine + ExceptionHelper.BuildMessage(unloadException));
-                    return ConsoleRunner.UNLOAD_ERROR;
                 }
 
                 if (reporter.Summary.UnexpectedError)


### PR DESCRIPTION
Looking at the code for a recent email discussion, I realised how trivial it was to fix #371 

This reverts to the previous-intended-functionality regarding app domain unloads (ignoring the bugs causing -100's up till 3.7!). Behaviour should now be that the engine continues to throw a NUnitEngineUnloadException - but the console just writes a warning to screen and exists with the normal code for the test run.

In future, we may wish to instead attach the warning to the test assembly at engine level, but that's a bigger implementation!