### PR TITLE
Add NUnit.Analyzers package 

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <add key="NUnit AppVeyor CI" value="https://ci.appveyor.com/nuget/nunit" />
     <add key="NUnit MyGet Feed" value="https://www.myget.org/F/nunit/api/v3/index.json" />
+    <add key="NUnit Analyzers MyGet Feed" value="https://www.myget.org/F/nunit-analyzers/api/v3/index.json" protocolVersion="3" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -159,7 +159,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void NoInputFiles()
         {
             ConsoleOptions options = new ConsoleOptions();
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(0, options.InputFiles.Count);
         }
 
@@ -238,7 +238,7 @@ namespace NUnit.ConsoleRunner.Tests
                 {
                     string optionPlusValue = string.Format("--{0}:{1}", option, value);
                     ConsoleOptions options = new ConsoleOptions(optionPlusValue);
-                    Assert.True(options.Validate(), "Should be valid: " + optionPlusValue);
+                    Assert.That(options.Validate(), Is.True, "Should be valid: " + optionPlusValue);
                     Assert.AreEqual(value, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
                 }
 
@@ -255,7 +255,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void CanRecognizeInProcessOption()
         {
             ConsoleOptions options = new ConsoleOptions("--inprocess");
-            Assert.True(options.Validate(), "Should be valid: --inprocess");
+            Assert.That(options.Validate(), Is.True, "Should be valid: --inprocess");
             Assert.AreEqual("InProcess", options.ProcessModel, "Didn't recognize --inprocess");
         }
 
@@ -273,7 +273,7 @@ namespace NUnit.ConsoleRunner.Tests
                 string lowercaseValue = canonicalValue.ToLowerInvariant();
                 string optionPlusValue = string.Format("--{0}:{1}", optionName, lowercaseValue);
                 ConsoleOptions options = new ConsoleOptions(optionPlusValue);
-                Assert.True(options.Validate(), "Should be valid: " + optionPlusValue);
+                Assert.That(options.Validate(), Is.True, "Should be valid: " + optionPlusValue);
                 Assert.AreEqual(canonicalValue, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
             }
         }
@@ -341,7 +341,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void AssemblyName()
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count);
             Assert.AreEqual("nunit.tests.dll", options.InputFiles[0]);
         }
@@ -359,7 +359,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void AssemblyAloneIsValid()
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
         }
 
@@ -367,7 +367,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void X86AndInProcessAreCompatibleIn32BitProcess()
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
         }
 
@@ -414,7 +414,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void TimeoutIsMinusOneIfNoOptionIsProvided()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(-1, options.DefaultTimeout);
         }
 
@@ -428,7 +428,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void TimeoutParsesIntValueCorrectly()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-timeout:5000");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(5000, options.DefaultTimeout);
         }
 
@@ -448,7 +448,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void ResultOptionWithFilePath()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
 
@@ -462,7 +462,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void ResultOptionWithFilePathAndFormat()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml;format=nunit2");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
 
@@ -482,7 +482,7 @@ namespace NUnit.ConsoleRunner.Tests
                 new DefaultOptionsProviderStub(false),
                 fileSystem,
                 "tests.dll", $"-result:results.xml;transform={transformFile}");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
 
@@ -497,7 +497,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void FileNameWithoutResultOptionLooksLikeParameter()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "results.xml");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(0, options.ErrorMessages.Count);
             Assert.AreEqual(2, options.InputFiles.Count);
         }
@@ -520,7 +520,7 @@ namespace NUnit.ConsoleRunner.Tests
                 new DefaultOptionsProviderStub(false),
                 fileSystem,
                 "tests.dll", "-result:results.xml", "-result:nunit2results.xml;format=nunit2", $"-result:myresult.xml;transform={transformFile}");
-            Assert.True(options.Validate(), "Should be valid");
+            Assert.That(options.Validate(), Is.True, "Should be valid");
 
             var specs = options.ResultOutputSpecifications;
             Assert.AreEqual(3, specs.Count);
@@ -599,18 +599,18 @@ namespace NUnit.ConsoleRunner.Tests
         public void ExploreOptionWithoutPath()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore");
-            Assert.True(options.Validate());
-            Assert.True(options.Explore);
+            Assert.That(options.Validate(), Is.True);
+            Assert.That(options.Explore, Is.True);
         }
 
         [Test]
         public void ExploreOptionWithFilePath()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
-            Assert.True(options.Explore);
+            Assert.That(options.Explore, Is.True);
 
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
@@ -622,10 +622,10 @@ namespace NUnit.ConsoleRunner.Tests
         public void ExploreOptionWithFilePathAndFormat()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml;format=cases");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
-            Assert.True(options.Explore);
+            Assert.That(options.Explore, Is.True);
 
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
@@ -642,10 +642,10 @@ namespace NUnit.ConsoleRunner.Tests
                 new DefaultOptionsProviderStub(false),
                 fileSystem,
                 "tests.dll", $"-explore:results.xml;transform={transformFile}");
-            Assert.True(options.Validate());
+            Assert.That(options.Validate(), Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
-            Assert.True(options.Explore);
+            Assert.That(options.Explore, Is.True);
 
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
             Assert.AreEqual("results.xml", spec.OutputPath);
@@ -658,8 +658,8 @@ namespace NUnit.ConsoleRunner.Tests
         public void ExploreOptionWithFilePathUsingEqualSign()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore=C:/nunit/tests/bin/Debug/console-test.xml");
-            Assert.True(options.Validate());
-            Assert.True(options.Explore);
+            Assert.That(options.Validate(), Is.True);
+            Assert.That(options.Explore, Is.True);
             Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
             Assert.AreEqual("tests.dll", options.InputFiles[0]);
             Assert.AreEqual("C:/nunit/tests/bin/Debug/console-test.xml", options.ExploreOutputSpecifications[0].OutputPath);

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -246,7 +246,7 @@ namespace NUnit.ConsoleRunner.Tests
                 {
                     string optionPlusValue = string.Format("--{0}:{1}", option, value);
                     ConsoleOptions options = new ConsoleOptions(optionPlusValue);
-                    Assert.False(options.Validate(), "Should not be valid: " + optionPlusValue);
+                    Assert.That(options.Validate(), Is.False, "Should not be valid: " + optionPlusValue);
                 }
             }
         }
@@ -333,7 +333,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void MissingValuesAreReported(string option)
         {
             ConsoleOptions options = new ConsoleOptions(option + "=");
-            Assert.False(options.Validate(), "Missing value should not be valid");
+            Assert.That(options.Validate(), Is.False, "Missing value should not be valid");
             Assert.AreEqual("Missing required value for option '" + option + "'.", options.ErrorMessages[0]);
         }
 
@@ -375,7 +375,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void X86AndInProcessAreNotCompatibleIn64BitProcess()
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
-            Assert.False(options.Validate(), "Should be invalid");
+            Assert.That(options.Validate(), Is.False, "Should be invalid");
             Assert.AreEqual("The --x86 and --inprocess options are incompatible.", options.ErrorMessages[0]);
         }
 
@@ -383,7 +383,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void InvalidOption()
         {
             ConsoleOptions options = new ConsoleOptions("-assembly:nunit.tests.dll");
-            Assert.False(options.Validate());
+            Assert.That(options.Validate(), Is.False);
             Assert.AreEqual(1, options.ErrorMessages.Count);
             Assert.AreEqual("Invalid argument: -assembly:nunit.tests.dll", options.ErrorMessages[0]);
         }
@@ -400,7 +400,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void InvalidCommandLineParms()
         {
             ConsoleOptions options = new ConsoleOptions("-garbage:TestFixture", "-assembly:Tests.dll");
-            Assert.False(options.Validate());
+            Assert.That(options.Validate(), Is.False);
             Assert.AreEqual(2, options.ErrorMessages.Count);
             Assert.AreEqual("Invalid argument: -garbage:TestFixture", options.ErrorMessages[0]);
             Assert.AreEqual("Invalid argument: -assembly:Tests.dll", options.ErrorMessages[1]);
@@ -436,7 +436,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void TimeoutCausesErrorIfValueIsNotInteger()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-timeout:abc");
-            Assert.False(options.Validate());
+            Assert.That(options.Validate(), Is.False);
             Assert.AreEqual(-1, options.DefaultTimeout);
         }
 
