### PR TITLE
Eliminate -dbg suffix from version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -21,7 +21,6 @@ var version = dash > 0
     : productVersion;
 
 var isAppveyor = BuildSystem.IsRunningOnAppVeyor;
-var dbgSuffix = configuration == "Debug" ? "-dbg" : "";
 
 //////////////////////////////////////////////////////////////////////
 // DEFINE RUN CONSTANTS
@@ -87,11 +86,11 @@ Setup(context =>
 
         if (branch == "master" && !isPullRequest)
         {
-            productVersion = version + "-dev-" + buildNumber + dbgSuffix;
+            productVersion = version + "-dev-" + buildNumber;
         }
         else
         {
-            var suffix = "-ci-" + buildNumber + dbgSuffix;
+            var suffix = "-ci-" + buildNumber;
 
             if (isPullRequest)
                 suffix += "-pr-" + AppVeyor.Environment.PullRequest.Number;


### PR DESCRIPTION
This PR is part of issue #551, point 2.

Simply eliminating it, as I have done here, seems to do the job for me. I no longer have to contend with unwanted changes to AssemblyInfo.cs simply because I build Debug from the command-line.

If we wanted to actually __publish__ debug__ builds through AppVeyor, that would require more work.