### PR TITLE
Comments documenting purpose of various runners

### DIFF
--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -28,11 +28,10 @@ using NUnit.Engine.Services;
 namespace NUnit.Engine.Runners
 {
     /// <summary>
-    /// AbstractTestRunner is the base class for all runners
-    /// within the NUnit Engine. It implements the ITestRunner
-    /// interface, which is used by clients of the engine and
-    /// uses a Template pattern with abstract methods overridden
-    /// by the derived runners.
+    /// AbstractTestRunner is the base class for all internal runners
+    /// within the NUnit Engine. It implements the ITestEngineRunner
+    /// interface, which uses TestEngineResults to communicate back
+    /// to higher level runners.
     /// </summary>
     public abstract class AbstractTestRunner : ITestEngineRunner
     {

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -38,8 +38,23 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public class AggregatingTestRunner : AbstractTestRunner
     {
+        // AggregatingTestRunner combines the results from tests run by different
+        // runners. It may be used as a base class or through one of it's derived
+        // classes, MultipleTestDomainRunner and MultipleTestProcessRunner.
+        //
         // The runners created by the derived class will (at least at the time
-        // of writing this comment) be either TestDomainRunners or ProcessRunners.
+        // of writing this comment) be either DirectTestRunners, ProcessRunners or
+        // AggregatingTestRunners.
+        //
+        // AggregatingTestRunner is used in the engine/runner process as well as in agent
+        // processes. It may be called with a TestPackage that specifies a single 
+        // assembly, multiple assemblies, a single project, multiple projects or
+        // a mix of projects and assemblies. Each file passed is handled by
+        // a single runner.
+        //
+        // TODO: Determine whether AggregatingTestRunner needs to create an XML result
+        // node for a project or if that responsibility can be delegated to the individual
+        // runners it creates.
         private List<ITestEngineRunner> _runners;
 
         // Exceptions from unloading individual runners are caught and rethrown

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -35,6 +35,29 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public abstract class DirectTestRunner : AbstractTestRunner
     {
+        // DirectTestRunner loads and runs tests in a particular AppDomain using
+        // one driver per assembly. All test assemblies are ultimately executed by
+        // one of the derived classes of DirectTestRunner, either LocalTestRunner
+        // or TestDomainRunner.
+        //
+        // DirectTestRunner creates an appropriate framework driver for each assembly
+        // included in the TestPackage. All frameworks loaded by the same DirectRunner
+        // must be compatible, i.e. runnable within the same AppDomain.
+        // 
+        // DirectTestRunner is used in the engine/runner process as well as in agent
+        // processes. It may be called with a TestPackage that specifies a single 
+        // assembly, multiple assemblies, a single project, multiple projects or
+        // a mix of projects and assemblies. This variety of potential package
+        // inputs complicates things. It arises from the fact that NUnit permits 
+        // the caller to specify that all projects and assemblies should be loaded 
+        // in the same AppDomain.
+        //
+        // TODO: When there are projects included in the TestPackage, DirectTestRUnner
+        // should create intermediate result nodes for each project.
+        //
+        // TODO: We really should detect and give a meaningful message if the user 
+        // tries to load incopatible frameworks in the same AppDomain.
+
         private readonly List<IFrameworkDriver> _drivers = new List<IFrameworkDriver>();
 
 #if !NETSTANDARD1_6

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -33,8 +33,25 @@ using System.ComponentModel;
 
 namespace NUnit.Engine.Runners
 {
+    /// <summary>
+    /// MasterTestRunner implements the ITestRunner interface, which
+    /// is the user-facing representation of a test runner. It uses
+    /// various internal runners to load and run tests for the user.
+    /// </summary>
     public class MasterTestRunner : ITestRunner
     {
+        // MasterTestRunner is the only runner that is passed back
+        // to users asking for an ITestRunner. The actual details of
+        // execution are handled by various internal runners, which
+        // impement ITestEngineRunner.
+        //
+        // Explore and execution results from MasterTestRunner are
+        // returned as XmlNodes, created from the internal 
+        // TestEngineResult representation.
+        // 
+        // MasterTestRUnner is responsible for creating the test-run
+        // element, which wraps all the individual assembly and project
+        // results.
         private const string TEST_RUN_ELEMENT = "test-run";
         private readonly ITestEngineRunner _engineRunner;
         private readonly IServiceLocator _services;

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -31,10 +31,18 @@ using NUnit.Engine.Services;
 namespace NUnit.Engine.Runners
 {
     /// <summary>
-    /// Summary description for ProcessRunner.
+    /// ProcessRunner loads and runs a set of tests in a single age process.
     /// </summary>
     public class ProcessRunner : AbstractTestRunner
     {
+        // ProcessRunner is given a TestPackage containing a single assembly
+        // multiple assemblies, a project, multiple projects or a mix. It loads
+        // and runs all tests in a single remote agent process.
+        //
+        // If the input contains projects, which are not summarized at a lower 
+        // level, the ProcessRunner should create an XML node for the entire
+        // project, aggregating the assembly results.
+
         private const int NORMAL_TIMEOUT = 30000;               // 30 seconds
         private const int DEBUG_TIMEOUT = NORMAL_TIMEOUT * 10;  // 5 minutes
 


### PR DESCRIPTION
@ChrisMaddock Here are some comments as you requested, giving the overall purpose and usage of each runner. I also added some TODOs for things I am aware of as not working.

Doing this was a good idea. Aside from its intrisic value, it gave me some ideas about how to handle the creation of project results. If nobody has started on it after my weekend trip, I'll grab it and take a shot.

Essentially - in case someone else wants to mess with it - my idea is that the aggregation of project results, which could happen in various places, really should be done at the lowest possible level, i.e. the first opportunity. Each runner can detect whether it is handling a top-level TestPackage that is a project and do the aggregation. Most of the actual aggregating methods are already in a utility class, so only the check would need to be duplicated.

The reasonig behind this is that a runner at certain level can check what the lower-level runners have done, but there is no way for it to know what higher-level runners __will__ do after it returns. Setting a rule that this happens at the lowest possible level gives us a standard for which tests can be written.