@@ -506,7 +506,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void ResultOptionWithoutFileNameIsInvalid()
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:");
-            Assert.False(options.Validate(), "Should not be valid");
+            Assert.That(options.Validate(), Is.False, "Should not be valid");
             Assert.AreEqual(1, options.ErrorMessages.Count, "An error was expected");
         }
 

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -66,7 +66,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             var actualArgs = ConsoleOptions.GetArgs(cmdline);
 
-            Assert.AreEqual(expectedArgs, actualArgs);
+            Assert.That(actualArgs, Is.EqualTo(expectedArgs));
         }
 
         [TestCase("--arg1 @file1.txt --arg2", "file1.txt:--filearg1 --filearg2", "--arg1", "--filearg1", "--filearg2", "--arg2")]
@@ -121,7 +121,7 @@ namespace NUnit.ConsoleRunner.Tests
             var expandedArgs = options.PreParse(commandline.Split(' '));
 
             // Then
-            Assert.AreEqual(expectedArgs, expandedArgs);
+            Assert.That(expandedArgs, Is.EqualTo(expectedArgs));
             Assert.IsEmpty(options.ErrorMessages);
         }
 
@@ -147,8 +147,8 @@ namespace NUnit.ConsoleRunner.Tests
 
             var arglist = options.PreParse(lines);
 
-            Assert.AreEqual(lines, arglist);
-            Assert.AreEqual(expectedErrors, options.ErrorMessages);
+            Assert.That(arglist, Is.EqualTo(lines));
+            Assert.That(options.ErrorMessages, Is.EqualTo(expectedErrors));
         }
 
         #endregion
@@ -160,7 +160,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions();
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(0, options.InputFiles.Count);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(0));
         }
 
         [TestCase("ShowHelp", "help|h")]
@@ -184,7 +184,7 @@ namespace NUnit.ConsoleRunner.Tests
             string[] prototypes = pattern.Split('|');
 
             PropertyInfo property = GetPropertyInfo(propertyName);
-            Assert.AreEqual(typeof(bool), property.PropertyType, "Property '{0}' is wrong type", propertyName);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(bool)), "Property '{0}' is wrong type", propertyName);
 
             foreach (string option in prototypes)
             {
@@ -193,22 +193,22 @@ namespace NUnit.ConsoleRunner.Tests
                 if (option.Length == 1)
                 {
                     options = new ConsoleOptions("-" + option);
-                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option);
+                    Assert.That((bool)property.GetValue(options, null), Is.EqualTo(true), "Didn't recognize -" + option);
 
                     options = new ConsoleOptions("-" + option + "+");
-                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "+");
+                    Assert.That((bool)property.GetValue(options, null), Is.EqualTo(true), "Didn't recognize -" + option + "+");
 
                     options = new ConsoleOptions("-" + option + "-");
-                    Assert.AreEqual(false, (bool)property.GetValue(options, null), "Didn't recognize -" + option + "-");
+                    Assert.That((bool)property.GetValue(options, null), Is.EqualTo(false), "Didn't recognize -" + option + "-");
                 }
                 else
                 {
                     options = new ConsoleOptions("--" + option);
-                    Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize --" + option);
+                    Assert.That((bool)property.GetValue(options, null), Is.EqualTo(true), "Didn't recognize --" + option);
                 }
 
                 options = new ConsoleOptions("/" + option);
-                Assert.AreEqual(true, (bool)property.GetValue(options, null), "Didn't recognize /" + option);
+                Assert.That((bool)property.GetValue(options, null), Is.EqualTo(true), "Didn't recognize /" + option);
             }
         }
 
@@ -230,7 +230,7 @@ namespace NUnit.ConsoleRunner.Tests
             string[] prototypes = pattern.Split('|');
 
             PropertyInfo property = GetPropertyInfo(propertyName);
-            Assert.AreEqual(typeof(string), property.PropertyType);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(string)));
 
             foreach (string option in prototypes)
             {
@@ -239,7 +239,7 @@ namespace NUnit.ConsoleRunner.Tests
                     string optionPlusValue = string.Format("--{0}:{1}", option, value);
                     ConsoleOptions options = new ConsoleOptions(optionPlusValue);
                     Assert.That(options.Validate(), Is.True, "Should be valid: " + optionPlusValue);
-                    Assert.AreEqual(value, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
+                    Assert.That((string)property.GetValue(options, null), Is.EqualTo(value), "Didn't recognize " + optionPlusValue);
                 }
 
                 foreach (string value in badValues)
@@ -256,7 +256,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("--inprocess");
             Assert.That(options.Validate(), Is.True, "Should be valid: --inprocess");
-            Assert.AreEqual("InProcess", options.ProcessModel, "Didn't recognize --inprocess");
+            Assert.That(options.ProcessModel, Is.EqualTo("InProcess"), "Didn't recognize --inprocess");
         }
 
         [TestCase("ProcessModel", "process", new string[] { "InProcess", "Separate", "Multiple" })]
@@ -266,7 +266,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void CanRecognizeLowerCaseOptionValues(string propertyName, string optionName, string[] canonicalValues)
         {
             PropertyInfo property = GetPropertyInfo(propertyName);
-            Assert.AreEqual(typeof(string), property.PropertyType);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(string)));
 
             foreach (string canonicalValue in canonicalValues)
             {
@@ -274,7 +274,7 @@ namespace NUnit.ConsoleRunner.Tests
                 string optionPlusValue = string.Format("--{0}:{1}", optionName, lowercaseValue);
                 ConsoleOptions options = new ConsoleOptions(optionPlusValue);
                 Assert.That(options.Validate(), Is.True, "Should be valid: " + optionPlusValue);
-                Assert.AreEqual(canonicalValue, (string)property.GetValue(options, null), "Didn't recognize " + optionPlusValue);
+                Assert.That((string)property.GetValue(options, null), Is.EqualTo(canonicalValue), "Didn't recognize " + optionPlusValue);
             }
         }
 
@@ -287,12 +287,12 @@ namespace NUnit.ConsoleRunner.Tests
             string[] prototypes = pattern.Split('|');
 
             PropertyInfo property = GetPropertyInfo(propertyName);
-            Assert.AreEqual(typeof(int), property.PropertyType);
+            Assert.That(property.PropertyType, Is.EqualTo(typeof(int)));
 
             foreach (string option in prototypes)
             {
                 ConsoleOptions options = new ConsoleOptions("--" + option + ":42");
-                Assert.AreEqual(42, (int)property.GetValue(options, null), "Didn't recognize --" + option + ":42");
+                Assert.That((int)property.GetValue(options, null), Is.EqualTo(42), "Didn't recognize --" + option + ":42");
             }
         }
 
@@ -334,7 +334,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions(option + "=");
             Assert.That(options.Validate(), Is.False, "Missing value should not be valid");
-            Assert.AreEqual("Missing required value for option '" + option + "'.", options.ErrorMessages[0]);
+            Assert.That(options.ErrorMessages[0], Is.EqualTo("Missing required value for option '" + option + "'."));
         }
 
         [Test]
@@ -342,8 +342,8 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count);
-            Assert.AreEqual("nunit.tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1));
+            Assert.That(options.InputFiles[0], Is.EqualTo("nunit.tests.dll"));
         }
 
         //[Test]
@@ -360,7 +360,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(0), "command line should be valid");
         }
 
         [Test, Platform("32-Bit")]
@@ -368,7 +368,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(0, options.ErrorMessages.Count, "command line should be valid");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(0), "command line should be valid");
         }
 
         [Test, Platform("64-Bit")]
