### PR TITLE
Don't try to load extensions in case of incompatible target frameworks (fix #524)

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -29,7 +29,6 @@ using NUnit.Engine.Extensibility;
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
-using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services.Tests
 {
@@ -151,7 +150,7 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
-        public void SkipsGracefullyLoadingOtherFrameworkExtensionAssembly()
+        public void SkipsGracefullyLoadingOtherFrameworkDirectExtensionAssembly()
         {
             //May be null on mono
             Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
@@ -168,6 +167,28 @@ namespace NUnit.Engine.Services.Tests
             service.FindExtensionPoints(typeof(TestEngine).Assembly);
             service.FindExtensionPoints(typeof(ITestEngine).Assembly);
             var extensionAssembly = new ExtensionAssembly(assemblyName, false);
+
+            Assert.That(() => service.FindExtensionsInAssembly(extensionAssembly), Throws.TypeOf<NUnitEngineException>());
+        }
+
+        [Test]
+        public void SkipsGracefullyLoadingOtherFrameworkWildCardExtensionAssembly()
+        {
+            //May be null on mono
+            Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
+
+#if NETCOREAPP2_0
+            string other = "net35"; // Attempt to load the .NET 3.5 version of the extensions from the .NET Core 2.0 tests
+#elif NET35
+            string other = "netcoreapp2.0"; // Attempt to load the .NET Core 2.0 version of the extensions from the .NET 3.5 tests
+#endif
+            var assemblyName = Path.Combine(GetSiblingDirectory(other), "nunit.engine.tests.dll");
+            Assert.That(assemblyName, Does.Exist);
+
+            var service = new ExtensionService();
+            service.FindExtensionPoints(typeof(TestEngine).Assembly);
+            service.FindExtensionPoints(typeof(ITestEngine).Assembly);
+            var extensionAssembly = new ExtensionAssembly(assemblyName, true);
 
             Assert.That(() => service.FindExtensionsInAssembly(extensionAssembly), Throws.Nothing);
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -150,7 +150,7 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
-        public void SkipsGracefullyLoadingOtherFrameworkDirectExtensionAssembly()
+        public void FailsGracefullyLoadingOtherFrameworkDirectExtensionAssembly()
         {
             //May be null on mono
             Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -29,6 +29,7 @@ using NUnit.Engine.Extensibility;
 using System.IO;
 using System.Reflection;
 using System.Collections.Generic;
+using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Services.Tests
 {
@@ -150,7 +151,11 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
+<<<<<<< HEAD
         public void FailsGracefullyLoadingOtherFrameworkDirectExtensionAssembly()
+=======
+        public void SkipsGracefullyLoadingOtherFrameworkExtensionAssembly()
+>>>>>>> parent of e3b0ea48... Throw EngineException if extension target framework is incompatible and found via non-wildcard, otherwise just warn
         {
             //May be null on mono
             Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
@@ -167,28 +172,6 @@ namespace NUnit.Engine.Services.Tests
             service.FindExtensionPoints(typeof(TestEngine).Assembly);
             service.FindExtensionPoints(typeof(ITestEngine).Assembly);
             var extensionAssembly = new ExtensionAssembly(assemblyName, false);
-
-            Assert.That(() => service.FindExtensionsInAssembly(extensionAssembly), Throws.TypeOf<NUnitEngineException>());
-        }
-
-        [Test]
-        public void SkipsGracefullyLoadingOtherFrameworkWildCardExtensionAssembly()
-        {
-            //May be null on mono
-            Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
-
-#if NETCOREAPP2_0
-            string other = "net35"; // Attempt to load the .NET 3.5 version of the extensions from the .NET Core 2.0 tests
-#elif NET35
-            string other = "netcoreapp2.0"; // Attempt to load the .NET Core 2.0 version of the extensions from the .NET 3.5 tests
-#endif
-            var assemblyName = Path.Combine(GetSiblingDirectory(other), "nunit.engine.tests.dll");
-            Assert.That(assemblyName, Does.Exist);
-
-            var service = new ExtensionService();
-            service.FindExtensionPoints(typeof(TestEngine).Assembly);
-            service.FindExtensionPoints(typeof(ITestEngine).Assembly);
-            var extensionAssembly = new ExtensionAssembly(assemblyName, true);
 
             Assert.That(() => service.FindExtensionsInAssembly(extensionAssembly), Throws.Nothing);
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -151,7 +151,7 @@ namespace NUnit.Engine.Services.Tests
         }
 
         [Test]
-        public void FailsGracefullyLoadingOtherFrameworkExtensionAssembly()
+        public void SkipsGracefullyLoadingOtherFrameworkExtensionAssembly()
         {
             //May be null on mono
             Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
@@ -169,22 +169,21 @@ namespace NUnit.Engine.Services.Tests
             service.FindExtensionPoints(typeof(ITestEngine).Assembly);
             var extensionAssembly = new ExtensionAssembly(assemblyName, false);
 
-            Assert.That(() => service.FindExtensionsInAssembly(extensionAssembly),
-                Throws.TypeOf<NUnitEngineException>(), $"Loading extension targeting {new TargetFrameworkHelper(extensionAssembly.FilePath).FrameworkName} did not throw.");
+            Assert.That(() => service.FindExtensionsInAssembly(extensionAssembly), Throws.Nothing);
         }
 
         [TestCaseSource(nameof(ValidCombos))]
         public void ValidTargetFrameworkCombinations(FrameworkCombo combo)
         {
             Assert.That(() => ExtensionService.ValidateTargetFramework(combo.RunnerAssembly, combo.ExtensionAssembly),
-                Throws.Nothing);
+                Is.True);
         }
 
         [TestCaseSource(nameof(InvalidCombos))]
         public void InvalidTargetFrameworkCombinations(FrameworkCombo combo)
         {
             Assert.That(() => ExtensionService.ValidateTargetFramework(combo.RunnerAssembly, combo.ExtensionAssembly),
-                Throws.TypeOf<NUnitEngineException>());
+                Is.False);
         }
 
         // ExtensionAssembly is internal, so cannot be part of the public test parameters

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -517,14 +517,6 @@ namespace NUnit.Engine.Services
                     ep.Install(node);
                 }
             }
