### PR TITLE
Eliminate use of ProjectService in agents and AbstractTestRunner

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -123,7 +123,6 @@ namespace NUnit.Agent
             //log.Info("Adding Services");
             engine.Services.Add(new SettingsService(false));
             engine.Services.Add(new ExtensionService());
-            engine.Services.Add(new ProjectService());
             engine.Services.Add(new DomainManager());
             engine.Services.Add(new InProcessTestRunnerFactory());
             engine.Services.Add(new DriverService());

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -121,7 +121,6 @@ namespace NUnit.Agent
 
             // Custom Service Initialization
             //log.Info("Adding Services");
-            engine.Services.Add(new SettingsService(false));
             engine.Services.Add(new ExtensionService());
             engine.Services.Add(new DomainManager());
             engine.Services.Add(new InProcessTestRunnerFactory());

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -39,7 +39,6 @@ namespace NUnit.Engine.Runners
         {
             Services = services;
             TestRunnerFactory = Services.GetService<ITestRunnerFactory>();
-            ProjectService = Services.GetService<IProjectService>();
             TestPackage = package;
         }
 
@@ -49,8 +48,6 @@ namespace NUnit.Engine.Runners
         /// Our Service Context
         /// </summary>
         protected IServiceLocator Services { get; private set; }
-
-        protected IProjectService ProjectService { get; private set; }
 
         protected ITestRunnerFactory TestRunnerFactory { get; private set; }
 


### PR DESCRIPTION
Fixes #563

After eliminating the reference in Program.cs, I realized that the reference in AbstractTestRunner was unused. That makes sense because AbstractTestRunner is the base class for all ITestEngineRunners. If the reference were needed, then the service would be needed in the agent as well.