### PR TITLE
Format error message when invalidating integer-valued arguments

### DIFF
--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -235,7 +235,7 @@ namespace NUnit.Common
                 }
                 catch (Exception)
                 {
-                    ErrorMessages.Add("An int value was expected for option '{0}' but a value of '{1}' was used");
+                    ErrorMessages.Add(String.Format("An int value was expected for option '{0}' but a value of '{1}' was used", option, val));
                 }
             }
 


### PR DESCRIPTION
Fixes #485 

Provide more information in error message when invalid values are passed into integer-valued arguments.

```
PS > .\bin\Debug\net35\nunit3-console.exe .\bin\Debug\net35\nunit3-console.tests.dll --workers j -noh
An int value was expected for option '--workers' but a value of 'j' was used
```