### PR TITLE
Initial Test Runner Selection Tests (1/4)

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Net20AssemblyTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Net20AssemblyTestCases.cs
@@ -1,0 +1,73 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using NUnit.Engine.Internal;
+using NUnit.Engine.Runners;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
+{
+#if !NETCOREAPP
+    internal static class Net20AssemblyTestCases
+    {
+        public static IEnumerable<TestCaseData> TestCases
+        {
+            get
+            {
+                var testName = "Single assembly";
+                var package = new TestPackage("a.dll");
+                var expected = new RunnerResult { TestRunner = typeof(ProcessRunner) };
+                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+
+                testName = "Two assemblies";
+                package = new TestPackage(new[] { "a.dll", "b.dll" });
+                expected = new RunnerResult
+                {
+                    TestRunner = typeof(MultipleTestProcessRunner),
+                    SubRunners = new[]
+                    {
+                        new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                        new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                    }
+                };
+                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+
+                testName = "Three assemblies";
+                package = new TestPackage(new[] { "a.dll", "b.dll", "c.dll" });
+                expected = new RunnerResult
+                {
+                    TestRunner = typeof(MultipleTestProcessRunner),
+                    SubRunners = new[]
+                    {
+                        new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                        new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                        new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                    }
+                };
+                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+            }
+        }
+    }
+#endif
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/NetStandardAssemblyTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/NetStandardAssemblyTestCases.cs
@@ -1,0 +1,72 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using NUnit.Engine.Runners;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
+{
+#if NETCOREAPP1_1 || NETCOREAPP2_0
+    internal static class NetStandardAssemblyTestCases
+    {
+        public static IEnumerable<TestCaseData> TestCases
+        {
+            get
+            {
+                var testName = "Single assembly";
+                var package = new TestPackage("a.dll");
+                var expected = new RunnerResult { TestRunner = typeof(LocalTestRunner) };
+                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+
+                testName = "Two assemblies";
+                package = new TestPackage(new[] { "a.dll", "b.dll" });
+                expected = new RunnerResult
+                {
+                    TestRunner = typeof(AggregatingTestRunner),
+                    SubRunners = new[]
+                    {
+                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                    }
+                };
+                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+
+                testName = "Three assemblies";
+                package = new TestPackage(new[] { "a.dll", "b.dll", "c.dll" });
+                expected = new RunnerResult
+                {
+                    TestRunner = typeof(AggregatingTestRunner),
+                    SubRunners = new[]
+                    {
+                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                    }
+                };
+                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+            }
+        }
+    }
+#endif
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
@@ -1,0 +1,54 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
+{
+    public class RunnerResult
+    {
+        public Type TestRunner { get; set; }
+
+        public ICollection<RunnerResult> SubRunners { get; set; } = new List<RunnerResult>();
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"TestRunner: {TestRunner.Name}");
+
+            if (SubRunners.Count == 0)
+                return sb.ToString();
+
+            sb.AppendLine("SubRunners:");
+
+            foreach (var subRunner in SubRunners)
+            {
+                sb.AppendLine($"\t{subRunner}");
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResultComparer.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResultComparer.cs
@@ -1,0 +1,48 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
+{
+    internal class RunnerResultComparer : IEqualityComparer<RunnerResult>
+    {
+        public static readonly RunnerResultComparer Instance = new RunnerResultComparer();
+
+        public bool Equals(RunnerResult x, RunnerResult y)
+        {
+            x = x ?? throw new ArgumentNullException(nameof(x));
+            y = y ?? throw new ArgumentNullException(nameof(y));
+
+            return x.TestRunner == y.TestRunner &&
+                   x.SubRunners.SequenceEqual(y.SubRunners, Instance);
+        }
+
+        public int GetHashCode(RunnerResult obj)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -1,0 +1,74 @@
+﻿// ***********************************************************************
+// Copyright (c) 2018 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Engine.Runners;
+using NUnit.Engine.Services;
+using NUnit.Engine.Services.Tests.Fakes;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
+{
+    public class RunnerSelectionTests
+    {
+        private DefaultTestRunnerFactory _factory;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            var services = new ServiceContext();
+#if !NETCOREAPP1_1
+            services.Add(new ExtensionService());
+            services.Add(new FakeProjectService());
+#endif
+            _factory = new DefaultTestRunnerFactory();
+            services.Add(_factory);
+            _factory.StartService();
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void RunnerSelectionTest(TestPackage package, RunnerResult expected)
+        {
+            var runner = _factory.MakeTestRunner(package);
+            var result = GetRunnerResult(runner);
+            Assert.That(result, Is.EqualTo(expected).Using(RunnerResultComparer.Instance));
+        }
+
+        private static RunnerResult GetRunnerResult(ITestEngineRunner runner)
+        {
+            var result = new RunnerResult { TestRunner = runner.GetType() };
+
+            if (runner is AggregatingTestRunner aggRunner)
+                result.SubRunners = aggRunner.Runners.Select(GetRunnerResult).ToList();
+
+            return result;
+        }
+
+#if NETCOREAPP
+        private static IEnumerable<TestCaseData> TestCases => NetStandardAssemblyTestCases.TestCases;
+#else
+        private static IEnumerable<TestCaseData> TestCases => Net20AssemblyTestCases.TestCases;
+#endif
+    }
+}


### PR DESCRIPTION
Contributes to #514.

This is the basic structure for the new tests I want to add to test the overall tree of `ITestRunners` which are built by the engine, in various situations. This currently just tests simple command-line-assembly usage - I started off trying to do everything in one go, but it gets more complicated once process/domain models and packages are added in, so I thought this would be easier for review.

I separated out the Full-Framework and NetStandard test cases, as the normal expected results are different anyway, and once process/domain model tests are added in, it becomes much more complex trying to maintain a single file.

This currently duplicates some test cases in the DefaultTestRunnerFactoryTests - I plan to finish off this test suite entirely first, before removing the old version.

This is ready for review and merge as is - I'll do the further work in separate PRs. 🙂

~Edit: Tracking the Appveyor failure at https://github.com/nunit/nunit-console/issues/515~