### PR TITLE
Ensure that all subpackages are located correctly

### DIFF
--- a/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NUnit.Engine.Internal
+{
+    public delegate bool TestPackageSelectorDelegate(TestPackage p);
+
+    /// <summary>
+    /// Extension methods for use with TestPackages
+    /// </summary>
+    public static class TestPackageExtensions
+    {
+        public static bool IsAssemblyPackage(this TestPackage package)
+        {
+            return package.FullName != null && PathUtils.IsAssemblyFileType(package.FullName);
+        }
+
+        public static bool HasSubPackages(this TestPackage package)
+        {
+            return package.SubPackages.Count > 0;
+        }
+
+        public static IList<TestPackage> Select(this TestPackage package, TestPackageSelectorDelegate selector)
+        {
+            var selection = new List<TestPackage>();
+
+            AccumulatePackages(package, selection, selector);
+
+            return selection;
+        }
+
+        private static void AccumulatePackages(TestPackage package, IList<TestPackage> selection, TestPackageSelectorDelegate selector)
+        {
+            if (selector(package))
+                selection.Add(package);
+
+            foreach (var subPackage in package.SubPackages)
+                AccumulatePackages(subPackage, selection, selector);
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// ***********************************************************************
+// Copyright (c) 2019 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
 using System.Collections.Generic;
 
 namespace NUnit.Engine.Internal

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -101,10 +101,6 @@ namespace NUnit.Engine.Runners
         {
             var results = new List<TestEngineResult>();
 
-            var packages = new List<TestPackage>(TestPackage.SubPackages);
-            if (packages.Count == 0)
-                packages.Add(TestPackage);
-
             foreach (var runner in Runners)
                 results.Add(runner.Load());
 

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -99,15 +99,15 @@ namespace NUnit.Engine.Runners
         {
             var result = new TestEngineResult();
 
-            // DirectRunner may be called with a single-assembly package
-            // or a set of assemblies as subpackages.
-            var packages = TestPackage.SubPackages;
-            if (packages.Count == 0)
-                packages.Add(TestPackage);
+            // DirectRunner may be called with a single-assembly package,
+            // a set of assemblies as subpackages or even an arbitrary
+            // hierarchy of packages and subpackages with assemblies
+            // found in the terminal nodes.
+            var packagesToLoad = TestPackage.Select(p => !p.HasSubPackages());
 
             var driverService = Services.GetService<IDriverService>();
 
-            foreach (var subPackage in packages)
+            foreach (var subPackage in packagesToLoad)
             {
                 var testFile = subPackage.FullName;
 
@@ -207,12 +207,7 @@ namespace NUnit.Engine.Runners
 #if !NETSTANDARD1_6
             if (_assemblyResolver != null)
             {
-                var packages = TestPackage.SubPackages;
-
-                if (packages.Count == 0)
-                    packages.Add(TestPackage);
-
-                foreach (var package in packages)
+                foreach (var package in TestPackage.Select(p => p.IsAssemblyPackage()))
                     _assemblyResolver.RemovePathFromFile(package.FullName);
             }
 #endif


### PR DESCRIPTION
Fixes #546 

This fix ensures that all leaf packages - those without subpackages - are handled in DirectRunner no matter how deep the hierarchy of packages and subpackages is.

It continues to pass all tests and solves the problem of not being able to run a project file using the --process:Separate option. However, I have not added a test for that case since it would require a project loader extension to be installed in order to function. This seems to be another one to deal with in the accepttance tests.

I intended to make a similar change in AggregatingTestRunner but discovered that the comparable code there for examining packages was not being used and removed it.