### PR TITLE
Remove CF, Silverlight and PORTABLE functionality

### DIFF
--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -30,10 +30,6 @@ using System.Reflection;
 [assembly: AssemblyCompany("NUnit Software")]
 [assembly: AssemblyCopyright("Copyright (c) 2018 Charlie Poole, Rob Prouse")]
 
-#if PORTABLE
-[assembly: AssemblyMetadata("PCL", "True")]
-#endif
-
 #if DEBUG
 #if NET_4_5
 [assembly: AssemblyConfiguration(".NET 4.5 Debug")]
@@ -41,8 +37,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET 4.0 Debug")]
 #elif NET_2_0
 [assembly: AssemblyConfiguration(".NET 2.0 Debug")]
-#elif PORTABLE
-[assembly: AssemblyConfiguration("Portable Debug")]
 #elif NETSTANDARD1_3 || NETSTANDARD1_6 || NETCOREAPP1_0
 [assembly: AssemblyConfiguration(".NET Standard Debug")]
 #else
@@ -55,8 +49,6 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET 4.0")]
 #elif NET_2_0
 [assembly: AssemblyConfiguration(".NET 2.0")]
-#elif PORTABLE
-[assembly: AssemblyConfiguration("Portable")]
 #elif NETSTANDARD1_3 || NETSTANDARD1_6 || NETCOREAPP1_0
 [assembly: AssemblyConfiguration(".NET Standard")]
 #else

--- a/src/NUnitConsole/nunit3-console.tests/DefaultOptionsProviderTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/DefaultOptionsProviderTests.cs
@@ -25,7 +25,6 @@ using System;
 using NUnit.Common;
 using NUnit.Framework;
 
-#if !SILVERLIGHT && !NETCF && !PORTABLE
 namespace NUnit.ConsoleRunner.Tests
 {
     [TestFixture]
@@ -71,4 +70,3 @@ namespace NUnit.ConsoleRunner.Tests
         }
     }
 }
-#endif

--- a/src/NUnitConsole/nunit3-console.tests/OutputSpecificationTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/OutputSpecificationTests.cs
@@ -20,7 +20,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
-#if !PORTABLE
 using System;
 using System.IO;
 using NUnit.Framework;
@@ -140,4 +139,3 @@ namespace NUnit.Common.Tests
         }
     }
 }
-#endif

