### PR TITLE
Support excluding tests in a testlist file

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilterBuilderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilterBuilderTests.cs
@@ -77,6 +77,40 @@ namespace NUnit.Engine.Services.Tests
                 "<filter><or><test>My.First.Test</test><test>My.Second.Test</test><test>My.Third.Test</test></or></filter>"));
         }
 
+        [Theory]
+        public void OneTestExcluded(bool useBangSyntax)
+        {
+            builder.AddTest((useBangSyntax ? "!" : "-") + "My.Test.Name");
+            TestFilter filter = builder.GetFilter();
+
+            Assert.That(filter.Text, Is.EqualTo(
+                "<filter><not><test>My.Test.Name</test></not></filter>"));
+        }
+
+        [Theory]
+        public void ThreeTestsExcluded(bool useBangSyntax)
+        {
+            builder.AddTest((useBangSyntax ? "!" : "-") + "My.First.Test");
+            builder.AddTest((useBangSyntax ? "!" : "-") + "My.Second.Test");
+            builder.AddTest((useBangSyntax ? "!" : "-") + "My.Third.Test");
+            TestFilter filter = builder.GetFilter();
+
+            Assert.That(filter.Text, Is.EqualTo(
+                "<filter><not><or><test>My.First.Test</test><test>My.Second.Test</test><test>My.Third.Test</test></or></not></filter>"));
+        }
+
+        [Theory]
+        public void TestsIncludedAndExcluded(bool useBangSyntax)
+        {
+            builder.AddTest("My.First.Test");
+            builder.AddTest((useBangSyntax ? "!" : "-") + "My.Second.Test");
+            builder.AddTest("My.Third.Test");
+            TestFilter filter = builder.GetFilter();
+
+            Assert.That(filter.Text, Is.EqualTo(
+                "<filter><or><test>My.First.Test</test><test>My.Third.Test</test></or><not><test>My.Second.Test</test></not></filter>"));
+        }
+
         [Test]
         public void WhereClause()
         {

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -75,7 +75,37 @@ namespace NUnit.Engine.Services.Tests
             builder.AddTest(testName);
 
             Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(count));
+        }
 
+        [Test]
+        public void UsingTestFilterBuilderExcludeOneTest()
+        {
+            var builder = new TestFilterBuilder();
+            builder.AddTest("-NUnit.Tests.Assemblies.MockTestFixture.FailingTest");
+
+            Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(MockAssembly.Tests - 1));
+        }
+
+        [Test]
+        public void UsingTestFilterBuilderExcludeTwoTests()
+        {
+            var builder = new TestFilterBuilder();
+            builder.AddTest("-NUnit.Tests.Assemblies.MockTestFixture.FailingTest");
+            builder.AddTest("-NUnit.Tests.TestAssembly.MockTestFixture.MyTest");
+
+            Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(MockAssembly.Tests - 2));
+        }
+
+        [Test]
+        public void UsingTestFilterBuilderIncludeAndExcludeTests()
+        {
+            var builder = new TestFilterBuilder();
+            builder.AddTest("NUnit.Tests.Assemblies.MockTestFixture");
+            builder.AddTest("-NUnit.Tests.Assemblies.MockTestFixture.FailingTest");
+            // also exclude a test not included : should have no effect (only one less than MockTestFixture.Test)
+            builder.AddTest("-NUnit.Tests.TestAssembly.MockTestFixture.MyTest");
+
+            Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(MockTestFixture.Tests - 1));
         }
 
         [TestCase("test==NUnit.Tests.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
@@ -91,7 +121,6 @@ namespace NUnit.Engine.Services.Tests
             builder.SelectWhere(expression);
 
             Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(count));
-
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2013-2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -60,16 +60,32 @@ namespace NUnit.Engine
         {
             var filter = new StringBuilder("<filter>");
 
-            if (_testList.Count > 0)
+            var includedTests = new List<string>();
+            var excludedTests = new List<string>();
+            foreach (var test in _testList)
             {
-                if (_testList.Count > 1)
-                    filter.Append("<or>");
-                foreach (string test in _testList)
-                    filter.AppendFormat("<test>{0}</test>", XmlEscape(test));
-                if (_testList.Count > 1)
-                    filter.Append("</or>");
+                if (test.StartsWith("-") || test.StartsWith("!"))
+                    excludedTests.Add(test.Substring(1));
+                else
+                    includedTests.Add(test);
             }
 
+            foreach (var testList in new[] { includedTests, excludedTests })
+            {
+                if (testList.Count == 0)
+                    continue;
+                bool excluded = testList == excludedTests;
+                if (excluded)
+                    filter.Append("<not>");
+                if (testList.Count > 1)
+                    filter.Append("<or>");
+                foreach (string test in testList)
+                    filter.AppendFormat("<test>{0}</test>", XmlEscape(test));
+                if (testList.Count > 1)
+                    filter.Append("</or>");
+                if (excluded)
+                    filter.Append("</not>");
+            }
 
             if (_whereClause != null)
                 filter.Append(new TestSelectionParser().Parse(_whereClause));


### PR DESCRIPTION
A use-case for this feature is for CI pipeline, when using results of previous
run to separate long running tests in their own process : we want to have a
reliable (and convenient) way to say "everything else".