### PR TITLE
Fix #441

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -79,6 +79,8 @@ namespace NUnit.Common
 
         public bool SkipNonTestAssemblies { get; private set; }
 
+        public bool Preload { get; private set; }
+
         private int _maxAgents = -1;
         public int MaxAgents { get { return _maxAgents; } }
         public bool MaxAgentsSpecified { get { return _maxAgents >= 0; } }
@@ -155,6 +157,9 @@ namespace NUnit.Common
 
             this.Add("skipnontestassemblies", "Skip any non-test assemblies specified, without error.",
                 v => SkipNonTestAssemblies = v != null);
+
+            this.Add("preload", "Enumerate all tests before execution.",
+                v => Preload = v != null);
 
             this.Add("agents=", "Specify the maximum {NUMBER} of test assembly agents to run at one time. If not specified, there is no limit.",
                 v => _maxAgents = RequiredInt(v, "--agents"));

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -213,6 +213,8 @@ namespace NUnit.ConsoleRunner
                 {
                     var eventHandler = new TestEventHandler(output, labels);
 
+                    if (_options.Preload)
+                        runner.Load();
                     result = runner.Run(eventHandler, filter);
                 }
             }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -98,7 +98,7 @@ namespace NUnit.Engine.Runners
         public XmlNode Load()
         {
             LoadResult = _engineRunner.Load();
-            return LoadResult.Xml;
+            return LoadResult.IsSingle ? LoadResult.Xml : null;
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a crash bug in MasterTestRunner.Load, and provides an option to load the runner before tests are executed. This fixes issue #441.

The command line option is just one way of doing it, as I don't know what you prefer. There is certainly a change in behavior when preloading like this. It takes longer time before tests start to execute. However, I think the total work being done is the same. We can also just always do it, or create an inverted option.