### PR TITLE
Fix timeout of agent-discovery due to CPU starvation

### DIFF
--- a/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
+++ b/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
@@ -30,6 +30,7 @@ namespace NUnit.Common
         public const int FAILED_TO_START_REMOTE_AGENT = -2;
         public const int DEBUGGER_SECURITY_VIOLATION = -3;
         public const int DEBUGGER_NOT_IMPLEMENTED = -4;
+        public const int UNABLE_TO_LOCATE_AGENCY = -5;
         public const int UNEXPECTED_EXCEPTION = -100;
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -46,7 +46,7 @@ namespace NUnit.Engine.Runners
         {
             get
             {
-                int maxAgents = TestPackage.GetSetting(EnginePackageSettings.MaxAgents, int.MaxValue);
+                var maxAgents = TestPackage.GetSetting(EnginePackageSettings.MaxAgents, Environment.ProcessorCount);
                 return Math.Min(maxAgents, TestPackage.SubPackages.Count);
             }
         }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -315,6 +315,9 @@ namespace NUnit.Engine.Services
                 case AgentExitCodes.DEBUGGER_NOT_IMPLEMENTED:
                     errorMsg = "Debugger could not be started on remote agent as not available on platform.";
                     break;
+                case AgentExitCodes.UNABLE_TO_LOCATE_AGENCY:
+                    errorMsg = "Remote test agent unable to locate agency process.";
+                    break;
                 default:
                     errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
                     break;


### PR DESCRIPTION
Adds temporary additional logging for nunit/nunit#2832.

I think what's currently here is overkill, but hopefully it will help us track down the problem. Once we understand the issue better, we can hopefully add more appropriate logging.

Update: Now fixes #436 