### PR TITLE
Report failures in testfixture teardowns as failures

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -103,8 +103,8 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new[] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 9, Warnings: 1, Inconclusive: 1, Skipped: 7",
-                "    Failed Tests - Failures: 5, Errors: 1, Invalid: 3",
+               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 11, Warnings: 1, Inconclusive: 1, Skipped: 7",
+                "    Failed Tests - Failures: 1, Errors: 7, Invalid: 3",
                 "    Skipped Tests - Ignored: 4, Explicit: 3, Other: 0",
                 "  Start time: 2015-10-19 02:12:28Z",
                 "    End time: 2015-10-19 02:12:29Z",

--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -103,8 +103,8 @@ namespace NUnit.ConsoleRunner.Tests
             var expected = new[] {
                 "Test Run Summary",
                 "  Overall result: Failed",
-               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 5, Warnings: 1, Inconclusive: 1, Skipped: 7",
-                "    Failed Tests - Failures: 1, Errors: 1, Invalid: 3",
+               $"  Test Count: {MockAssembly.Tests}, Passed: {MockAssembly.Passed}, Failed: 9, Warnings: 1, Inconclusive: 1, Skipped: 7",
+                "    Failed Tests - Failures: 5, Errors: 1, Invalid: 3",
                 "    Skipped Tests - Ignored: 4, Explicit: 3, Other: 0",
                 "  Start time: 2015-10-19 02:12:28Z",
                 "    End time: 2015-10-19 02:12:29Z",

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -183,12 +183,14 @@ namespace NUnit.ConsoleRunner
                     {
                         case "Passed":
                             if (failedInFixtureTearDown)
-                                FailureCount++;
+                                ErrorCount++;
                             else
                                 PassCount++;
                             break;
                         case "Failed":
-                            if (label == null || failedInFixtureTearDown)
+                            if (failedInFixtureTearDown)
+                                ErrorCount++;
+                            else if (label == null)
                                 FailureCount++;
                             else if (label == "Invalid")
                                 InvalidCount++;
@@ -197,13 +199,13 @@ namespace NUnit.ConsoleRunner
                             break;
                         case "Warning":
                             if (failedInFixtureTearDown)
-                                FailureCount++;
+                                ErrorCount++;
                             else
                                 WarningCount++;
                             break;
                         case "Inconclusive":
                             if (failedInFixtureTearDown)
-                                FailureCount++;
+                                ErrorCount++;
                             else
                                 InconclusiveCount++;
                             break;

--- a/src/NUnitEngine/mock-assembly/MockAssembly.cs
+++ b/src/NUnitEngine/mock-assembly/MockAssembly.cs
@@ -59,7 +59,8 @@ namespace NUnit.Tests
                         + GenericFixtureConstants.Tests
                         + AccessesCurrentTestContextDuringDiscovery.Tests
                         + FixtureWithDispose.Tests
-                        + FixtureWithOneTimeTearDown.Tests;
+                        + FixtureWithOneTimeTearDown.Tests
+                        + TestSetUpFixture.SetUpFixture.TestsInNamespace;
 
             public const int Suites = MockTestFixture.Suites
                         + Singletons.OneTestCase.Suites
@@ -93,7 +94,10 @@ namespace NUnit.Tests
                         + GenericFixtureConstants.Tests
                         + AccessesCurrentTestContextDuringDiscovery.Tests;
 
-            public const int PassedInAttribute = Passed + FixtureWithDispose.Tests + FixtureWithOneTimeTearDown.Tests;
+            public const int PassedInAttribute = Passed
+                        + FixtureWithDispose.Tests
+                        + FixtureWithOneTimeTearDown.Tests
+                        + TestSetUpFixture.SetUpFixture.TestsInNamespace;
 
             public const int Skipped_Ignored = MockTestFixture.Skipped_Ignored + IgnoredFixture.Tests;
             public const int Skipped_Explicit = MockTestFixture.Skipped_Explicit + ExplicitFixture.Tests;
@@ -344,6 +348,36 @@ namespace NUnit.Tests
         public void OneTimeTearDown()
         {
             throw new Exception("Exception in OneTimeTearDown");
+        }
+    }
+
+    namespace TestSetUpFixture
+    {
+        [SetUpFixture]
+        public class SetUpFixture
+        {
+            public const int SuitesInNamespace = 2;
+            public const int TestsInNamespace = 2;
+
+            [OneTimeTearDown]
+            public void OneTimeTearDown()
+            {
+                throw new Exception("Exception in SetUpFixture.OneTimeTearDown");
+            }
+        }
+
+        [TestFixture]
+        public class Fixture1
+        {
+            [Test]
+            public void Test1() { }
+        }
+
+        [TestFixture]
+        public class Fixture2
+        {
+            [Test]
+            public void Test1() { }
         }
     }
 }

--- a/src/NUnitEngine/mock-assembly/MockAssembly.cs
+++ b/src/NUnitEngine/mock-assembly/MockAssembly.cs
@@ -57,7 +57,9 @@ namespace NUnit.Tests
                         + FixtureWithTestCases.Tests
                         + ParameterizedFixture.Tests
                         + GenericFixtureConstants.Tests
