### PR TITLE
Add --testparam to enable test parameters to contain semicolons

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -722,6 +722,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             var options = new ConsoleOptions("--params=X=5");
             Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.WarningMessages, Has.One.Contains("deprecated").IgnoreCase);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" } }));
         }
 
@@ -730,6 +731,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             var options = new ConsoleOptions("--params:X=5;Y=7");
             Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.WarningMessages, Has.One.Contains("deprecated").IgnoreCase);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" } }));
         }
 
@@ -738,6 +740,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             var options = new ConsoleOptions("-p:X=5", "-p:Y=7");
             Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.WarningMessages, Has.One.Contains("deprecated").IgnoreCase);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" } }));
         }
 
@@ -746,6 +749,7 @@ namespace NUnit.ConsoleRunner.Tests
         {
             var options = new ConsoleOptions("--params:X=5;Y=7", "-p:Z=3");
             Assert.That(options.ErrorMessages, Is.Empty);
+            Assert.That(options.WarningMessages, Has.One.Contains("deprecated").IgnoreCase);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" }, { "Z", "3" } }));
         }
 
@@ -753,6 +757,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void DeprecatedParameterWithoutEqualSignIsInvalid()
         {
             var options = new ConsoleOptions("--params=X5");
+            Assert.That(options.WarningMessages, Has.One.Contains("deprecated").IgnoreCase);
             Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
         }
 

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -709,7 +709,7 @@ namespace NUnit.ConsoleRunner.Tests
             // Not copying this test file into releases
             Assume.That(testListPath, Does.Exist);
             var options = new ConsoleOptions("--testlist=" + testListPath);
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestList, Is.EqualTo(new[] {"AmazingTest"}));
         }
 
@@ -721,7 +721,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void SingleDeprecatedTestParameter()
         {
             var options = new ConsoleOptions("--params=X=5");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" } }));
         }
 
@@ -729,7 +729,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void TwoDeprecatedTestParametersInOneOption()
         {
             var options = new ConsoleOptions("--params:X=5;Y=7");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" } }));
         }
 
@@ -737,7 +737,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void TwoDeprecatedTestParametersInSeparateOptions()
         {
             var options = new ConsoleOptions("-p:X=5", "-p:Y=7");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" } }));
         }
 
@@ -745,7 +745,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void ThreeDeprecatedTestParametersInTwoOptions()
         {
             var options = new ConsoleOptions("--params:X=5;Y=7", "-p:Z=3");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" }, { "Z", "3" } }));
         }
 
@@ -760,7 +760,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void SingleTestParameter()
         {
             var options = new ConsoleOptions("--testparam=X=5");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" } }));
         }
 
@@ -768,7 +768,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void SemicolonsDoNotSplitTestParameters()
         {
             var options = new ConsoleOptions("--testparam:X=5;Y=7");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5;Y=7" } }));
         }
 