@@ -376,7 +376,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("nunit.tests.dll", "--x86", "--inprocess");
             Assert.That(options.Validate(), Is.False, "Should be invalid");
-            Assert.AreEqual("The --x86 and --inprocess options are incompatible.", options.ErrorMessages[0]);
+            Assert.That(options.ErrorMessages[0], Is.EqualTo("The --x86 and --inprocess options are incompatible."));
         }
 
         [Test]
@@ -384,8 +384,8 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("-assembly:nunit.tests.dll");
             Assert.That(options.Validate(), Is.False);
-            Assert.AreEqual(1, options.ErrorMessages.Count);
-            Assert.AreEqual("Invalid argument: -assembly:nunit.tests.dll", options.ErrorMessages[0]);
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+            Assert.That(options.ErrorMessages[0], Is.EqualTo("Invalid argument: -assembly:nunit.tests.dll"));
         }
 
 
@@ -401,9 +401,9 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("-garbage:TestFixture", "-assembly:Tests.dll");
             Assert.That(options.Validate(), Is.False);
-            Assert.AreEqual(2, options.ErrorMessages.Count);
-            Assert.AreEqual("Invalid argument: -garbage:TestFixture", options.ErrorMessages[0]);
-            Assert.AreEqual("Invalid argument: -assembly:Tests.dll", options.ErrorMessages[1]);
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(2));
+            Assert.That(options.ErrorMessages[0], Is.EqualTo("Invalid argument: -garbage:TestFixture"));
+            Assert.That(options.ErrorMessages[1], Is.EqualTo("Invalid argument: -assembly:Tests.dll"));
         }
 
         #endregion
@@ -415,7 +415,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(-1, options.DefaultTimeout);
+            Assert.That(options.DefaultTimeout, Is.EqualTo(-1));
         }
 
         [Test]
@@ -429,7 +429,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-timeout:5000");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(5000, options.DefaultTimeout);
+            Assert.That(options.DefaultTimeout, Is.EqualTo(5000));
         }
 
         [Test]
@@ -437,7 +437,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-timeout:abc");
             Assert.That(options.Validate(), Is.False);
-            Assert.AreEqual(-1, options.DefaultTimeout);
+            Assert.That(options.DefaultTimeout, Is.EqualTo(-1));
         }
 
         #endregion
@@ -449,12 +449,12 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
 
             OutputSpecification spec = options.ResultOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("nunit3", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec.Format, Is.EqualTo("nunit3"));
             Assert.Null(spec.Transform);
         }
 
@@ -463,12 +463,12 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:results.xml;format=nunit2");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
 
             OutputSpecification spec = options.ResultOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("nunit2", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec.Format, Is.EqualTo("nunit2"));
             Assert.Null(spec.Transform);
         }
 
@@ -483,14 +483,14 @@ namespace NUnit.ConsoleRunner.Tests
                 fileSystem,
                 "tests.dll", $"-result:results.xml;transform={transformFile}");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
 
             OutputSpecification spec = options.ResultOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("user", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec.Format, Is.EqualTo("user"));
             var fullFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, transformFile);
-            Assert.AreEqual(fullFilePath, spec.Transform);
+            Assert.That(spec.Transform, Is.EqualTo(fullFilePath));
         }
 
         [Test]
@@ -498,8 +498,8 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "results.xml");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(0, options.ErrorMessages.Count);
-            Assert.AreEqual(2, options.InputFiles.Count);
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(0));
+            Assert.That(options.InputFiles.Count, Is.EqualTo(2));
         }
 
         [Test]
@@ -507,7 +507,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-result:");
             Assert.That(options.Validate(), Is.False, "Should not be valid");
-            Assert.AreEqual(1, options.ErrorMessages.Count, "An error was expected");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1), "An error was expected");
         }
 
         [Test]
@@ -523,34 +523,34 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(options.Validate(), Is.True, "Should be valid");
 
             var specs = options.ResultOutputSpecifications;
-            Assert.AreEqual(3, specs.Count);
+            Assert.That(specs.Count, Is.EqualTo(3));
 
             var spec1 = specs[0];
-            Assert.AreEqual("results.xml", spec1.OutputPath);
-            Assert.AreEqual("nunit3", spec1.Format);
+            Assert.That(spec1.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec1.Format, Is.EqualTo("nunit3"));
             Assert.Null(spec1.Transform);
 
             var spec2 = specs[1];
-            Assert.AreEqual("nunit2results.xml", spec2.OutputPath);
-            Assert.AreEqual("nunit2", spec2.Format);
+            Assert.That(spec2.OutputPath, Is.EqualTo("nunit2results.xml"));
+            Assert.That(spec2.Format, Is.EqualTo("nunit2"));
             Assert.Null(spec2.Transform);
 
             var spec3 = specs[2];
-            Assert.AreEqual("myresult.xml", spec3.OutputPath);
-            Assert.AreEqual("user", spec3.Format);
+            Assert.That(spec3.OutputPath, Is.EqualTo("myresult.xml"));
+            Assert.That(spec3.Format, Is.EqualTo("user"));
             var fullFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, transformFile);
-            Assert.AreEqual(fullFilePath, spec3.Transform);
+            Assert.That(spec3.Transform, Is.EqualTo(fullFilePath));
         }
 
         [Test]
         public void DefaultResultSpecification()
         {
             var options = new ConsoleOptions("test.dll");
-            Assert.AreEqual(1, options.ResultOutputSpecifications.Count);
+            Assert.That(options.ResultOutputSpecifications.Count, Is.EqualTo(1));
 
             var spec = options.ResultOutputSpecifications[0];
-            Assert.AreEqual("TestResult.xml", spec.OutputPath);
-            Assert.AreEqual("nunit3", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("TestResult.xml"));
+            Assert.That(spec.Format, Is.EqualTo("nunit3"));
             Assert.Null(spec.Transform);
         }
 
@@ -558,14 +558,14 @@ namespace NUnit.ConsoleRunner.Tests
         public void NoResultSuppressesDefaultResultSpecification()
         {
             var options = new ConsoleOptions("test.dll", "-noresult");
-            Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
+            Assert.That(options.ResultOutputSpecifications.Count, Is.EqualTo(0));
         }
 
         [Test]
         public void NoResultSuppressesAllResultSpecifications()
         {
             var options = new ConsoleOptions("test.dll", "-result:results.xml", "-noresult", "-result:nunit2results.xml;format=nunit2");
-            Assert.AreEqual(0, options.ResultOutputSpecifications.Count);
+            Assert.That(options.ResultOutputSpecifications.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -608,13 +608,13 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
             Assert.That(options.Explore, Is.True);
 
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("nunit3", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec.Format, Is.EqualTo("nunit3"));
             Assert.Null(spec.Transform);
         }
 
@@ -623,13 +623,13 @@ namespace NUnit.ConsoleRunner.Tests
         {
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore:results.xml;format=cases");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
             Assert.That(options.Explore, Is.True);
 
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("cases", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec.Format, Is.EqualTo("cases"));
             Assert.Null(spec.Transform);
         }
 
@@ -643,15 +643,15 @@ namespace NUnit.ConsoleRunner.Tests
                 fileSystem,
                 "tests.dll", $"-explore:results.xml;transform={transformFile}");
             Assert.That(options.Validate(), Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
             Assert.That(options.Explore, Is.True);
 
             OutputSpecification spec = options.ExploreOutputSpecifications[0];
-            Assert.AreEqual("results.xml", spec.OutputPath);
-            Assert.AreEqual("user", spec.Format);
+            Assert.That(spec.OutputPath, Is.EqualTo("results.xml"));
+            Assert.That(spec.Format, Is.EqualTo("user"));
             var fullFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, transformFile);
-            Assert.AreEqual(fullFilePath, spec.Transform);
+            Assert.That(spec.Transform, Is.EqualTo(fullFilePath));
         }
 
         [Test]
