### PR TITLE
Fix --inprocess NUnit Project loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build/
 .vscode/
 tools/
 !tools/packages.config
+launchSettings.json
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/

--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -56,7 +56,7 @@ namespace NUnit.Engine.Services.Tests
         // Single file
         [TestCase("x.nunit",           null,        typeof(AggregatingTestRunner))]
         [TestCase("x.dll",             null,        typeof(ProcessRunner))]
-        [TestCase("x.nunit",           "Single",    typeof(TestDomainRunner))]
+        [TestCase("x.nunit",           "Single",    typeof(MultipleTestDomainRunner))]
         [TestCase("x.dll",             "Single",    typeof(TestDomainRunner))]
         [TestCase("x.nunit",           "Separate",  typeof(ProcessRunner))]
         [TestCase("x.dll",             "Separate",  typeof(ProcessRunner))]


### PR DESCRIPTION
Fixes #386 

As far as I can see - any project must at some point be fed into an AggregatingTestRunner - as this is runner which currently has the knowledge to unpack the project.

In a multiple process situation (via ProcessModel.Default, or ProcessModel.Multiple), projects are fed either directly to an AggregatingProcessRunner, or to the MultipleProcessRunner (incidentally, also not the correct solution - logged as: https://github.com/nunit/nunit-console/issues/382)

This PR fixes the specific issue of running a project a single nunit project under ProcessModel.Single - by ensuring such a project would be passed to the MultipleDomainRunner. (Which inherits from AggregatingTestRunner, and therefore is able to unpack the project TestPackage.) I'd like to merge this as an incremental step - although given #382, and also #439, I think this area may need a more substantial refactor.

The majority of actual code changes here are additional lines of logging, which I thought helpful to leave  in, as this code is also hit in the agent process. The only production code change is in InProcessTestRunnerFactory.