### PR TITLE
Use MSBuild /restore

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,14 +15,14 @@ See also [Building and testing for Linux on a Windows machine](#building-and-tes
 
 ## Prerequisites
 
-- Visual Studio 2017 to build on Windows
+- Visual Studio 2017 Update 5 or newer to build on Windows
 - .NET 4.5+ or Mono 5.10.0+
 - .NET Core 1.1.6 or newer
 
 ## Solution Build
 
 All projects are built together using a single Visual Studio solution NUnitConsole.sln, which may be
-built with Visual Studio 2017+ or on the command line using Cake. The projects all place their output in
+built with Visual Studio or on the command line using Cake. The projects all place their output in
 a common bin directory.
 
 ## Build Script

--- a/build.cake
+++ b/build.cake
@@ -148,7 +148,9 @@ MSBuildSettings CreateMSBuildSettings(string target) => new MSBuildSettings()
     .SetConfiguration(configuration)
     .SetVerbosity(Verbosity.Minimal)
     .WithProperty("PackageVersion", productVersion)
-    .WithTarget(target);
+    .WithTarget(target)
+    // Workaround for https://github.com/Microsoft/msbuild/issues/3626
+    .WithProperty("AddSyntheticProjectReferencesForSolutionDependencies", "false");
 
 Task("BuildNetFramework")
     .Description("Builds the .NET Framework version of the engine and console")

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.26.1" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
Simplifies by using MSBuild's `/restore` parameter (Cake 0.27's `WithRestore()`) which runs the Restore target in its own MSBuild context before running the specified target.

(Been around for nearly a year: `https://github.com/Microsoft/msbuild/pull/2414`)