### PR TITLE
Single YAML-based Azure DevOps build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,6 @@ root = true
 indent_style = space
 indent_size = 4
 
-[*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml}]
+[*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml,yml}]
 indent_style = space
 indent_size = 2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,117 @@
+trigger:
+  branches:
+    include: [ '*' ]
+    exclude: [ 'refs/tags/*' ]
+
+jobs:
+
+- job: Windows
+  pool:
+    vmImage: vs2017-win2016
+  steps:
+
+  - powershell: .\build.ps1 -Target Test -Configuration Release
+    displayName: Build and test
+
+  # Workaround for https://github.com/nunit/nunit/issues/3012#issuecomment-441517922
+  - task: PublishTestResults@2
+    displayName: Publish net35 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results\net35\*.xml
+      mergeTestResults: true
+      testRunTitle: net35/Windows
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp1.1 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results\netcoreapp1.1\*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp1.1/Windows
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp2.0 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results\netcoreapp2.0\*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp2.0/Windows
+    condition: succeededOrFailed()
+
+  - powershell: .\build.ps1 -Target Package --artifact-dir='$(Build.ArtifactStagingDirectory)'
+    displayName: Package
+
+  - task: PublishBuildArtifacts@1
+    displayName: Save package artifacts
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)
+      ArtifactName: Package
+
+- job: Linux
+  pool:
+    vmImage: ubuntu-16.04
+  steps:
+
+  - bash: ./build.sh --target Test --configuration Release
+    displayName: Build and test
+
+  # Workaround for https://github.com/nunit/nunit/issues/3012#issuecomment-441517922
+  - task: PublishTestResults@2
+    displayName: Publish net35 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/net35/*.xml
+      mergeTestResults: true
+      testRunTitle: net35/Linux
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp1.1 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/netcoreapp1.1/*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp1.1/Linux
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp2.0 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/netcoreapp2.0/*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp2.0/Linux
+    condition: succeededOrFailed()
+
+- job: macOS
+  pool:
+    vmImage: macOS-10.13
+  steps:
+
+  - bash: ./build.sh --target Test --configuration Release
+    displayName: Build and test
+
+  # Workaround for https://github.com/nunit/nunit/issues/3012#issuecomment-441517922
+  - task: PublishTestResults@2
+    displayName: Publish net35 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/net35/*.xml
+      mergeTestResults: true
+      testRunTitle: net35/macOS
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp1.1 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/netcoreapp1.1/*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp1.1/macOS
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp2.0 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/netcoreapp2.0/*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp2.0/macOS
+    condition: succeededOrFailed()

--- a/build.cake
+++ b/build.cake
@@ -97,7 +97,7 @@ Setup(context =>
             else if (AppVeyor.Environment.Repository.Branch.StartsWith("release", StringComparison.OrdinalIgnoreCase))
                 suffix += "-pre-" + buildNumber;
             else
-                suffix += "-" + branch;
+                suffix += "-" + System.Text.RegularExpressions.Regex.Replace(branch, "[^0-9A-Za-z-]+", "-");
 
             // Nuget limits "special version part" to 20 chars. Add one for the hyphen.
             if (suffix.Length > 21)

--- a/build.cake
+++ b/build.cake
@@ -27,7 +27,7 @@ var isAppveyor = BuildSystem.IsRunningOnAppVeyor;
 //////////////////////////////////////////////////////////////////////
 
 var PROJECT_DIR = Context.Environment.WorkingDirectory.FullPath + "/";
-var PACKAGE_DIR = PROJECT_DIR + "package/";
+var PACKAGE_DIR = Argument("artifact-dir", PROJECT_DIR + "package") + "/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var NET35_BIN_DIR = BIN_DIR + "net35/";
 var NETCOREAPP11_BIN_DIR = BIN_DIR + "netcoreapp1.1/";

--- a/build.cake
+++ b/build.cake
@@ -260,8 +260,7 @@ Task("TestNetStandard16Engine")
             RunDotnetCoreTests(
                 NETCOREAPP11_BIN_DIR + ENGINE_TESTS,
                 NETCOREAPP11_BIN_DIR,
-                frameworkVersion: "1.1.2", // 1.1.2 is the highest version currently available on Appveyor
-                frameworkName: "netcoreapp1.1",
+                "netcoreapp1.1",
                 ref ErrorDetail);
         }
         else
@@ -285,8 +284,7 @@ Task("TestNetStandard20Engine")
             RunDotnetCoreTests(
                 NETCOREAPP20_BIN_DIR + ENGINE_TESTS,
                 NETCOREAPP20_BIN_DIR,
-                frameworkVersion: "2.0.6",
-                frameworkName: "netcoreapp2.0",
+                "netcoreapp2.0",
                 ref ErrorDetail);
         }
         else
@@ -553,28 +551,27 @@ void RunTest(FilePath exePath, DirectoryPath workingDir, string testAssembly, st
         errorDetail.Add(string.Format("{0} returned rc = {1}", exePath, rc));
 }
 
-void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string frameworkVersion, string frameworkName, ref List<string> errorDetail)
+void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string framework, ref List<string> errorDetail)
 {
-    RunDotnetCoreTests(exePath, workingDir, arguments: null, frameworkVersion, frameworkName, ref errorDetail);
+    RunDotnetCoreTests(exePath, workingDir, arguments: null, framework, ref errorDetail);
 }
 
-void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string arguments, string frameworkVersion, string frameworkName, ref List<string> errorDetail)
+void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string arguments, string framework, ref List<string> errorDetail)
 {
     int rc = StartProcess(
         "dotnet",
         new ProcessSettings
         {
             Arguments = new ProcessArgumentBuilder()
-                .AppendSwitchQuoted("--fx-version", frameworkVersion)
                 .AppendQuoted(exePath.FullPath)
                 .Append(arguments)
-                .AppendSwitchQuoted("--result", ":", GetResultXmlPath(exePath.FullPath, frameworkName).FullPath)
+                .AppendSwitchQuoted("--result", ":", GetResultXmlPath(exePath.FullPath, framework).FullPath)
                 .Render(),
             WorkingDirectory = workingDir
         });
 
     if (rc > 0)
-        errorDetail.Add(string.Format("{0}: {1} tests failed", frameworkName, rc));
+        errorDetail.Add(string.Format("{0}: {1} tests failed", framework, rc));
     else if (rc < 0)
         errorDetail.Add(string.Format("{0} returned rc = {1}", exePath, rc));
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.30.0" />
+    <package id="Cake" version="0.32.1" />
 </packages>


### PR DESCRIPTION
Pretty much a copy of https://github.com/nunit/nunit/pull/3096. Closes https://github.com/nunit/nunit-console/issues/508.

**When this PR is merged**, whoever gets there first should set https://nunit.visualstudio.com/NUnit/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=13&view=Tab_Triggers to stop overriding the YAML triggers and allow pushes and PRs to trigger the build for validation:

![image](https://user-images.githubusercontent.com/8040367/54470737-c2713e00-4783-11e9-9740-4bfb6c798f4f.png)

### Test results

![image](https://user-images.githubusercontent.com/8040367/54470625-5392e580-4781-11e9-8b15-37328318198c.png)

### Artifacts

The Windows build runs the Package target and creates an artifact named Package (maybe later we should split into multiple artifacts):

![image](https://user-images.githubusercontent.com/8040367/54470637-9e146200-4781-11e9-9565-961ed2d213d1.png)

