### PR TITLE
Report failures in testfixture teardowns as failures

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -103,7 +103,7 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new[] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 5, Warnings: 1, Inconclusive: 1, Skipped: 7",
+               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 7, Warnings: 1, Inconclusive: 1, Skipped: 7",
                 "    Failed Tests - Failures: 1, Errors: 1, Invalid: 3",
                 "    Skipped Tests - Ignored: 4, Explicit: 3, Other: 0",
                 "  Start time: 2015-10-19 02:12:28Z",

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -258,7 +258,7 @@ namespace NUnit.ConsoleRunner
 
                 return reporter.Summary.InvalidTestFixtures > 0
                     ? ConsoleRunner.INVALID_TEST_FIXTURE
-                    : reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount;
+                    : reporter.Summary.FailureCount + reporter.Summary.ErrorCount + reporter.Summary.InvalidCount + reporter.Summary.FailureInFixtureTearDown;
             }
 
             // If we got here, it's because we had an exception, but check anyway

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -74,11 +74,11 @@ namespace NUnit.ConsoleRunner
         }
 
         /// <summary>
-        /// Returns the number of failed test cases (including errors and invalid tests)
+        /// Returns the number of failed test cases (including errors, invalid tests, and failures in fixture teardowns)
         /// </summary>
         public int FailedCount
         {
-            get { return FailureCount + InvalidCount + ErrorCount;  }
+            get { return FailureCount + InvalidCount + ErrorCount + FailureInFixtureTearDown;  }
         }
 
         public int WarningCount { get; private set; }
@@ -148,6 +148,11 @@ namespace NUnit.ConsoleRunner
         /// </summary>
         public int InvalidTestFixtures { get; private set; }
 
+        /// <summary>
+        /// Gets the count of failures in test fixture teardowns (e.g. OneTimeTearDown, Dispose)
+        /// </summary>
+        public int FailureInFixtureTearDown { get; private set; }
+
         #endregion
 
         #region Helper Methods
@@ -165,6 +170,7 @@ namespace NUnit.ConsoleRunner
             ExplicitCount = 0;
             InvalidCount = 0;
             InvalidAssemblies = 0;
+            FailureInFixtureTearDown = 0;
         }
 
         private void Summarize(XmlNode node)
@@ -172,6 +178,7 @@ namespace NUnit.ConsoleRunner
             string type = node.GetAttribute("type");
             string status = node.GetAttribute("result");
             string label = node.GetAttribute("label");
+            string site = node.GetAttribute("site");
 
             switch (node.Name)
             {
@@ -221,6 +228,10 @@ namespace NUnit.ConsoleRunner
                     {
                         InvalidAssemblies++;
                         UnexpectedError = true;
+                    }
+                    if ((type == "SetUpFixture" || type == "TestFixture") && status == "Failed" && label == "Error" && site == "TearDown")
+                    {
+                        FailureInFixtureTearDown++;
                     }
 
                     Summarize(node.ChildNodes);

--- a/src/NUnitEngine/mock-assembly/MockAssembly.cs
+++ b/src/NUnitEngine/mock-assembly/MockAssembly.cs
@@ -57,7 +57,9 @@ namespace NUnit.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
                         + GenericFixtureConstants.Tests
-                        + AccessesCurrentTestContextDuringDiscovery.Tests;
+                        + AccessesCurrentTestContextDuringDiscovery.Tests
+                        + FixtureWithDispose.Tests
+                        + FixtureWithOneTimeTearDown.Tests;
 
             public const int Suites = MockTestFixture.Suites
                         + Singletons.OneTestCase.Suites
@@ -69,7 +71,9 @@ namespace NUnit.Tests
                         + ParameterizedFixture.Suites
                         + GenericFixtureConstants.Suites
                         + AccessesCurrentTestContextDuringDiscovery.Suites
-                        + NamespaceSuites;
+                        + NamespaceSuites
+                        + FixtureWithDispose.Suites
+                        + FixtureWithOneTimeTearDown.Suites;
 
             public const int TestStartedEvents = Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests;
             public const int TestFinishedEvents = Tests;
@@ -87,7 +91,9 @@ namespace NUnit.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
                         + GenericFixtureConstants.Tests
-                        + AccessesCurrentTestContextDuringDiscovery.Tests;
+                        + AccessesCurrentTestContextDuringDiscovery.Tests
+                        + FixtureWithDispose.Tests
+                        + FixtureWithOneTimeTearDown.Tests;
 
             public const int Skipped_Ignored = MockTestFixture.Skipped_Ignored + IgnoredFixture.Tests;
             public const int Skipped_Explicit = MockTestFixture.Skipped_Explicit + ExplicitFixture.Tests;
@@ -302,5 +308,36 @@ namespace NUnit.Tests
         
         [Test]
         public void Test2() { }
+    }
+
+    [TestFixture]
+    public class FixtureWithDispose : IDisposable
+    {
+        public const int Suites = 1;
+        public const int Tests = 1;
+
+        [Test]
+        public void Test() { }
+
+        public void Dispose()
+        {
+            throw new Exception("Exception in Dispose");
+        }
+    }
+
+    [TestFixture]
+    public class FixtureWithOneTimeTearDown
+    {
+        public const int Suites = 1;
+        public const int Tests = 1;
+
+        [Test]
+        public void Test() { }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            throw new Exception("Exception in OneTimeTearDown");
+        }
     }
 }


### PR DESCRIPTION
Failures in testfixture teardowns (e.g. failures in OneTimeTearDown
or Dispose) are now reported as failures, meaning that they will
affect the number of failures shown in the output of the console and
also affect the exit code of the console.

Fixes #483, fixes #464, and fixes #282.