### PR TITLE
Enable reading source info from Portable and Embedded PDBs on .NET 472

### DIFF
--- a/src/NUnitConsole/nunit3-console/app.config
+++ b/src/NUnitConsole/nunit3-console/app.config
@@ -18,7 +18,10 @@
 
     <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
     <loadFromRemoteSources enabled="true" />
-    
+
+    <!-- Enable reading source information from Portable and Embedded PDBs when running applications -->
+    <!-- built against previous .NET Framework versions on .NET Framework 4.7.2 -->
+    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
   </runtime>
   
 </configuration>

--- a/src/NUnitEngine/nunit-agent/app.config
+++ b/src/NUnitEngine/nunit-agent/app.config
@@ -25,6 +25,9 @@
     <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
     <loadFromRemoteSources enabled="true" />
 
+    <!-- Enable reading source information from Portable and Embedded PDBs when running applications -->
+    <!-- built against previous .NET Framework versions on .NET Framework 4.7.2 -->
+    <AppContextSwitchOverrides value="Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces=false" />
   </runtime>
   
 </configuration>


### PR DESCRIPTION
Fixes #385 

See https://github.com/dotnet/designs/blob/master/accepted/diagnostics/debugging-with-symbols-and-sources.md#stack-traces