@@ -776,7 +776,7 @@ namespace NUnit.ConsoleRunner.Tests
         public void TwoTestParametersInSeparateOptions()
         {
             var options = new ConsoleOptions("--testparam:X=5", "--testparam:Y=7");
-            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" } }));
         }
 

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -802,6 +802,78 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
+        public void LeadingWhitespaceIsPreservedInParameterName()
+        {
+            // Command line examples to get in this scenario:
+            // --testparams:"  X"=5
+            // --testparams:"  X=5"
+            // "--testparams:  X=5"
+
+            var options = new ConsoleOptions("--testparam:  X=5");
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["  X"] = "5" }));
+        }
+
+        [Test]
+        public void TrailingWhitespaceIsPreservedInParameterName()
+        {
+            // Command line examples to get in this scenario:
+            // --testparams:"X  "=5
+            // --testparams:"X  =5"
+            // "--testparams:X  =5"
+
+            var options = new ConsoleOptions("--testparam:X  =5");
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["X  "] = "5" }));
+        }
+
+        [Test]
+        public void WhitespaceIsPermittedAsParameterName()
+        {
+            // Command line examples to get in this scenario:
+            // --testparams:"  "=5
+            // --testparams:"  =5"
+            // "--testparams:  =5"
+
+            var options = new ConsoleOptions("--testparam:  =5");
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["  "] = "5" }));
+        }
+
+        [Test]
+        public void LeadingWhitespaceIsPreservedInParameterValue()
+        {
+            // Command line examples to get in this scenario:
+            // --testparams:X="  5"
+            // --testparams:"X=  5"
+            // "--testparams:X=  5"
+
+            var options = new ConsoleOptions("--testparam:X=  5");
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["X"] = "  5" }));
+        }
+
+        [Test]
+        public void TrailingWhitespaceIsPreservedInParameterValue()
+        {
+            // Command line examples to get in this scenario:
+            // --testparams:X="5  "
+            // --testparams:"X=5  "
+            // "--testparams:X=5  "
+
+            var options = new ConsoleOptions("--testparam:X=5  ");
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["X"] = "5  " }));
+        }
+
+        [Test]
+        public void WhitespaceIsPermittedAsParameterValue()
+        {
+            // Command line examples to get in this scenario:
+            // --testparams:X="  "
+            // --testparams:"X=  "
+            // "--testparams:X=  "
+
+            var options = new ConsoleOptions("--testparam:X=  ");
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["X"] = "  " }));
+        }
+
+        [Test]
         public void DisplayTestParameters()
         {
             if (TestContext.Parameters.Count == 0)

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -788,6 +788,35 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
+        public void ParameterWithMissingNameIsInvalid()
+        {
+            var options = new ConsoleOptions("--testparam:=5");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ParameterWithWhitespaceNameIsInvalid()
+        {
+            var options = new ConsoleOptions("--testparam: =5");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ParameterWithMissingValueIsInvalid()
+        {
+            var options = new ConsoleOptions("--testparam:X=");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void ParameterWithWhitespaceValueIsValid()
+        {
+            var options = new ConsoleOptions("--testparam:X= ");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["X"] = " " }));
+        }
+
+        [Test]
         public void DisplayTestParameters()
         {
             if (TestContext.Parameters.Count == 0)

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -795,25 +795,10 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
-        public void ParameterWithWhitespaceNameIsInvalid()
-        {
-            var options = new ConsoleOptions("--testparam: =5");
-            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
-        }
-
-        [Test]
         public void ParameterWithMissingValueIsInvalid()
         {
             var options = new ConsoleOptions("--testparam:X=");
             Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
-        }
-
-        [Test]
-        public void ParameterWithWhitespaceValueIsValid()
-        {
-            var options = new ConsoleOptions("--testparam:X= ");
-            Assert.That(options.errorMessages, Is.Empty);
-            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { ["X"] = " " }));
         }
 
         [Test]

--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -718,7 +718,7 @@ namespace NUnit.ConsoleRunner.Tests
         #region Test Parameters
 
         [Test]
