### PR TITLE
Use Previous appveyor build image to fix CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ branches:
   except:
     - /travis-.*/
 
-image: Visual Studio 2017
+image: Previous Visual Studio 2017
 
 build_script:
   - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit-console/issues/515

Appveyor builds have been failing since the Dec 13 Appveyor upgrade. Issue appears to be https://github.com/NuGet/Home/issues/7414. I tried all the following to get things working, none of which appear to have worked:

- Upgrade to .NET Core 2.1
- Upgrade to .NET Core 2.2
- Use "Preview" VS 2017 appveyor image
- Use "Preview" VS 2019 appveyor image

Will log an issue with Appveyor shortly...although they've previously passed the issue onto dotnet, who've passed it on to NuGet... :-/