### PR TITLE
Specify productVersion as an argument

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,6 +6,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
+var productVersion = Argument("productVersion", "3.10.0");
 
 var ErrorDetail = new List<string>();
 bool IsDotNetCoreInstalled = false;
@@ -14,12 +15,13 @@ bool IsDotNetCoreInstalled = false;
 // SET PACKAGE VERSION
 //////////////////////////////////////////////////////////////////////
 
-var version = "3.10.0";
-var modifier = "";
+var dash = productVersion.IndexOf('-');
+var version = dash > 0
+    ? productVersion.Substring(0, dash)
+    : productVersion;
 
 var isAppveyor = BuildSystem.IsRunningOnAppVeyor;
 var dbgSuffix = configuration == "Debug" ? "-dbg" : "";
-var productVersion = version + modifier + dbgSuffix;
 
 //////////////////////////////////////////////////////////////////////
 // DEFINE RUN CONSTANTS


### PR DESCRIPTION
Part of issue #551.

This merely allows a user running the script to specify an additional argument that gives the product Version to be used. The assembly version is parsed out of the product version and the default values remain the same if nothing is specified.

Note that this setting is intended for local use and will actually be overridden on AppVeyor. If it were desired to use it there, more modifications would be needed.