### PR TITLE
Update result message body to use output colour

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleTestResult.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleTestResult.cs
@@ -137,10 +137,10 @@ namespace NUnit.ConsoleRunner
                 string.Format("{0}) {1} : {2}", reportID, status, fullName));
 
             if (!string.IsNullOrEmpty(message))
-                writer.WriteLine(style, message);
+                writer.WriteLine(ColorStyle.Output, message);
 
             if (!string.IsNullOrEmpty(stackTrace))
-                writer.WriteLine(style, stackTrace);
+                writer.WriteLine(ColorStyle.Output, stackTrace);
 
             writer.WriteLine(); // Skip after each item
         }


### PR DESCRIPTION
Resolves #519 

The header of the result will still use the error/warning colour set for
the result writer.

Example of console result:
![image](https://user-images.githubusercontent.com/5313400/52527000-1cfc1380-2c87-11e9-852e-d1411b4fe4d3.png)
