### PR TITLE
Use API version for nunit.engine.api

### DIFF
--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />
-    <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
+    <Compile Include="..\EngineApiVersion.cs" LinkBase="Properties" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit-console/issues/412. Just a simple typo in the PR converting to the new csproj - it shows up a gap in our integration testing - but that's a gap I believe we're already well aware of...