### PR TITLE
Add datetime of run to header

### DIFF
--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -175,6 +176,7 @@ namespace NUnit.ConsoleRunner
 
             OutWriter.WriteLine(ColorStyle.Header, header);
             OutWriter.WriteLine(ColorStyle.SubHeader, versionBlock.LegalCopyright);
+            OutWriter.WriteLine(ColorStyle.SubHeader, DateTime.Now.ToString(CultureInfo.CurrentCulture.DateTimeFormat.FullDateTimePattern));
             OutWriter.WriteLine();
         }
 


### PR DESCRIPTION
Fixes #178

Adds localized time to the console runner header. The format of the datetime is using the current culture's full datetime pattern.