@@ -660,9 +660,9 @@ namespace NUnit.ConsoleRunner.Tests
             ConsoleOptions options = new ConsoleOptions("tests.dll", "-explore=C:/nunit/tests/bin/Debug/console-test.xml");
             Assert.That(options.Validate(), Is.True);
             Assert.That(options.Explore, Is.True);
-            Assert.AreEqual(1, options.InputFiles.Count, "assembly should be set");
-            Assert.AreEqual("tests.dll", options.InputFiles[0]);
-            Assert.AreEqual("C:/nunit/tests/bin/Debug/console-test.xml", options.ExploreOutputSpecifications[0].OutputPath);
+            Assert.That(options.InputFiles.Count, Is.EqualTo(1), "assembly should be set");
+            Assert.That(options.InputFiles[0], Is.EqualTo("tests.dll"));
+            Assert.That(options.ExploreOutputSpecifications[0].OutputPath, Is.EqualTo("C:/nunit/tests/bin/Debug/console-test.xml"));
         }
 
         [Test]
@@ -695,7 +695,7 @@ namespace NUnit.ConsoleRunner.Tests
             var actualTeamCity = options.TeamCity;
 
             // Then
-            Assert.AreEqual(actualTeamCity, expectedTeamCity);
+            Assert.That(expectedTeamCity, Is.EqualTo(actualTeamCity));
         }
 
         #endregion

--- a/src/NUnitConsole/nunit3-console.tests/DefaultOptionsProviderTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/DefaultOptionsProviderTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.ConsoleRunner.Tests
             Environment.SetEnvironmentVariable(EnvironmentVariableTeamcityProjectName, string.Empty);
 
             // Then
-            Assert.False(provider.TeamCity);
+            Assert.That(provider.TeamCity, Is.False);
         }
 
         private static DefaultOptionsProvider CreateInstance()

--- a/src/NUnitConsole/nunit3-console.tests/DefaultOptionsProviderTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/DefaultOptionsProviderTests.cs
@@ -48,7 +48,7 @@ namespace NUnit.ConsoleRunner.Tests
             Environment.SetEnvironmentVariable(EnvironmentVariableTeamcityProjectName, "Abc");
 
             // Then
-            Assert.True(provider.TeamCity);
+            Assert.That(provider.TeamCity, Is.True);
         }
 
         [Test]

--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -35,8 +35,8 @@ namespace NUnit.ConsoleRunner.Tests
             var options = new ConsoleOptions("test.dll");
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.AreEqual(1, package.SubPackages.Count);
-            Assert.AreEqual(Path.GetFullPath("test.dll"), package.SubPackages[0].FullName);
+            Assert.That(package.SubPackages.Count, Is.EqualTo(1));
+            Assert.That(package.SubPackages[0].FullName, Is.EqualTo(Path.GetFullPath("test.dll")));
         }
 
         [Test]
@@ -46,10 +46,10 @@ namespace NUnit.ConsoleRunner.Tests
             var options = new ConsoleOptions(names);
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.AreEqual(3, package.SubPackages.Count);
-            Assert.AreEqual(Path.GetFullPath("test1.dll"), package.SubPackages[0].FullName);
-            Assert.AreEqual(Path.GetFullPath("test2.dll"), package.SubPackages[1].FullName);
-            Assert.AreEqual(Path.GetFullPath("test3.dll"), package.SubPackages[2].FullName);
+            Assert.That(package.SubPackages.Count, Is.EqualTo(3));
+            Assert.That(package.SubPackages[0].FullName, Is.EqualTo(Path.GetFullPath("test1.dll")));
+            Assert.That(package.SubPackages[1].FullName, Is.EqualTo(Path.GetFullPath("test2.dll")));
+            Assert.That(package.SubPackages[2].FullName, Is.EqualTo(Path.GetFullPath("test3.dll")));
         }
 
         [TestCase("--timeout=50", "DefaultTimeout", 50)]
@@ -86,7 +86,7 @@ namespace NUnit.ConsoleRunner.Tests
             var package = ConsoleRunner.MakeTestPackage(options);
 
             Assert.That(package.Settings.ContainsKey(key), "Setting not included for {0}", option);
-            Assert.AreEqual(val, package.Settings[key], "NumberOfTestWorkers not set correctly for {0}", option);
+            Assert.That(package.Settings[key], Is.EqualTo(val), "NumberOfTestWorkers not set correctly for {0}", option);
         }
 
         [Test]

--- a/src/NUnitConsole/nunit3-console.tests/TestNameParserTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/TestNameParserTests.cs
@@ -40,8 +40,8 @@ namespace NUnit.Common.Tests
         public void SingleName(string name)
         {
             string[] names = TestNameParser.Parse(name);
-            Assert.AreEqual(1, names.Length);
-            Assert.AreEqual(name.Trim(new char[] { ' ', ',' }), names[0]);
+            Assert.That(names.Length, Is.EqualTo(1));
+            Assert.That(names[0], Is.EqualTo(name.Trim(new char[] { ' ', ',' })));
         }
 
         [TestCase("Test.Namespace.Fixture.Method1", "Test.Namespace.Fixture.Method2")]
@@ -52,9 +52,9 @@ namespace NUnit.Common.Tests
         {
             char[] delims = new char[] { ' ', ',' };
             string[] names = TestNameParser.Parse(name1 + "," + name2);
-            Assert.AreEqual(2, names.Length);
-            Assert.AreEqual(name1.Trim(delims), names[0]);
-            Assert.AreEqual(name2.Trim(delims), names[1]);
+            Assert.That(names.Length, Is.EqualTo(2));
+            Assert.That(names[0], Is.EqualTo(name1.Trim(delims)));
+            Assert.That(names[1], Is.EqualTo(name2.Trim(delims)));
         }
     }
 }

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="0.1.0-dev-00079" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />

--- a/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
@@ -46,7 +46,7 @@ namespace NUnit.Engine.Api.Tests
         [Test]
         public void AssemblyPathIsUsedAsFilePath()
         {
-            Assert.AreEqual(Path.GetFullPath("test.dll"), package.FullName);
+            Assert.That(package.FullName, Is.EqualTo(Path.GetFullPath("test.dll")));
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
@@ -69,7 +69,7 @@ namespace NUnit.Engine.Tests
         {
             var result = new TestEngineResult();
             _asyncResult.SetResult(result);
-            Assert.IsTrue(_asyncResult.IsComplete);
+            Assert.That(_asyncResult.IsComplete, Is.True);
         }
 
         [Test]
@@ -81,8 +81,7 @@ namespace NUnit.Engine.Tests
 
             _asyncResult.SetResult(result);
 
-            Assert.IsTrue(_asyncResult.Wait(0),
-                "Expected wait to be true because the test is complete");
+            Assert.That(_asyncResult.Wait(0), Is.True, "Expected wait to be true because the test is complete");
 
             Assert.AreEqual(result.Xml, _asyncResult.EngineResult.Xml);
         }
