### PR TITLE
Update vs-project-loader extension to 3.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.sln.docstates
 *.project.lock.json
+launchSettings.json
 
 # Build results
 

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -37,7 +37,7 @@
       <group>
           <dependency id="nunit-console-runner" version="$version$" />
           <dependency id="nunit-extension-nunit-project-loader" version="3.5.0" />
-          <dependency id="nunit-extension-vs-project-loader" version="3.7.0" />
+          <dependency id="nunit-extension-vs-project-loader" version="3.8.0" />
           <dependency id="nunit-extension-nunit-v2-result-writer" version="3.5.0" />
           <dependency id="nunit-extension-nunit-v2-driver" version="3.6.0" />
           <dependency id="nunit-extension-teamcity-event-listener" version="1.0.3" />

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -31,7 +31,7 @@
       <group>
           <dependency id="NUnit.ConsoleRunner" version="$version$" />
           <dependency id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" />
-          <dependency id="NUnit.Extension.VSProjectLoader" version="3.7.0" />
+          <dependency id="NUnit.Extension.VSProjectLoader" version="3.8.0" />
           <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" />
           <dependency id="NUnit.Extension.NUnitV2Driver" version="3.6.0" />
         <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0.3" />

--- a/nuget/runners/nunit.runners.nuspec
+++ b/nuget/runners/nunit.runners.nuspec
@@ -33,7 +33,7 @@
       <group>
         <dependency id="NUnit.ConsoleRunner" version="$version$" />
         <dependency id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" />
-        <dependency id="NUnit.Extension.VSProjectLoader" version="3.7.0" />
+        <dependency id="NUnit.Extension.VSProjectLoader" version="3.8.0" />
         <dependency id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" />
         <dependency id="NUnit.Extension.NUnitV2Driver" version="3.6.0" />
         <dependency id="NUnit.Extension.TeamCityEventListener" version="1.0.3" />


### PR DESCRIPTION
Update vs-project-loader to 3.8.0. Blocked by https://github.com/nunit/vs-project-loader/issues/29, should be fine to merge once the package has been uploaded to nuget.org

Fixes #450 