-        public void SingleTestParameter()
+        public void SingleDeprecatedTestParameter()
         {
             var options = new ConsoleOptions("--params=X=5");
             Assert.That(options.errorMessages, Is.Empty);
@@ -726,7 +726,7 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
-        public void TwoTestParametersInOneOption()
+        public void TwoDeprecatedTestParametersInOneOption()
         {
             var options = new ConsoleOptions("--params:X=5;Y=7");
             Assert.That(options.errorMessages, Is.Empty);
@@ -734,7 +734,7 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
-        public void TwoTestParametersInSeparateOptions()
+        public void TwoDeprecatedTestParametersInSeparateOptions()
         {
             var options = new ConsoleOptions("-p:X=5", "-p:Y=7");
             Assert.That(options.errorMessages, Is.Empty);
@@ -742,7 +742,7 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
-        public void ThreeTestParametersInTwoOptions()
+        public void ThreeDeprecatedTestParametersInTwoOptions()
         {
             var options = new ConsoleOptions("--params:X=5;Y=7", "-p:Z=3");
             Assert.That(options.errorMessages, Is.Empty);
@@ -750,9 +750,40 @@ namespace NUnit.ConsoleRunner.Tests
         }
 
         [Test]
-        public void ParameterWithoutEqualSignIsInvalid()
+        public void DeprecatedParameterWithoutEqualSignIsInvalid()
         {
             var options = new ConsoleOptions("--params=X5");
+            Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SingleTestParameter()
+        {
+            var options = new ConsoleOptions("--testparam=X=5");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" } }));
+        }
+
+        [Test]
+        public void SemicolonsDoNotSplitTestParameters()
+        {
+            var options = new ConsoleOptions("--testparam:X=5;Y=7");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5;Y=7" } }));
+        }
+
+        [Test]
+        public void TwoTestParametersInSeparateOptions()
+        {
+            var options = new ConsoleOptions("--testparam:X=5", "--testparam:Y=7");
+            Assert.That(options.errorMessages, Is.Empty);
+            Assert.That(options.TestParameters, Is.EqualTo(new Dictionary<string, string> { { "X", "5" }, { "Y", "7" } }));
+        }
+
+        [Test]
+        public void ParameterWithoutEqualSignIsInvalid()
+        {
+            var options = new ConsoleOptions("--testparam=X5");
             Assert.That(options.ErrorMessages.Count, Is.EqualTo(1));
         }
 

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -154,11 +154,13 @@ namespace NUnit.Common
 
         // Error Processing
 
+        public IList<string> WarningMessages { get; } = new List<string>();
+
         public IList<string> ErrorMessages { get; } = new List<string>();
 
-#endregion
+        #endregion
 
-#region Public Methods
+        #region Public Methods
 
         public bool Validate()
         {

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -292,28 +292,19 @@ namespace NUnit.Common
             this.Add("where=", "Test selection {EXPRESSION} indicating what tests will be run. See description below.",
                 v => WhereClause = RequiredValue(v, "--where"));
 
-            this.Add("params|p=", "Define a test parameter.",
+            this.Add("params|p=", "Deprecated and will be removed in a future release. Please use --testparam instead.",
                 v =>
                 {
                     string parameters = RequiredValue( v, "--params");
 
-                    // This can be changed without breaking backwards compatibility with frameworks.
                     foreach (string param in parameters.Split(new[] { ';' }))
                     {
-                        int eq = param.IndexOf("=");
-                        if (eq == -1 || eq == param.Length - 1)
-                        {
-                            ErrorMessages.Add("Invalid format for test parameter. Use NAME=VALUE.");
-                        }
-                        else
-                        {
-                            string name = param.Substring(0, eq);
-                            string val = param.Substring(eq + 1);
-
-                            TestParameters[name] = val;
-                        }
+                        ApplyTestParameter(param);
                     }
                 });
+
+            this.Add("testparam=", "Sets a single named value which test code can access.",
+                v => ApplyTestParameter(RequiredValue(v, "--testparam")));
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
                 v => defaultTimeout = RequiredInt(v, "--timeout"));
@@ -384,6 +375,23 @@ namespace NUnit.Common
                 else
                     InputFiles.Add(v);
             });
+        }
+
+        private void ApplyTestParameter(string testParameterSpecification)
+        {
+            var equalsIndex = testParameterSpecification.IndexOf("=");
+
+            if (equalsIndex == -1 || equalsIndex == testParameterSpecification.Length - 1)
+            {
+                ErrorMessages.Add("Invalid format for test parameter. Use NAME=VALUE.");
+            }
+            else
+            {
+                string name = testParameterSpecification.Substring(0, equalsIndex);
+                string value = testParameterSpecification.Substring(equalsIndex + 1);
+
+                TestParameters[name] = value;
+            }
         }
 
         private void ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications)

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -86,31 +86,24 @@ namespace NUnit.Common
 
         // Select tests
 
-        private List<string> inputFiles = new List<string>();
-        public IList<string> InputFiles { get { return inputFiles; } }
+        public IList<string> InputFiles { get; } = new List<string>();
 
-        private List<string> testList = new List<string>();
-        public IList<string> TestList { get { return testList; } }
+        public IList<string> TestList { get; } =  new List<string>();
 
-        private Dictionary<string, string> testParameters = new Dictionary<string, string>();
-        public IDictionary<string, string> TestParameters { get { return testParameters; } }
+        public IDictionary<string, string> TestParameters { get; } = new Dictionary<string, string>();
 
         public string WhereClause { get; private set; }
         public bool WhereClauseSpecified { get { return WhereClause != null; } }
 
-        private int defaultTimeout = -1;
-        public int DefaultTimeout { get { return defaultTimeout; } }
-        public bool DefaultTimeoutSpecified { get { return defaultTimeout >= 0; } }
+        public int DefaultTimeout { get; private set; } = -1;
+        public bool DefaultTimeoutSpecified { get { return DefaultTimeout >= 0; } }
 
-        private int randomSeed = -1;
-        public int RandomSeed { get { return randomSeed; } }
-        public bool RandomSeedSpecified { get { return randomSeed >= 0; } }
+        public int RandomSeed { get; private set; } = -1;
+        public bool RandomSeedSpecified { get { return RandomSeed >= 0; } }
 
         public string DefaultTestNamePattern { get; private set; }
-
-        private int numWorkers = -1;
-        public int NumberOfTestWorkers { get { return numWorkers; } }
-        public bool NumberOfTestWorkersSpecified { get { return numWorkers >= 0; } }
+        public int NumberOfTestWorkers { get; private set; } = -1;
+        public bool NumberOfTestWorkersSpecified { get { return NumberOfTestWorkers >= 0; } }
 
         public bool StopOnError { get; private set; }
 
@@ -141,7 +134,7 @@ namespace NUnit.Common
         public string InternalTraceLevel { get; private set; }
         public bool InternalTraceLevelSpecified { get { return InternalTraceLevel != null; } }
 
-        private List<OutputSpecification> resultOutputSpecifications = new List<OutputSpecification>();
+        private readonly List<OutputSpecification> resultOutputSpecifications = new List<OutputSpecification>();
         public IList<OutputSpecification> ResultOutputSpecifications
         {
             get
@@ -157,13 +150,11 @@ namespace NUnit.Common
             }
         }
 