@@ -92,11 +91,9 @@ namespace NUnit.Engine.Tests
         {
             _asyncResult.SetResult(new TestEngineResult());
             
-            Assert.IsTrue(_asyncResult.Wait(0),
-                "Expected wait to be true because the test is complete");
+            Assert.That(_asyncResult.Wait(0), Is.True, "Expected wait to be true because the test is complete");
 
-            Assert.IsTrue(_asyncResult.Wait(0),
-                "Expected the second wait to be non blocking");
+            Assert.That(_asyncResult.Wait(0), Is.True, "Expected the second wait to be non blocking");
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.Engine.Tests
         [Test]
         public void IsComplete_FalseIfNotComplete()
         {
-            Assert.IsFalse(_asyncResult.IsComplete);
+            Assert.That(_asyncResult.IsComplete, Is.False);
         }
 
         [Test]
@@ -77,8 +77,7 @@ namespace NUnit.Engine.Tests
         {
             var result = new TestEngineResult("<test-assembly />");
 
-            Assert.IsFalse(_asyncResult.Wait(0),
-                "Expected wait to be false because test hasn't completed yet");
+            Assert.That(_asyncResult.Wait(0), Is.False, "Expected wait to be false because test hasn't completed yet");
 
             _asyncResult.SetResult(result);
 

--- a/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
@@ -83,7 +83,7 @@ namespace NUnit.Engine.Tests
 
             Assert.That(_asyncResult.Wait(0), Is.True, "Expected wait to be true because the test is complete");
 
-            Assert.AreEqual(result.Xml, _asyncResult.EngineResult.Xml);
+            Assert.That(_asyncResult.EngineResult.Xml, Is.EqualTo(result.Xml));
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Internal/Extensibility/ExtensionAttributeTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/Extensibility/ExtensionAttributeTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Extensibility
         public void MayBeExplicitlyDisabled()
         {
             var attr = new ExtensionAttribute() { Enabled = false };
-            Assert.False(attr.Enabled);
+            Assert.That(attr.Enabled, Is.False);
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Internal/Extensibility/ExtensionAttributeTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/Extensibility/ExtensionAttributeTests.cs
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Extensibility
         [Test]
         public void IsEnabledByDefault()
         {
-            Assert.True(new ExtensionAttribute().Enabled);
+            Assert.That(new ExtensionAttribute().Enabled, Is.True);
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace NUnit.Engine.Extensibility
         public void MayBeExplicitlyEnabled()
         {
             var attr = new ExtensionAttribute() { Enabled = true };
-            Assert.True(attr.Enabled);
+            Assert.That(attr.Enabled, Is.True);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Engine.Internal.Tests
 		public static void NotSamePathOrUnder( string path1, string path2 )
 		{
 			string msg = "\r\n\texpected: Not same path or under <{0}>\r\n\t but was: <{1}>";
-			Assert.IsFalse( PathUtils.SamePathOrUnder( path1, path2 ), msg, path1, path2 );
+			Assert.That(PathUtils.SamePathOrUnder( path1, path2 ), Is.False, msg, path1, path2);
 		}
 	}
 

--- a/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
@@ -45,7 +45,7 @@ namespace NUnit.Engine.Internal.Tests
 		public static void SamePathOrUnder( string path1, string path2 )
 		{
 			string msg = "\r\n\texpected: Same path or under <{0}>\r\n\t but was: <{1}>";
-			Assert.IsTrue( PathUtils.SamePathOrUnder( path1, path2 ), msg, path1, path2 );
+			Assert.That(PathUtils.SamePathOrUnder( path1, path2 ), Is.True, msg, path1, path2);
 		}
 
 		public static void NotSamePathOrUnder( string path1, string path2 )

--- a/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
@@ -34,8 +34,8 @@ namespace NUnit.Engine.Internal.Tests
 		[Test]
 		public void CheckDefaults()
 		{
-			Assert.AreEqual( Path.DirectorySeparatorChar, PathUtils.DirectorySeparatorChar );
-			Assert.AreEqual( Path.AltDirectorySeparatorChar, PathUtils.AltDirectorySeparatorChar );
+			Assert.That(PathUtils.DirectorySeparatorChar, Is.EqualTo(Path.DirectorySeparatorChar));
+			Assert.That(PathUtils.AltDirectorySeparatorChar, Is.EqualTo(Path.AltDirectorySeparatorChar));
 		}
 	}
 
@@ -75,16 +75,11 @@ namespace NUnit.Engine.Internal.Tests
 		[Test]
 		public void Canonicalize()
 		{
-			Assert.AreEqual( @"C:\folder1\file.tmp",
-				PathUtils.Canonicalize( @"C:\folder1\.\folder2\..\file.tmp" ) );
-			Assert.AreEqual( @"folder1\file.tmp",
-				PathUtils.Canonicalize( @"folder1\.\folder2\..\file.tmp" ) );
-			Assert.AreEqual( @"folder1\file.tmp",
-				PathUtils.Canonicalize( @"folder1\folder2\.\..\file.tmp" ) );
-			Assert.AreEqual( @"file.tmp",
-				PathUtils.Canonicalize( @"folder1\folder2\..\.\..\file.tmp" ) );
-			Assert.AreEqual( @"file.tmp",
-				PathUtils.Canonicalize( @"folder1\folder2\..\..\..\file.tmp" ) );
+			Assert.That(PathUtils.Canonicalize( @"C:\folder1\.\folder2\..\file.tmp" ), Is.EqualTo(@"C:\folder1\file.tmp"));
+			Assert.That(PathUtils.Canonicalize( @"folder1\.\folder2\..\file.tmp" ), Is.EqualTo(@"folder1\file.tmp"));
+			Assert.That(PathUtils.Canonicalize( @"folder1\folder2\.\..\file.tmp" ), Is.EqualTo(@"folder1\file.tmp"));
+			Assert.That(PathUtils.Canonicalize( @"folder1\folder2\..\.\..\file.tmp" ), Is.EqualTo(@"file.tmp"));
+			Assert.That(PathUtils.Canonicalize( @"folder1\folder2\..\..\..\file.tmp" ), Is.EqualTo(@"file.tmp"));
 		}
 
         [Test]
@@ -101,36 +96,34 @@ namespace NUnit.Engine.Internal.Tests
 
             Assume.That(windows, Is.True);
 
-			Assert.AreEqual( @"folder2\folder3", PathUtils.RelativePath(
-				@"c:\folder1", @"c:\folder1\folder2\folder3" ) );
-			Assert.AreEqual( @"..\folder2\folder3", PathUtils.RelativePath(
-				@"c:\folder1", @"c:\folder2\folder3" ) );
-			Assert.AreEqual( @"bin\debug", PathUtils.RelativePath(
-				@"c:\folder1", @"bin\debug" ) );
+			Assert.That(PathUtils.RelativePath(
+				@"c:\folder1", @"c:\folder1\folder2\folder3" ), Is.EqualTo(@"folder2\folder3"));
+			Assert.That(PathUtils.RelativePath(
+				@"c:\folder1", @"c:\folder2\folder3" ), Is.EqualTo(@"..\folder2\folder3"));
+			Assert.That(PathUtils.RelativePath(
+				@"c:\folder1", @"bin\debug" ), Is.EqualTo(@"bin\debug"));
 			Assert.IsNull( PathUtils.RelativePath( @"C:\folder", @"D:\folder" ),
 				"Unrelated paths should return null" );
             Assert.IsNull(PathUtils.RelativePath(@"C:\", @"D:\"),
                 "Unrelated roots should return null");
             Assert.IsNull(PathUtils.RelativePath(@"C:", @"D:"),
                 "Unrelated roots (no trailing separators) should return null");
-            Assert.AreEqual(string.Empty,
-                PathUtils.RelativePath(@"C:\folder1", @"C:\folder1"));
-            Assert.AreEqual(string.Empty,
-                PathUtils.RelativePath(@"C:\", @"C:\"));
+            Assert.That(PathUtils.RelativePath(@"C:\folder1", @"C:\folder1"), Is.EqualTo(string.Empty));
+            Assert.That(PathUtils.RelativePath(@"C:\", @"C:\"), Is.EqualTo(string.Empty));
 
             // First filePath consisting just of a root:
-            Assert.AreEqual(@"folder1\folder2", PathUtils.RelativePath(
-                @"C:\", @"C:\folder1\folder2"));
+            Assert.That(PathUtils.RelativePath(
+                @"C:\", @"C:\folder1\folder2"), Is.EqualTo(@"folder1\folder2"));
 
             // Trailing directory separator in first filePath shall be ignored:
-            Assert.AreEqual(@"folder2\folder3", PathUtils.RelativePath(
-                @"c:\folder1\", @"c:\folder1\folder2\folder3"));
+            Assert.That(PathUtils.RelativePath(
+                @"c:\folder1\", @"c:\folder1\folder2\folder3"), Is.EqualTo(@"folder2\folder3"));
 
             // Case-insensitive behavior, preserving 2nd filePath directories in result:
-            Assert.AreEqual(@"Folder2\Folder3", PathUtils.RelativePath(
-                @"C:\folder1", @"c:\folder1\Folder2\Folder3"));
-            Assert.AreEqual(@"..\Folder2\folder3", PathUtils.RelativePath(
-                @"c:\folder1", @"C:\Folder2\folder3"));
+            Assert.That(PathUtils.RelativePath(
+                @"C:\folder1", @"c:\folder1\Folder2\Folder3"), Is.EqualTo(@"Folder2\Folder3"));
+            Assert.That(PathUtils.RelativePath(
+                @"c:\folder1", @"C:\Folder2\folder3"), Is.EqualTo(@"..\Folder2\folder3"));
         }
 
         [Test]
@@ -169,48 +162,34 @@ namespace NUnit.Engine.Internal.Tests
 		[Test]
 		public void Canonicalize()
 		{
-			Assert.AreEqual( "/folder1/file.tmp",
-				PathUtils.Canonicalize( "/folder1/./folder2/../file.tmp" ) );
-			Assert.AreEqual( "folder1/file.tmp",
-				PathUtils.Canonicalize( "folder1/./folder2/../file.tmp" ) );
-			Assert.AreEqual( "folder1/file.tmp",
-				PathUtils.Canonicalize( "folder1/folder2/./../file.tmp" ) );
-			Assert.AreEqual( "file.tmp",
-				PathUtils.Canonicalize( "folder1/folder2/.././../file.tmp" ) );
-			Assert.AreEqual( "file.tmp",
-				PathUtils.Canonicalize( "folder1/folder2/../../../file.tmp" ) );
+			Assert.That(PathUtils.Canonicalize( "/folder1/./folder2/../file.tmp" ), Is.EqualTo("/folder1/file.tmp"));
+			Assert.That(PathUtils.Canonicalize( "folder1/./folder2/../file.tmp" ), Is.EqualTo("folder1/file.tmp"));
+			Assert.That(PathUtils.Canonicalize( "folder1/folder2/./../file.tmp" ), Is.EqualTo("folder1/file.tmp"));
+			Assert.That(PathUtils.Canonicalize( "folder1/folder2/.././../file.tmp" ), Is.EqualTo("file.tmp"));
+			Assert.That(PathUtils.Canonicalize( "folder1/folder2/../../../file.tmp" ), Is.EqualTo("file.tmp"));
 		}
 
 		[Test]
 		public void RelativePath()
 		{
-			Assert.AreEqual( "folder2/folder3",
-				PathUtils.RelativePath(	"/folder1", "/folder1/folder2/folder3" ) );
-			Assert.AreEqual( "../folder2/folder3",
-				PathUtils.RelativePath( "/folder1", "/folder2/folder3" ) );
-			Assert.AreEqual( "bin/debug",
-				PathUtils.RelativePath( "/folder1", "bin/debug" ) );
-			Assert.AreEqual( "../other/folder",
-				PathUtils.RelativePath( "/folder", "/other/folder" ) );
-			Assert.AreEqual( "../../d",
-				PathUtils.RelativePath( "/a/b/c", "/a/d" ) );
-            Assert.AreEqual(string.Empty,
-                PathUtils.RelativePath("/a/b", "/a/b"));
-            Assert.AreEqual(string.Empty,
-                PathUtils.RelativePath("/", "/"));
+			Assert.That(PathUtils.RelativePath(	"/folder1", "/folder1/folder2/folder3" ), Is.EqualTo("folder2/folder3"));
+			Assert.That(PathUtils.RelativePath( "/folder1", "/folder2/folder3" ), Is.EqualTo("../folder2/folder3"));
+			Assert.That(PathUtils.RelativePath( "/folder1", "bin/debug" ), Is.EqualTo("bin/debug"));
+			Assert.That(PathUtils.RelativePath( "/folder", "/other/folder" ), Is.EqualTo("../other/folder"));
+			Assert.That(PathUtils.RelativePath( "/a/b/c", "/a/d" ), Is.EqualTo("../../d"));
+            Assert.That(PathUtils.RelativePath("/a/b", "/a/b"), Is.EqualTo(string.Empty));
+            Assert.That(PathUtils.RelativePath("/", "/"), Is.EqualTo(string.Empty));
 
             // First filePath consisting just of a root:
-            Assert.AreEqual("folder1/folder2", PathUtils.RelativePath(
-                "/", "/folder1/folder2"));
+            Assert.That(PathUtils.RelativePath(
+                "/", "/folder1/folder2"), Is.EqualTo("folder1/folder2"));
 
             // Trailing directory separator in first filePath shall be ignored:
-            Assert.AreEqual("folder2/folder3", PathUtils.RelativePath(
-                "/folder1/", "/folder1/folder2/folder3"));
+            Assert.That(PathUtils.RelativePath(
+                "/folder1/", "/folder1/folder2/folder3"), Is.EqualTo("folder2/folder3"));
 
             // Case-sensitive behavior:
-            Assert.AreEqual("../Folder1/Folder2/folder3",
-                PathUtils.RelativePath("/folder1", "/Folder1/Folder2/folder3"),
-                "folders differing in case");
+            Assert.That(PathUtils.RelativePath("/folder1", "/Folder1/Folder2/folder3"), Is.EqualTo("../Folder1/Folder2/folder3"), "folders differing in case");
         }
 
 		[Test]

--- a/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
@@ -57,7 +57,7 @@ namespace NUnit.Engine.Internal.Tests
         {
             settings.SaveSetting(name, expected);
             object actual = settings.GetSetting(name);
-            Assert.AreEqual(expected, actual);
+            Assert.That(actual, Is.EqualTo(expected));
             Assert.IsInstanceOf(expected.GetType(),actual);
         }
 
@@ -76,7 +76,7 @@ namespace NUnit.Engine.Internal.Tests
 
             settings.RemoveSetting("X");
             Assert.IsNull(settings.GetSetting("X"), "X not removed");
-            Assert.AreEqual("Charlie", settings.GetSetting("NAME"));
+            Assert.That(settings.GetSetting("NAME"), Is.EqualTo("Charlie"));
 
             settings.RemoveSetting("NAME");
             Assert.IsNull(settings.GetSetting("NAME"), "NAME not removed");
@@ -86,19 +86,19 @@ namespace NUnit.Engine.Internal.Tests
         public void WhenSettingIsNotInitialized_DefaultValueIsReturned()
         {
 
-            Assert.AreEqual( 5, settings.GetSetting( "X", 5 ) );
-            Assert.AreEqual( 6, settings.GetSetting( "X", 6 ) );
-            Assert.AreEqual( "7", settings.GetSetting( "X", "7" ) );
+            Assert.That(settings.GetSetting( "X", 5 ), Is.EqualTo(5));
+            Assert.That(settings.GetSetting( "X", 6 ), Is.EqualTo(6));
+            Assert.That(settings.GetSetting( "X", "7" ), Is.EqualTo("7"));
 
-            Assert.AreEqual( "Charlie", settings.GetSetting( "NAME", "Charlie" ) );
-            Assert.AreEqual( "Fred", settings.GetSetting( "NAME", "Fred" ) );
+            Assert.That(settings.GetSetting( "NAME", "Charlie" ), Is.EqualTo("Charlie"));
+            Assert.That(settings.GetSetting( "NAME", "Fred" ), Is.EqualTo("Fred"));
         }
 
         [Test]
         public void WhenSettingIsNotValid_DefaultSettingIsReturned()
         {
             settings.SaveSetting( "X", "1y25" );
-            Assert.AreEqual( 42, settings.GetSetting( "X", 42 ) );
+            Assert.That(settings.GetSetting( "X", 42 ), Is.EqualTo(42));
         }
 
 #if !NETCOREAPP1_1 && !NETCOREAPP2_0

--- a/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
@@ -58,8 +58,7 @@ namespace NUnit.Engine.Runners.Tests
 
             task.MarkTaskAsCompleted();
 
-            Assert.IsTrue(workerPool.WaitAll(100),
-                "Threads should have exited, all work is complete");
+            Assert.That(workerPool.WaitAll(100), Is.True, "Threads should have exited, all work is complete");
         }
 
         [Test]
@@ -86,8 +85,7 @@ namespace NUnit.Engine.Runners.Tests
 
             task2.MarkTaskAsCompleted();
 
-            Assert.IsTrue(workerPool.WaitAll(100),
-                "Threads should have exited, all work is complete");
+            Assert.That(workerPool.WaitAll(100), Is.True, "Threads should have exited, all work is complete");
 
             Assert.AreEqual(BusyTaskState.Completed, task1.State);
             Assert.AreEqual(BusyTaskState.Completed, task2.State);
@@ -117,8 +115,7 @@ namespace NUnit.Engine.Runners.Tests
 
             task2.MarkTaskAsCompleted();
 
-            Assert.IsTrue(workerPool.WaitAll(100),
-                "Threads should have exited, all work is complete");
+            Assert.That(workerPool.WaitAll(100), Is.True, "Threads should have exited, all work is complete");
 
             Assert.AreEqual(BusyTaskState.Completed, task1.State);
             Assert.AreEqual(BusyTaskState.Completed, task2.State);

--- a/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
@@ -54,8 +54,7 @@ namespace NUnit.Engine.Runners.Tests
             workerPool.Enqueue(task);
             workerPool.Start();
 
-            Assert.IsFalse(workerPool.WaitAll(10),
-                "Threads should not have exited, work is in progress");
+            Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, work is in progress");
 
             task.MarkTaskAsCompleted();
 
@@ -73,16 +72,14 @@ namespace NUnit.Engine.Runners.Tests
             workerPool.Enqueue(task2);
             workerPool.Start();
 
-            Assert.IsFalse(workerPool.WaitAll(10),
-                "Threads should not have exited, 2 tasks are in progress");
+            Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 2 tasks are in progress");
 
             Assert.AreEqual(BusyTaskState.Executing, task1.State);
             Assert.AreEqual(BusyTaskState.Queued, task2.State);
 
             task1.MarkTaskAsCompleted();
 
-            Assert.IsFalse(workerPool.WaitAll(10),
-                "Threads should not have exited, 1 task is in progress");
+            Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 1 task is in progress");
 
             Assert.AreEqual(BusyTaskState.Completed, task1.State);
             Assert.AreEqual(BusyTaskState.Executing, task2.State);
@@ -106,16 +103,14 @@ namespace NUnit.Engine.Runners.Tests
             workerPool.Enqueue(task2);
             workerPool.Start();
 
-            Assert.IsFalse(workerPool.WaitAll(10),
-                "Threads should not have exited, 2 tasks are in progress");
+            Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 2 tasks are in progress");
 
             Assert.AreEqual(BusyTaskState.Executing, task1.State);
             Assert.AreEqual(BusyTaskState.Executing, task2.State);
 
             task1.MarkTaskAsCompleted();
 
-            Assert.IsFalse(workerPool.WaitAll(10),
-                "Threads should not have exited, 1 task is in progress");
+            Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 1 task is in progress");
 
             Assert.AreEqual(BusyTaskState.Completed, task1.State);
             Assert.AreEqual(BusyTaskState.Executing, task2.State);

--- a/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
@@ -73,22 +73,22 @@ namespace NUnit.Engine.Runners.Tests
 
             Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 2 tasks are in progress");
 
-            Assert.AreEqual(BusyTaskState.Executing, task1.State);
-            Assert.AreEqual(BusyTaskState.Queued, task2.State);
+            Assert.That(task1.State, Is.EqualTo(BusyTaskState.Executing));
+            Assert.That(task2.State, Is.EqualTo(BusyTaskState.Queued));
 
             task1.MarkTaskAsCompleted();
 
             Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 1 task is in progress");
 
-            Assert.AreEqual(BusyTaskState.Completed, task1.State);
-            Assert.AreEqual(BusyTaskState.Executing, task2.State);
+            Assert.That(task1.State, Is.EqualTo(BusyTaskState.Completed));
+            Assert.That(task2.State, Is.EqualTo(BusyTaskState.Executing));
 
             task2.MarkTaskAsCompleted();
 
             Assert.That(workerPool.WaitAll(100), Is.True, "Threads should have exited, all work is complete");
 
-            Assert.AreEqual(BusyTaskState.Completed, task1.State);
-            Assert.AreEqual(BusyTaskState.Completed, task2.State);
+            Assert.That(task1.State, Is.EqualTo(BusyTaskState.Completed));
+            Assert.That(task2.State, Is.EqualTo(BusyTaskState.Completed));
         }
 
         [Test]
@@ -103,22 +103,22 @@ namespace NUnit.Engine.Runners.Tests
 
             Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 2 tasks are in progress");
 
-            Assert.AreEqual(BusyTaskState.Executing, task1.State);
-            Assert.AreEqual(BusyTaskState.Executing, task2.State);
+            Assert.That(task1.State, Is.EqualTo(BusyTaskState.Executing));
+            Assert.That(task2.State, Is.EqualTo(BusyTaskState.Executing));
 
             task1.MarkTaskAsCompleted();
 
             Assert.That(workerPool.WaitAll(10), Is.False, "Threads should not have exited, 1 task is in progress");
 
-            Assert.AreEqual(BusyTaskState.Completed, task1.State);
-            Assert.AreEqual(BusyTaskState.Executing, task2.State);
+            Assert.That(task1.State, Is.EqualTo(BusyTaskState.Completed));
+            Assert.That(task2.State, Is.EqualTo(BusyTaskState.Executing));
 
             task2.MarkTaskAsCompleted();
 
             Assert.That(workerPool.WaitAll(100), Is.True, "Threads should have exited, all work is complete");
 
-            Assert.AreEqual(BusyTaskState.Completed, task1.State);
-            Assert.AreEqual(BusyTaskState.Completed, task2.State);
+            Assert.That(task1.State, Is.EqualTo(BusyTaskState.Completed));
+            Assert.That(task2.State, Is.EqualTo(BusyTaskState.Completed));
         }
 
         private class NoOpTask : ITestExecutionTask

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -161,7 +161,7 @@ namespace NUnit.Engine.Runners.Tests
             if (_runner is DirectTestRunner)
                 Assert.That(_runner.IsPackageLoaded, "Package was not loaded automatically");
             else
-                Assert.False(_runner.IsPackageLoaded, "Package should not be loaded automatically");
+                Assert.That(_runner.IsPackageLoaded, Is.False, "Package should not be loaded automatically");
         }
 
         private void CheckBasicResult(TestEngineResult result)

--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -91,9 +91,9 @@ namespace NUnit.Engine.Tests
         public void CanCreateUsingFrameworkVersion(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.runtime, data.frameworkVersion);
-            Assert.AreEqual(data.runtime, framework.Runtime);
-            Assert.AreEqual(data.frameworkVersion, framework.FrameworkVersion);
-            Assert.AreEqual(data.clrVersion, framework.ClrVersion);
+            Assert.That(framework.Runtime, Is.EqualTo(data.runtime));
+            Assert.That(framework.FrameworkVersion, Is.EqualTo(data.frameworkVersion));
+            Assert.That(framework.ClrVersion, Is.EqualTo(data.clrVersion));
         }
 
         [TestCaseSource(nameof(frameworkData))]
@@ -102,25 +102,25 @@ namespace NUnit.Engine.Tests
             Assume.That(data.frameworkVersion.Major != 3);
 
             RuntimeFramework framework = new RuntimeFramework(data.runtime, data.clrVersion);
-            Assert.AreEqual(data.runtime, framework.Runtime);
-            Assert.AreEqual(data.frameworkVersion, framework.FrameworkVersion);
-            Assert.AreEqual(data.clrVersion, framework.ClrVersion);
+            Assert.That(framework.Runtime, Is.EqualTo(data.runtime));
+            Assert.That(framework.FrameworkVersion, Is.EqualTo(data.frameworkVersion));
+            Assert.That(framework.ClrVersion, Is.EqualTo(data.clrVersion));
         }
 
         [TestCaseSource(nameof(frameworkData))]
         public void CanParseRuntimeFramework(FrameworkData data)
         {
             RuntimeFramework framework = RuntimeFramework.Parse(data.representation);
-            Assert.AreEqual(data.runtime, framework.Runtime);
-            Assert.AreEqual(data.clrVersion, framework.ClrVersion);
+            Assert.That(framework.Runtime, Is.EqualTo(data.runtime));
+            Assert.That(framework.ClrVersion, Is.EqualTo(data.clrVersion));
         }
 
         [TestCaseSource(nameof(frameworkData))]
         public void CanDisplayFrameworkAsString(FrameworkData data)
         {
             RuntimeFramework framework = new RuntimeFramework(data.runtime, data.frameworkVersion);
-            Assert.AreEqual(data.representation, framework.ToString());
-            Assert.AreEqual(data.displayName, framework.DisplayName);
+            Assert.That(framework.ToString(), Is.EqualTo(data.representation));
+            Assert.That(framework.DisplayName, Is.EqualTo(data.displayName));
         }
 
         [TestCaseSource(nameof(matchData))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -44,9 +44,7 @@ namespace NUnit.Engine.Services.Tests
         {
             string[] assemblies = new string[] { path1, path2, path3 };
 
-            Assert.AreEqual(
-                TestPath("bin/debug") + Path.PathSeparator + TestPath("utils"),
-                DomainManager.GetPrivateBinPath(TestPath("/test"), assemblies));
+            Assert.That(DomainManager.GetPrivateBinPath(TestPath("/test"), assemblies), Is.EqualTo(TestPath("bin/debug") + Path.PathSeparator + TestPath("utils")));
         }
 
         [Test]
@@ -54,9 +52,7 @@ namespace NUnit.Engine.Services.Tests
         {
             string[] assemblies = new string[] { path1 };
 
-            Assert.AreEqual(
-                TestPath("/test/bin/debug"),
-                DomainManager.GetCommonAppBase(assemblies));
+            Assert.That(DomainManager.GetCommonAppBase(assemblies), Is.EqualTo(TestPath("/test/bin/debug")));
         }
 
         [Test]
@@ -64,9 +60,7 @@ namespace NUnit.Engine.Services.Tests
         {
             string[] assemblies = new string[] { path1, path2 };
 
-            Assert.AreEqual(
-                TestPath("/test/bin/debug"),
-                DomainManager.GetCommonAppBase(assemblies));
+            Assert.That(DomainManager.GetCommonAppBase(assemblies), Is.EqualTo(TestPath("/test/bin/debug")));
         }
 
         [Test]
@@ -74,9 +68,7 @@ namespace NUnit.Engine.Services.Tests
         {
             string[] assemblies = new string[] { path1, path3 };
 
-            Assert.AreEqual(
-                TestPath("/test"),
-                DomainManager.GetCommonAppBase(assemblies));
+            Assert.That(DomainManager.GetCommonAppBase(assemblies), Is.EqualTo(TestPath("/test")));
         }
 
         [Test]
@@ -84,9 +76,7 @@ namespace NUnit.Engine.Services.Tests
         {
             string[] assemblies = new string[] { path1, path2, path3 };
 
-            Assert.AreEqual(
-                TestPath("/test"),
-                DomainManager.GetCommonAppBase(assemblies));
+            Assert.That(DomainManager.GetCommonAppBase(assemblies), Is.EqualTo(TestPath("/test")));
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -63,7 +63,7 @@ namespace NUnit.Engine.Services.Tests
                 Path.GetFileName(setup.ConfigurationFile),
                 Is.EqualTo("mock-assembly.dll.config").IgnoreCase,
                 "ConfigurationFile");
-            Assert.AreEqual(null, setup.PrivateBinPath, "PrivateBinPath");
+            Assert.That(setup.PrivateBinPath, Is.EqualTo(null), "PrivateBinPath");
             Assert.That(setup.ShadowCopyFiles, Is.Null.Or.EqualTo("false"));
             //Assert.That(setup.ShadowCopyDirectories, Is.SamePath(Path.GetDirectoryName(MockAssembly.AssemblyPath)), "ShadowCopyDirectories" );
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -128,7 +128,7 @@ namespace NUnit.Engine.Services.Tests
                 unloaded = true;
             }
 
-            Assert.True(unloaded, "Domain was not unloaded");
+            Assert.That(unloaded, Is.True, "Domain was not unloaded");
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Engine.Services.Tests
         public void EmptyList()
         {
             Assert.IsNotNull(  _recentFiles.Entries, "Entries should never be null" );
-            Assert.AreEqual( 0, _recentFiles.Entries.Count );
+            Assert.That(_recentFiles.Entries.Count, Is.EqualTo(0));
         }
 
         [Test]
@@ -178,17 +178,17 @@ namespace NUnit.Engine.Services.Tests
         private void CheckMockValues(int count)
         {
             var files = _recentFiles.Entries;
-            Assert.AreEqual(count, files.Count, "Count");
+            Assert.That(files.Count, Is.EqualTo(count), "Count");
 
             for (int index = 0; index < count; index++)
-                Assert.AreEqual((index + 1).ToString(), files[index], "Item");
+                Assert.That(files[index], Is.EqualTo((index + 1).ToString()), "Item");
         }
 
         // Check that we can add count items correctly
         private void CheckAddItems(int count)
         {
             SetMockValues(count);
-            Assert.AreEqual("1", _recentFiles.Entries[0], "RecentFile");
+            Assert.That(_recentFiles.Entries[0], Is.EqualTo("1"), "RecentFile");
 
             CheckMockValues(Math.Min(count, _recentFiles.MaxFiles));
         }
@@ -198,10 +198,10 @@ namespace NUnit.Engine.Services.Tests
         private void CheckListContains(params int[] item)
         {
             var files = _recentFiles.Entries;
-            Assert.AreEqual(item.Length, files.Count, "Count");
+            Assert.That(files.Count, Is.EqualTo(item.Length), "Count");
 
             for (int index = 0; index < files.Count; index++)
-                Assert.AreEqual(item[index].ToString(), files[index], "Item");
+                Assert.That(files[index], Is.EqualTo(item[index].ToString()), "Item");
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine.tests/TestEngineResultTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/TestEngineResultTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Tests
         public void CanCreateFromXmlString()
         {
             TestEngineResult result = new TestEngineResult(xmlText);
-            Assert.True(result.IsSingle);
+            Assert.That(result.IsSingle, Is.True);
             Assert.That(result.Xml.Name, Is.EqualTo("test-assembly"));
             Assert.That(result.Xml.Attributes["result"].Value, Is.EqualTo("Passed"));
             Assert.That(result.Xml.Attributes["total"].Value, Is.EqualTo("23"));
@@ -61,7 +61,7 @@ namespace NUnit.Engine.Tests
             XmlHelper.AddAttribute(node, "asserts", "40");
 
             TestEngineResult result = new TestEngineResult(node);
-            Assert.True(result.IsSingle);
+            Assert.That(result.IsSingle, Is.True);
             Assert.That(result.Xml.OuterXml, Is.EqualTo(xmlText));
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="0.1.0-dev-00079" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit-console/issues/506. Adds NUnit.Analyzers NuGet package, and, to best fit those, converts unit tests to use constraint syntax instead of classic syntax.

See discussion on https://github.com/nunit/nunit-console/issues/506 - let's keep discussion over there, for now. 🙂 