### PR TITLE
Separate NuGet Restore for Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,10 @@ branches:
   except:
     - /travis-.*/
 
-image: Previous Visual Studio 2017
+image: Visual Studio 2017
 
 build_script:
+  - nuget restore src\NUnitEngine\mock-assembly\mock-assembly.csproj
   - ps: .\build.ps1 -Target "Appveyor" -Configuration "Release"
 
 # disable built-in tests.


### PR DESCRIPTION
Following on from: https://github.com/nunit/nunit-console/pull/517, @IlyaFinkelshteyn from the @appveyor team found this solution, which will allow us to continue using the current appveyor image, and our builds not to fail when the "Previous" image next changes.

The core issue seems to be this one: https://github.com/NuGet/Home/issues/7414, which Appveyor are tracking via: https://github.com/appveyor/ci/issues/2787