-        private List<OutputSpecification> exploreOutputSpecifications = new List<OutputSpecification>();
-        public IList<OutputSpecification> ExploreOutputSpecifications { get { return exploreOutputSpecifications; } }
+        public IList<OutputSpecification> ExploreOutputSpecifications { get; } = new List<OutputSpecification>();
 
         // Error Processing
 
-        public List<string> errorMessages = new List<string>();
-        public IList<string> ErrorMessages { get { return errorMessages; } }
+        public IList<string> ErrorMessages { get; } = new List<string>();
 
 #endregion
 
@@ -307,13 +298,13 @@ namespace NUnit.Common
                 v => ApplyTestParameter(RequiredValue(v, "--testparam")));
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",
-                v => defaultTimeout = RequiredInt(v, "--timeout"));
+                v => DefaultTimeout = RequiredInt(v, "--timeout"));
 
             this.Add("seed=", "Set the random {SEED} used to generate test cases.",
-                v => randomSeed = RequiredInt(v, "--seed"));
+                v => RandomSeed = RequiredInt(v, "--seed"));
 
             this.Add("workers=", "Specify the {NUMBER} of worker threads to be used in running tests. If not specified, defaults to 2 or the number of processors, whichever is greater.",
-                v => numWorkers = RequiredInt(v, "--workers"));
+                v => NumberOfTestWorkers = RequiredInt(v, "--workers"));
 
             this.Add("stoponerror", "Stop run immediately upon any test failure or error.",
                 v => StopOnError = v != null);

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -301,7 +301,7 @@ namespace NUnit.Common
                     }
                 });
 
-            this.Add("testparam=", "Followed by a key-value pair separated by an equals sign. Test code can access the value by name.",
+            this.Add("testparam|tp=", "Followed by a key-value pair separated by an equals sign. Test code can access the value by name.",
                 v => ApplyTestParameter(RequiredValue(v, "--testparam")));
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -301,7 +301,7 @@ namespace NUnit.Common
                     }
                 });
 
-            this.Add("testparam=", "Sets a single named value which test code can access.",
+            this.Add("testparam=", "Followed by a key-value pair separated by an equals sign. Test code can access the value by name.",
                 v => ApplyTestParameter(RequiredValue(v, "--testparam")));
 
             this.Add("timeout=", "Set timeout for each test case in {MILLISECONDS}.",

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -288,6 +288,11 @@ namespace NUnit.Common
             this.Add("params|p=", "Deprecated and will be removed in a future release. Please use --testparam instead.",
                 v =>
                 {
+                    const string deprecationWarning = "--params is deprecated and will be removed in a future release. Please use --testparam instead.";
+
+                    if (!WarningMessages.Contains(deprecationWarning))
+                        WarningMessages.Add(deprecationWarning);
+
                     string parameters = RequiredValue( v, "--params");
 
                     foreach (string param in parameters.Split(new[] { ';' }))

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -381,7 +381,7 @@ namespace NUnit.Common
         {
             var equalsIndex = testParameterSpecification.IndexOf("=");
 
-            if (equalsIndex == -1 || equalsIndex == testParameterSpecification.Length - 1)
+            if (equalsIndex <= 0 || equalsIndex == testParameterSpecification.Length - 1)
             {
                 ErrorMessages.Add("Invalid format for test parameter. Use NAME=VALUE.");
             }

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -98,6 +98,14 @@ namespace NUnit.ConsoleRunner
                 if (Options.ShowVersion)
                     return ConsoleRunner.OK;
 
+                if (Options.WarningMessages.Count != 0)
+                {
+                    foreach (string message in Options.WarningMessages)
+                        OutWriter.WriteLine(ColorStyle.Warning, message);
+
+                    OutWriter.WriteLine();
+                }
+
                 if (!Options.Validate())
                 {
                     using (new ColorConsole(ColorStyle.Error))


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit-console/issues/23. Feel free to ignore till after the release is done (unless there's a reason you'd like to get it in 3.10).

Visual updates:

![image](https://user-images.githubusercontent.com/8040367/54498487-8f8f8d00-48de-11e9-8690-42f95c53ab08.png)

![image](https://user-images.githubusercontent.com/8040367/54498504-adf58880-48de-11e9-8344-34fb945f2546.png)

Let me know if there's anything you'd like to do differently.