### PR TITLE
Make output received when providing user friendly messages unloading the domain more user friendly

### DIFF
--- a/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
+using NUnit.Common;
 
 namespace NUnit.Engine.Internal
 {
@@ -34,6 +35,8 @@ namespace NUnit.Engine.Internal
     /// </summary>
     internal static class DomainDetailsBuilder
     {
+        private static readonly ILogger Log = InternalTrace.GetLogger(nameof(DomainDetailsBuilder));
+
         /// <summary>
         /// Get human readable string containing details of application domain.
         /// </summary>
@@ -58,14 +61,15 @@ namespace NUnit.Engine.Internal
                         WriteAssemblyInformation(sb, assembly);
                 }
             }
-            catch (AppDomainUnloadedException)
+            catch (AppDomainUnloadedException ex)
             {
                 sb.AppendLine("Application domain was unloaded before all details could be read.");
+                Log.Error(ExceptionHelper.BuildStackTrace(ex));
             }
             catch (Exception ex)
             {
                 sb.AppendLine($"Error trying to read application domain details: {ex.Message}");
-                sb.AppendLine($"{ex.StackTrace}");
+                Log.Error(ExceptionHelper.BuildStackTrace(ex));
             }
             return sb.ToString();
         }

--- a/src/NUnitEngine/nunit.engine/Internal/ExceptionHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ExceptionHelper.cs
@@ -63,17 +63,16 @@ namespace NUnit.Common
         public static string BuildStackTrace(Exception exception)
         {
             var sb = new StringBuilder("--");
-            sb.Append(exception.GetType().Name);
-            sb.Append(Environment.NewLine);
-            sb.Append(GetSafeStackTrace(exception));
+            sb.AppendLine(exception.GetType().Name);
+            sb.AppendLine(GetExceptionMessage(exception));
+            sb.AppendLine(GetSafeStackTrace(exception));
 
             foreach (Exception inner in FlattenExceptionHierarchy(exception))
             {
-                sb.Append(Environment.NewLine);
-                sb.Append("--");
-                sb.Append(inner.GetType().Name);
-                sb.Append(Environment.NewLine);
-                sb.Append(GetSafeStackTrace(inner));
+                sb.AppendLine("--");
+                sb.AppendLine(inner.GetType().Name);
+                sb.AppendLine(GetExceptionMessage(inner));
+                sb.AppendLine(GetSafeStackTrace(inner));
             }
 
             return sb.ToString();


### PR DESCRIPTION
Phew!

When a domain unload fails, a user friendly explanation is printed to the console to help diagnosis. If an exception is thrown whilst trying to retrieve this user friendly information - that is currently printed to console.

This change prints the stack trace to log, and just prints the message to console - the stack trace at this point will all be in the framework anyway. https://github.com/nunit/nunit-console/issues/410 is a good example where this would have been preferable.