--- a/src/NUnitConsole/nunit3-console/Options.cs
+++ b/src/NUnitConsole/nunit3-console/Options.cs
@@ -357,29 +357,18 @@ namespace NUnit.Options
         protected static T Parse<T> (string value, OptionContext c)
         {
             Type tt = typeof (T);
-#if PORTABLE
-            bool nullable = tt.GetTypeInfo().IsValueType && tt.GetTypeInfo().IsGenericType &&
-                !tt.GetTypeInfo().IsGenericTypeDefinition &&
-                tt.GetGenericTypeDefinition () == typeof (Nullable<>);
-            Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
-#else
+
             bool nullable = tt.IsValueType && tt.IsGenericType &&
                 !tt.IsGenericTypeDefinition &&
                 tt.GetGenericTypeDefinition () == typeof (Nullable<>);
             Type targetType = nullable ? tt.GetGenericArguments () [0] : typeof (T);
-#endif
 
-#if !NETCF && !SILVERLIGHT && !PORTABLE
             TypeConverter conv = TypeDescriptor.GetConverter (targetType);
-#endif
+
             T t = default (T);
             try {
                 if (value != null)
-#if NETCF || SILVERLIGHT || PORTABLE
-                    t = (T)Convert.ChangeType(value, tt, CultureInfo.InvariantCulture);
-#else
                     t = (T) conv.ConvertFromString (value);
-#endif
             }
             catch (Exception e) {
                 throw new OptionException (
@@ -508,33 +497,28 @@ namespace NUnit.Options
             this.option = optionName;
         }
 
-#if !NETCF && !SILVERLIGHT && !PORTABLE
         protected OptionException (SerializationInfo info, StreamingContext context)
             : base (info, context)
         {
             this.option = info.GetString ("OptionName");
         }
-#endif
 
         public string OptionName {
             get {return this.option;}
         }
 
-#if !NETCF && !SILVERLIGHT && !PORTABLE
         [SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
         public override void GetObjectData (SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData (info, context);
             info.AddValue ("OptionName", option);
         }
-#endif
     }
 
     public delegate void OptionAction<TKey, TValue> (TKey key, TValue value);
 
     public class OptionSet : KeyedCollection<string, Option>
     {
-#if !PORTABLE
         public OptionSet ()
             : this (delegate (string f) {return f;})
         {
@@ -550,17 +534,6 @@ namespace NUnit.Options
         public Converter<string, string> MessageLocalizer {
             get {return localizer;}
         }
-#else
-        string localizer(string msg)
-        {
-            return msg;
-        }
-
-        public string MessageLocalizer(string msg)
-        {
-            return msg;
-        }
-#endif
 
         protected override string GetKeyForItem (Option item)
         {

--- a/src/NUnitConsole/nunit3-console/Options.cs
+++ b/src/NUnitConsole/nunit3-console/Options.cs
@@ -122,10 +122,6 @@
 //      p.Parse (new string[]{"-a+"});  // sets v != null
 //      p.Parse (new string[]{"-a-"});  // sets v == null
 //
-// The NUnit version of this file introduces conditional compilation for
-// building under the Compact Framework (NETCF) and Silverlight (SILVERLIGHT)
-// as well as for use with a portable class library  (PORTABLE).
-//
 // 11/5/2015 -
 // Change namespace to avoid conflict with user code use of mono.options
 
@@ -144,11 +140,7 @@ using System.Text.RegularExpressions;
 // Missing XML Docs
 #pragma warning disable 1591
 
-#if PORTABLE
-using NUnit.Compatibility;
-#else
 using System.Security.Permissions;
-#endif
 
 #if LINQ
 using System.Linq;
@@ -474,9 +466,7 @@ namespace NUnit.Options
         }
     }
 
-#if !PORTABLE
     [Serializable]
-#endif
     public class OptionException : Exception
     {
         private string option;

--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -33,9 +33,7 @@ namespace NUnit.Engine.Tests
         static RuntimeType currentRuntime =
             Type.GetType("Mono.Runtime", false) != null
                 ? RuntimeType.Mono
-                : Environment.OSVersion.Platform == PlatformID.WinCE
-                    ? RuntimeType.NetCF
-                    : RuntimeType.Net;
+                : RuntimeType.Net;
 
         [Test]
         public void CanGetCurrentFramework()

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -154,12 +154,6 @@ namespace NUnit.Engine
                                 break;
                         }
                         break;
-
-                    case RuntimeType.Silverlight:
-                        this.ClrVersion = version.Major >= 4
-                            ? new Version(4, 0, 60310)
-                            : new Version(2, 0, 50727);
-                        break;
                 }
         }
 
@@ -195,9 +189,7 @@ namespace NUnit.Engine
 
                     RuntimeType runtime = isMono
                         ? RuntimeType.Mono
-                        : Environment.OSVersion.Platform == PlatformID.WinCE
-                            ? RuntimeType.NetCF
-                            : RuntimeType.Net;
+                        : RuntimeType.Net;
 
                     int major = Environment.Version.Major;
                     int minor = Environment.Version.Minor;

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -271,7 +271,6 @@ namespace NUnit.Engine
         /// <summary>
         /// Gets an array of all available frameworks
         /// </summary>
-        // TODO: Special handling for netcf
         public static RuntimeFramework[] AvailableFrameworks
         {
             get

--- a/src/NUnitEngine/nunit.engine/RuntimeType.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeType.cs
@@ -10,11 +10,7 @@
         Any,
         /// <summary>Microsoft .NET Framework</summary>
         Net,
-        /// <summary>Microsoft .NET Compact Framework</summary>
-        NetCF,
         /// <summary>Mono</summary>
-        Mono,
-        /// <summary>Silverlight</summary>
-        Silverlight
+        Mono
     }
 }


### PR DESCRIPTION
Relates to #406, fixes #103. 

Runtime Framework code still blows my mind a little...this is a baby step towards simplifying things. I believe these items are remnants of when this code was shared with the framework.