### PR TITLE
Fix duplicate test ids when loading projects

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -150,16 +150,7 @@ namespace NUnit.Engine.Runners.Tests
             Assert.That(suite.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(suite.GetAttribute("runstate"), Is.EqualTo("Runnable"));
 
-            var dict = new Dictionary<string, bool>();
-            AssertThatIdsAreUnique(result, dict);
-        }
-
-        private void AssertThatIdsAreUnique(XmlNode test, Dictionary<string, bool> dict)
-        {
-            Assert.That(dict, Does.Not.ContainKey(test.GetAttribute("id")));
-
-            foreach (XmlNode child in test.SelectNodes("test-suite"))
-                AssertThatIdsAreUnique(child, dict);
+            AssertThatIdsAreUnique(result);
         }
 
         [Test]
@@ -204,12 +195,27 @@ namespace NUnit.Engine.Runners.Tests
                 Assert.That(suite.GetAttribute("inconclusive", 0), Is.EqualTo(MockAssembly.Inconclusive));
             }
 
+            AssertThatIdsAreUnique(result);
+
             Assert.That(_events[0].Name, Is.EqualTo("start-run"));
             Assert.That(_events[0].GetAttribute("count", -1), Is.EqualTo(MockAssembly.Tests * _numAssemblies), "Start-run count value");
             Assert.That(_events[1].Name, Is.EqualTo("start-suite"));
             Assert.That(_events[_events.Count - 2].Name, Is.EqualTo("test-suite"));
             Assert.That(_events[_events.Count - 1].Name, Is.EqualTo("test-run"));
             Assert.That(_events.Count(x => x.Name == "test-case"), Is.EqualTo(MockAssembly.Tests * _numAssemblies));
+        }
+
+        private void AssertThatIdsAreUnique(XmlNode test)
+        {
+            AssertThatIdsAreUnique(test, new Dictionary<string, bool>());
+        }
+
+        private void AssertThatIdsAreUnique(XmlNode test, Dictionary<string, bool> dict)
+        {
+            Assert.That(dict, Does.Not.ContainKey(test.GetAttribute("id")));
+
+            foreach (XmlNode child in test.SelectNodes("test-suite"))
+                AssertThatIdsAreUnique(child, dict);
         }
 
         void ITestEventListener.OnTestEvent(string report)

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -149,6 +149,17 @@ namespace NUnit.Engine.Runners.Tests
             Assert.NotNull(suite, "No suite found");
             Assert.That(suite.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(suite.GetAttribute("runstate"), Is.EqualTo("Runnable"));
+
+            var dict = new Dictionary<string, bool>();
+            AssertThatIdsAreUnique(result, dict);
+        }
+
+        private void AssertThatIdsAreUnique(XmlNode test, Dictionary<string, bool> dict)
+        {
+            Assert.That(dict, Does.Not.ContainKey(test.GetAttribute("id")));
+
+            foreach (XmlNode child in test.SelectNodes("test-suite"))
+                AssertThatIdsAreUnique(child, dict);
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DefaultTestRunnerFactoryTests.cs
@@ -78,7 +78,7 @@ namespace NUnit.Engine.Services.Tests
         // Single file
         [TestCase("x.nunit",           null,        typeof(AggregatingTestRunner))]
         [TestCase("x.dll",             null,        typeof(ProcessRunner))]
-        [TestCase("x.nunit",           "Single",    typeof(TestDomainRunner))]
+        [TestCase("x.nunit",           "Single",    typeof(AggregatingTestRunner))]
         [TestCase("x.dll",             "Single",    typeof(TestDomainRunner))]
         [TestCase("x.nunit",           "Separate",  typeof(ProcessRunner))]
         [TestCase("x.dll",             "Separate",  typeof(ProcessRunner))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -22,6 +22,7 @@
 // ***********************************************************************
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Engine.Extensibility;
 
@@ -29,14 +30,31 @@ namespace NUnit.Engine.Services.Tests.Fakes
 {
     public class FakeProjectService : FakeService, IProjectService
     {
+        private string _supportedExtension;
+        private Dictionary<string, string[]> _projects = new Dictionary<string, string[]>();
+
+        public FakeProjectService(string supportedExtension = ".nunit")
+        {
+            _supportedExtension = supportedExtension;
+        }
+
+        public void Add(string projectName, params string[] assemblies)
+        {
+            _projects.Add(projectName, assemblies);
+        }
+
         void IProjectService.ExpandProjectPackage(TestPackage package)
         {
-            throw new NotImplementedException();
+            if (_projects.ContainsKey(package.Name))
+            {
+                foreach (string assembly in _projects[package.Name])
+                    package.AddSubPackage(new TestPackage(assembly));
+            }
         }
 
         bool IProjectService.CanLoadFrom(string path)
         {
-            return Path.GetExtension(path) == ".nunit";
+            return Path.GetExtension(path) == _supportedExtension;
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
@@ -43,7 +43,7 @@ namespace NUnit.Engine.Services.Tests
             _settingsService = new FakeSettingsService();
             _serviceManager.AddService(_settingsService);
 
-            _projectService = new FakeProjectService();
+            _projectService = new Fakes.FakeProjectService();
             _serviceManager.AddService(_projectService);
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -296,11 +296,8 @@ namespace NUnit.Engine.Runners
         {
             if (package == null) throw new ArgumentNullException("package");
 
-            string packageName = package.FullName;
-            if (File.Exists(packageName) && _projectService.CanLoadFrom(packageName))
-            {
+            if (_projectService.CanLoadFrom(package.FullName))
                 _projectService.ExpandProjectPackage(package);
-            }
         }
 
         // Any Errors thrown from this method indicate that the client

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -118,7 +118,10 @@ namespace NUnit.Engine.Services
                     return new ProcessRunner(this.ServiceContext, package);
 
                 case ProcessModel.InProcess:
-                    return base.MakeTestRunner(package);
+                    if (projectCount > 0)
+                        return new AggregatingTestRunner(ServiceContext, package);
+                    else
+                        return base.MakeTestRunner(package);
             }
         }
 


### PR DESCRIPTION
Fixes #533 

The first three commits merely serve to verify that no duplicates are generated when there are __no__ projects involved.I added cases with the notests-assembly because that's where I was seeing errors when they are included in projects. However, the tests didn't break anything.

Next step is to create some tests that use a project.