-                        + AccessesCurrentTestContextDuringDiscovery.Tests;
+                        + AccessesCurrentTestContextDuringDiscovery.Tests
+                        + FixtureWithDispose.Tests
+                        + FixtureWithOneTimeTearDown.Tests;
 
             public const int Suites = MockTestFixture.Suites
                         + Singletons.OneTestCase.Suites
@@ -69,7 +71,9 @@ namespace NUnit.Tests
                         + ParameterizedFixture.Suites
                         + GenericFixtureConstants.Suites
                         + AccessesCurrentTestContextDuringDiscovery.Suites
-                        + NamespaceSuites;
+                        + NamespaceSuites
+                        + FixtureWithDispose.Suites
+                        + FixtureWithOneTimeTearDown.Suites;
 
             public const int TestStartedEvents = Tests - IgnoredFixture.Tests - BadFixture.Tests - ExplicitFixture.Tests;
             public const int TestFinishedEvents = Tests;
@@ -88,6 +92,8 @@ namespace NUnit.Tests
                         + ParameterizedFixture.Tests
                         + GenericFixtureConstants.Tests
                         + AccessesCurrentTestContextDuringDiscovery.Tests;
+
+            public const int PassedInAttribute = Passed + FixtureWithDispose.Tests + FixtureWithOneTimeTearDown.Tests;
 
             public const int Skipped_Ignored = MockTestFixture.Skipped_Ignored + IgnoredFixture.Tests;
             public const int Skipped_Explicit = MockTestFixture.Skipped_Explicit + ExplicitFixture.Tests;
@@ -302,5 +308,42 @@ namespace NUnit.Tests
         
         [Test]
         public void Test2() { }
+    }
+
+    [TestFixture]
+    public class FixtureWithDispose : IDisposable
+    {
+        public const int Suites = 1;
+        public const int Tests = 2;
+
+        [Test]
+        public void Test1() { }
+
+        [Test]
+        public void Test2() { }
+
+        public void Dispose()
+        {
+            throw new Exception("Exception in Dispose");
+        }
+    }
+
+    [TestFixture]
+    public class FixtureWithOneTimeTearDown
+    {
+        public const int Suites = 1;
+        public const int Tests = 2;
+
+        [Test]
+        public void Test1() { }
+
+        [Test]
+        public void Test2() { }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            throw new Exception("Exception in OneTimeTearDown");
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests.netstandard/Drivers/NUnitNetStandardDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests.netstandard/Drivers/NUnitNetStandardDriverTests.cs
@@ -131,7 +131,7 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(result.GetAttribute("runstate"), Is.EqualTo("Runnable"));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("passed"), Is.EqualTo(MockAssembly.Passed.ToString()));
+            Assert.That(result.GetAttribute("passed"), Is.EqualTo(MockAssembly.PassedInAttribute.ToString()));
             Assert.That(result.GetAttribute("failed"), Is.EqualTo(MockAssembly.Failed.ToString()));
             Assert.That(result.GetAttribute("skipped"), Is.EqualTo(MockAssembly.Skipped.ToString()));
             Assert.That(result.GetAttribute("inconclusive"), Is.EqualTo(MockAssembly.Inconclusive.ToString()));

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -137,7 +137,7 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(result.GetAttribute("runstate"), Is.EqualTo("Runnable"));
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("passed"), Is.EqualTo(MockAssembly.Passed.ToString()));
+            Assert.That(result.GetAttribute("passed"), Is.EqualTo(MockAssembly.PassedInAttribute.ToString()));
             Assert.That(result.GetAttribute("failed"), Is.EqualTo(MockAssembly.Failed.ToString()));
             Assert.That(result.GetAttribute("skipped"), Is.EqualTo(MockAssembly.Skipped.ToString()));
             Assert.That(result.GetAttribute("inconclusive"), Is.EqualTo(MockAssembly.Inconclusive.ToString()));

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -132,7 +132,7 @@ namespace NUnit.Engine.Runners.Tests
             Assert.That(result.Name, Is.EqualTo("test-run"));
             Assert.That(result.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Passed));
+            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.PassedInAttribute));
             Assert.That(result.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.Failed));
             Assert.That(result.GetAttribute("skipped", 0), Is.EqualTo(MockAssembly.Skipped));
             Assert.That(result.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));
@@ -141,7 +141,7 @@ namespace NUnit.Engine.Runners.Tests
             Assert.NotNull("No suite found");
             Assert.That(suite.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(suite.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(suite.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Passed));
+            Assert.That(suite.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.PassedInAttribute));
             Assert.That(suite.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.Failed));
             Assert.That(suite.GetAttribute("skipped", 0), Is.EqualTo(MockAssembly.Skipped));
             Assert.That(suite.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -174,7 +174,7 @@ namespace NUnit.Engine.Runners.Tests
         private void CheckRunResult(XmlNode result)
         {
             CheckBasicResult(result);
-            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.Passed));
+            Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.PassedInAttribute));
             Assert.That(result.GetAttribute("failed", 0), Is.EqualTo(MockAssembly.Failed));
             Assert.That(result.GetAttribute("skipped", 0), Is.EqualTo(MockAssembly.Skipped));
             Assert.That(result.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));


### PR DESCRIPTION
Failures in testfixture teardowns (e.g. failures in OneTimeTearDown
or Dispose) are now reported as failures, meaning that they will
affect the number of failures shown in the output of the console and
also affect the exit code of the console.

Fixes #483, fixes #464, and fixes #282.

Relates to #494