-            else if (!assembly.FromWildCard)
-            {
-                throw new NUnitEngineException($"Cannot load {assembly.FilePath} as extension assembly due not supported target framework.");
-            }
-            else
-            {
-                log.Warning($"Skipping {assembly.FilePath} assembly as extension assembly due not supported target framework.");
-            }
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -431,7 +431,7 @@ namespace NUnit.Engine.Services
         {
             log.Info("Scanning {0} assembly for Extensions", assembly.FilePath);
 
-            if (ValidateTargetFramework(Assembly.GetEntryAssembly(), assembly))
+            if (CanLoadTargetFramework(Assembly.GetEntryAssembly(), assembly))
             {
 
                 IRuntimeFramework assemblyTargetFramework = null;
@@ -525,7 +525,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="runnerAsm">The executing runner</param>
         /// <param name="extensionAsm">The extension we are attempting to load</param>
-        internal static bool ValidateTargetFramework(Assembly runnerAsm, ExtensionAssembly extensionAsm)
+        internal static bool CanLoadTargetFramework(Assembly runnerAsm, ExtensionAssembly extensionAsm)
         {
             if (runnerAsm == null)
                 return true;
@@ -534,20 +534,19 @@ namespace NUnit.Engine.Services
             var runnerHelper = new TargetFrameworkHelper(runnerAsm.Location);
             if (runnerHelper.FrameworkName?.StartsWith(".NETStandard") == true)
             {
-                log.Warning($"{runnerAsm.FullName} test runner must target .NET Core or .NET Framework, not .NET Standard");
-                return false;
+                throw new NUnitEngineException($"{runnerAsm.FullName} test runner must target .NET Core or .NET Framework, not .NET Standard");
             }
             else if (runnerHelper.FrameworkName?.StartsWith(".NETCoreApp") == true)
             {
                 if (extHelper.FrameworkName?.StartsWith(".NETStandard") != true && extHelper.FrameworkName?.StartsWith(".NETCoreApp") != true)
                 {
-                    log.Warning($".NET Core runners require .NET Core or .NET Standard extension for {extensionAsm.FilePath}");
+                    log.Info($".NET Core runners require .NET Core or .NET Standard extension for {extensionAsm.FilePath}");
                     return false;
                 }
             }
             else if (extHelper.FrameworkName?.StartsWith(".NETCoreApp") == true)
             {
-                log.Warning($".NET Framework runners cannot load .NET Core extension {extensionAsm.FilePath}");
+                log.Info($".NET Framework runners cannot load .NET Core extension {extensionAsm.FilePath}");
                 return false;
             }
 

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -517,6 +517,14 @@ namespace NUnit.Engine.Services
                     ep.Install(node);
                 }
             }
+            else if (!assembly.FromWildCard)
+            {
+                throw new NUnitEngineException($"Cannot load {assembly.FilePath} as extension assembly due not supported target framework.");
+            }
+            else
+            {
+                log.Warning($"Skipping {assembly.FilePath} assembly as extension assembly due not supported target framework.");
+            }
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -64,7 +64,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         public IEnumerable<IExtensionNode> Extensions
         {
-            get { return _extensions.ToArray();  }
+            get { return _extensions.ToArray(); }
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace NUnit.Engine.Services
         public IEnumerable<T> GetExtensions<T>()
         {
             foreach (var node in GetExtensionNodes<T>())
-              	 yield return (T)node.ExtensionObject;
+                yield return (T)node.ExtensionObject;
         }
 
         #endregion
@@ -431,89 +431,91 @@ namespace NUnit.Engine.Services
         {
             log.Info("Scanning {0} assembly for Extensions", assembly.FilePath);
 
-            ValidateTargetFramework(Assembly.GetEntryAssembly(), assembly);
-
-            IRuntimeFramework assemblyTargetFramework = null;
-#if !NETSTANDARD2_0
-            var currentFramework = RuntimeFramework.CurrentFramework;
-            assemblyTargetFramework = assembly.TargetFramework;
-            if (!currentFramework.CanLoad(assemblyTargetFramework))
+            if (ValidateTargetFramework(Assembly.GetEntryAssembly(), assembly))
             {
-                if (!assembly.FromWildCard)
+
+                IRuntimeFramework assemblyTargetFramework = null;
+#if !NETSTANDARD2_0
+                var currentFramework = RuntimeFramework.CurrentFramework;
+                assemblyTargetFramework = assembly.TargetFramework;
+                if (!currentFramework.CanLoad(assemblyTargetFramework))
                 {
-                    throw new NUnitEngineException($"Extension {assembly.FilePath} targets {assemblyTargetFramework.DisplayName}, which is not available.");
+                    if (!assembly.FromWildCard)
+                    {
+                        throw new NUnitEngineException($"Extension {assembly.FilePath} targets {assemblyTargetFramework.DisplayName}, which is not available.");
+                    }
+                    else
+                    {
+                        log.Info($"Assembly {assembly.FilePath} targets {assemblyTargetFramework.DisplayName}, which is not available. Assembly found via wildcard.");
+                        return;
+                    }
                 }
-                else
-                {
-                    log.Info($"Assembly {assembly.FilePath} targets {assemblyTargetFramework.DisplayName}, which is not available. Assembly found via wildcard.");
-                    return;
-                }
-            }
 #endif
 
-            foreach (var type in assembly.MainModule.GetTypes())
-            {
-                CustomAttribute extensionAttr = type.GetAttribute("NUnit.Engine.Extensibility.ExtensionAttribute");
-
-                if (extensionAttr == null)
-                    continue;
-
-                object versionArg = extensionAttr.GetNamedArgument("EngineVersion");
-                if (versionArg != null && new Version((string)versionArg) > ENGINE_VERSION)
-                    continue;
-
-                var node = new ExtensionNode(assembly.FilePath, type.FullName, assemblyTargetFramework);
-                node.Path = extensionAttr.GetNamedArgument("Path") as string;
-                node.Description = extensionAttr.GetNamedArgument("Description") as string;
-
-                object enabledArg = extensionAttr.GetNamedArgument("Enabled");
-                node.Enabled = enabledArg != null
-                    ? (bool)enabledArg : true;
-
-                log.Info("  Found ExtensionAttribute on Type " + type.Name);
-
-                foreach (var attr in type.GetAttributes("NUnit.Engine.Extensibility.ExtensionPropertyAttribute"))
+                foreach (var type in assembly.MainModule.GetTypes())
                 {
-                    string name = attr.ConstructorArguments[0].Value as string;
-                    string value = attr.ConstructorArguments[1].Value as string;
+                    CustomAttribute extensionAttr = type.GetAttribute("NUnit.Engine.Extensibility.ExtensionAttribute");
 
-                    if (name != null && value != null)
+                    if (extensionAttr == null)
+                        continue;
+
+                    object versionArg = extensionAttr.GetNamedArgument("EngineVersion");
+                    if (versionArg != null && new Version((string)versionArg) > ENGINE_VERSION)
+                        continue;
+
+                    var node = new ExtensionNode(assembly.FilePath, type.FullName, assemblyTargetFramework);
+                    node.Path = extensionAttr.GetNamedArgument("Path") as string;
+                    node.Description = extensionAttr.GetNamedArgument("Description") as string;
+
+                    object enabledArg = extensionAttr.GetNamedArgument("Enabled");
+                    node.Enabled = enabledArg != null
+                        ? (bool)enabledArg : true;
+
+                    log.Info("  Found ExtensionAttribute on Type " + type.Name);
+
+                    foreach (var attr in type.GetAttributes("NUnit.Engine.Extensibility.ExtensionPropertyAttribute"))
                     {
-                        node.AddProperty(name, value);
-                        log.Info("        ExtensionProperty {0} = {1}", name, value);
-                    }
-                }
+                        string name = attr.ConstructorArguments[0].Value as string;
+                        string value = attr.ConstructorArguments[1].Value as string;
 
-                _extensions.Add(node);
-
-                ExtensionPoint ep;
-                if (node.Path == null)
-                {
-                    ep = DeduceExtensionPointFromType(type);
-                    if (ep == null)
-                    {
-                        string msg = string.Format(
-                            "Unable to deduce ExtensionPoint for Type {0}. Specify Path on ExtensionAttribute to resolve.",
-                            type.FullName);
-                        throw new NUnitEngineException(msg);
+                        if (name != null && value != null)
+                        {
+                            node.AddProperty(name, value);
+                            log.Info("        ExtensionProperty {0} = {1}", name, value);
+                        }
                     }
 
-                    node.Path = ep.Path;
-                }
-                else
-                {
-                    ep = GetExtensionPoint(node.Path);
-                    if (ep == null)
-                    {
-                        string msg = string.Format(
-                            "Unable to locate ExtensionPoint for Type {0}. The Path {1} cannot be found.",
-                            type.FullName,
-                            node.Path);
-                        throw new NUnitEngineException(msg);
-                    }
-                }
+                    _extensions.Add(node);
 
-                ep.Install(node);
+                    ExtensionPoint ep;
+                    if (node.Path == null)
+                    {
+                        ep = DeduceExtensionPointFromType(type);
+                        if (ep == null)
+                        {
+                            string msg = string.Format(
+                                "Unable to deduce ExtensionPoint for Type {0}. Specify Path on ExtensionAttribute to resolve.",
+                                type.FullName);
+                            throw new NUnitEngineException(msg);
+                        }
+
+                        node.Path = ep.Path;
+                    }
+                    else
+                    {
+                        ep = GetExtensionPoint(node.Path);
+                        if (ep == null)
+                        {
+                            string msg = string.Format(
+                                "Unable to locate ExtensionPoint for Type {0}. The Path {1} cannot be found.",
+                                type.FullName,
+                                node.Path);
+                            throw new NUnitEngineException(msg);
+                        }
+                    }
+
+                    ep.Install(node);
+                }
             }
         }
 
@@ -523,28 +525,33 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="runnerAsm">The executing runner</param>
         /// <param name="extensionAsm">The extension we are attempting to load</param>
-        internal static void ValidateTargetFramework(Assembly runnerAsm, ExtensionAssembly extensionAsm)
+        internal static bool ValidateTargetFramework(Assembly runnerAsm, ExtensionAssembly extensionAsm)
         {
             if (runnerAsm == null)
-                return;
+                return true;
 
             var extHelper = new TargetFrameworkHelper(extensionAsm.FilePath);
             var runnerHelper = new TargetFrameworkHelper(runnerAsm.Location);
             if (runnerHelper.FrameworkName?.StartsWith(".NETStandard") == true)
             {
-                throw new NUnitEngineException("Test runners must target .NET Core or .NET Framework, not .NET Standard");
+                log.Warning($"{runnerAsm.FullName} test runner must target .NET Core or .NET Framework, not .NET Standard");
+                return false;
             }
             else if (runnerHelper.FrameworkName?.StartsWith(".NETCoreApp") == true)
             {
                 if (extHelper.FrameworkName?.StartsWith(".NETStandard") != true && extHelper.FrameworkName?.StartsWith(".NETCoreApp") != true)
                 {
-                    throw new NUnitEngineException(".NET Core runners require .NET Core or .NET Standard extensions");
+                    log.Warning($".NET Core runners require .NET Core or .NET Standard extension for {extensionAsm.FilePath}");
+                    return false;
                 }
             }
             else if (extHelper.FrameworkName?.StartsWith(".NETCoreApp") == true)
             {
-                throw new NUnitEngineException(".NET Framework runners cannot load .NET Core extensions");
+                log.Warning($".NET Framework runners cannot load .NET Core extension {extensionAsm.FilePath}");
+                return false;
             }
+
+            return true;
         }
 
         #endregion


### PR DESCRIPTION
Just skip loading of extensions if they are not compatible with target framework.
Extensions should not affect nunit engine execution.
Trying to fix #524 