### PR TITLE
[WIP] Add project result elements to XML

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -199,7 +199,7 @@ namespace NUnit.ConsoleRunner.Tests
 
         private static TestEngineResult AddMetadata(TestEngineResult input)
         {
-            return input.Aggregate("test-run start-time=\"2015-10-19 02:12:28Z\" end-time=\"2015-10-19 02:12:29Z\" duration=\"0.348616\"", string.Empty, string.Empty);
+            return input.Aggregate("test-run start-time=\"2015-10-19 02:12:28Z\" end-time=\"2015-10-19 02:12:29Z\" duration=\"0.348616\"", "2", string.Empty, string.Empty);
         }
 
         private string GetReport(TestDelegate del)

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="0.1.0-dev-00079" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />

--- a/src/NUnitEngine/nunit.engine.tests/ResultHelperTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/ResultHelperTests.cs
@@ -61,7 +61,7 @@ namespace NUnit.Engine.Internal.Tests
         [Test]
         public void AggregateTestResult()
         {
-            TestEngineResult combined = result2.Aggregate("test-run", "NAME", "FULLNAME");
+            TestEngineResult combined = result2.Aggregate("test-run", "2", "NAME", "FULLNAME");
             Assert.That(combined.IsSingle);
 
             XmlNode combinedNode = combined.Xml;
@@ -79,13 +79,14 @@ namespace NUnit.Engine.Internal.Tests
         [Test]
         public void MergeAndAggregateTestResults()
         {
-            TestEngineResult combined = ResultHelper.Merge(twoResults).Aggregate("test-suite", "Project", "NAME", "FULLNAME");
+            TestEngineResult combined = ResultHelper.Merge(twoResults).Aggregate("test-suite", "Project", "ID", "NAME", "FULLNAME");
             Assert.That(combined.IsSingle);
 
             XmlNode combinedNode = combined.Xml;
 
             Assert.That(combinedNode.Name, Is.EqualTo("test-suite"));
             Assert.That(combinedNode.Attributes["type"].Value, Is.EqualTo("Project"));
+            Assert.That(combinedNode.Attributes["id"].Value, Is.EqualTo("ID"));
             Assert.That(combinedNode.Attributes["name"].Value, Is.EqualTo("NAME"));
             Assert.That(combinedNode.Attributes["fullname"].Value, Is.EqualTo("FULLNAME"));
             Assert.That(combinedNode.Attributes["result"].Value, Is.EqualTo("Failed"));
@@ -100,7 +101,7 @@ namespace NUnit.Engine.Internal.Tests
         [Test]
         public void AggregateXmlNodes()
         {
-            XmlNode combined = ResultHelper.Aggregate("test-run", "NAME", "FULLNAME", twoNodes);
+            XmlNode combined = ResultHelper.Aggregate("test-run", "ID", "NAME", "FULLNAME", twoNodes);
 
             Assert.That(combined.Name, Is.EqualTo("test-run"));
             Assert.That(combined.Attributes["name"].Value, Is.EqualTo("NAME"));
@@ -139,7 +140,7 @@ namespace NUnit.Engine.Internal.Tests
             var firstEngineResult = new TestEngineResult(firstResultText);
             var secondEngineResult = new TestEngineResult(secondResultText);
             var data = new XmlNode[]{ firstEngineResult.Xml, secondEngineResult.Xml };
-            XmlNode combined = ResultHelper.Aggregate("test-run", "NAME", "FULLNAME", data);
+            XmlNode combined = ResultHelper.Aggregate("test-run", "ID", "NAME", "FULLNAME", data);
             Assert.That(combined.Attributes["result"].Value, Is.EqualTo(aggregateResult));
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -82,7 +82,19 @@ namespace NUnit.Engine.Runners.Tests
             new AssemblyData("mock-assembly.dll", "Runnable", MockAssembly.Tests, MockAssembly.PassedInAttribute, MockAssembly.Failed, MockAssembly.Skipped, MockAssembly.Inconclusive);
 
         static AssemblyData NoTestsAssemblyData =
-            new AssemblyData("notests-assembly.dll", "NotRunnable", 0, 0, 0, 0, 0);
+            new AssemblyData("empty-assembly.dll", "NotRunnable", 0, 0, 0, 0, 0);
+
+        static AssemblyData Project1Data =
+            new AssemblyData("project1.nunit", "Runnable", MockAssembly.Tests, MockAssembly.PassedInAttribute, MockAssembly.Failed, MockAssembly.Skipped, MockAssembly.Inconclusive);
+
+        static AssemblyData Project2Data =
+            new AssemblyData("project2.nunit", "Runnable", 2*MockAssembly.Tests, 2*MockAssembly.PassedInAttribute, 2*MockAssembly.Failed, 2*MockAssembly.Skipped, 2*MockAssembly.Inconclusive);
+
+        static AssemblyData Project3Data =
+            new AssemblyData("project3.nunit", "Runnable", 0, 0, 0, 0, 0);
+
+        static AssemblyData Project4Data =
+            new AssemblyData("project4.nunit", "Runnable", 0, 0, 0, 0, 0);
 
         static TestRunData[] FixtureData = new TestRunData[]
         {
@@ -91,32 +103,32 @@ namespace NUnit.Engine.Runners.Tests
 #if NETCOREAPP1_1
             new TestRunData( "mock-assembly.dll", typeof(LocalTestRunner), MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "notests-assembly.dll", typeof(LocalTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "notests-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "mock-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData )
+            new TestRunData( "empty-assembly.dll", typeof(LocalTestRunner), NoTestsAssemblyData ),
+            new TestRunData( "empty-assembly.dll,empty-assembly.dll", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
+            new TestRunData( "mock-assembly.dll,empty-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData )
             // .NET Standard 1.6 doesn't support projects.
 #elif NETCOREAPP2_0
             new TestRunData( "mock-assembly.dll", typeof(LocalTestRunner), MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "notests-assembly.dll", typeof(LocalTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "notests-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "mock-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), MockAssemblyData ),
-            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "project3.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "project4.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit,notests-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData, MockAssemblyData, MockAssemblyData)
+            new TestRunData( "empty-assembly.dll", typeof(LocalTestRunner), NoTestsAssemblyData ),
+            new TestRunData( "empty-assembly.dll,empty-assembly.dll", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
+            new TestRunData( "mock-assembly.dll,empty-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData ),
+            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), Project1Data ),
+            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), Project2Data ),
+            new TestRunData( "project3.nunit", typeof(AggregatingTestRunner), Project3Data ),
+            new TestRunData( "project4.nunit", typeof(AggregatingTestRunner), Project4Data ),
+            new TestRunData( "project1.nunit,empty-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), Project1Data, NoTestsAssemblyData, Project2Data)
 #else
             new TestRunData( "mock-assembly.dll", typeof(TestDomainRunner), MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", typeof(MultipleTestDomainRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "notests-assembly.dll", typeof(TestDomainRunner), NoTestsAssemblyData ),
-            new TestRunData( "notests-assembly.dll,notests-assembly.dll", typeof(MultipleTestDomainRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "mock-assembly.dll,notests-assembly.dll", typeof(MultipleTestDomainRunner), MockAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), MockAssemblyData ),
-            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "project3.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "project4.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit,notests-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData, MockAssemblyData, MockAssemblyData)
+            new TestRunData( "empty-assembly.dll", typeof(TestDomainRunner), NoTestsAssemblyData ),
+            new TestRunData( "empty-assembly.dll,empty-assembly.dll", typeof(MultipleTestDomainRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
+            new TestRunData( "mock-assembly.dll,empty-assembly.dll", typeof(MultipleTestDomainRunner), MockAssemblyData, NoTestsAssemblyData ),
+            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), Project1Data ),
+            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), Project2Data ),
+            new TestRunData( "project3.nunit", typeof(AggregatingTestRunner), Project3Data ),
+            new TestRunData( "project4.nunit", typeof(AggregatingTestRunner), Project4Data ),
+            new TestRunData( "project1.nunit,empty-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), Project1Data, NoTestsAssemblyData, Project2Data)
 #endif
         };
 
@@ -184,6 +196,7 @@ namespace NUnit.Engine.Runners.Tests
             foreach (XmlNode child in suites)
             {
                 var data = _data[i++];
+                Assert.That(child.GetAttribute("name"), Is.EqualTo(data.Name));
                 Assert.That(child.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
                 Assert.That(child.GetAttribute("runstate"), Is.EqualTo(data.RunState));
             }
@@ -207,6 +220,7 @@ namespace NUnit.Engine.Runners.Tests
             foreach (XmlNode child in result.SelectNodes("test-suite"))
             {
                 var data = _data[i++];
+                Assert.That(child.GetAttribute("name"), Is.EqualTo(data.Name));
                 Assert.That(child.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
                 Assert.That(child.GetAttribute("runstate"), Is.EqualTo(data.RunState));
             }
@@ -236,6 +250,7 @@ namespace NUnit.Engine.Runners.Tests
             foreach (XmlNode suite in suites)
             {
                 var data = _data[i++];
+                Assert.That(suite.GetAttribute("name"), Is.EqualTo(data.Name));
                 Assert.That(suite.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
                 Assert.That(suite.GetAttribute("runstate"), Is.EqualTo(data.RunState));
             }
@@ -281,6 +296,7 @@ namespace NUnit.Engine.Runners.Tests
             foreach (XmlNode suite in suites)
             {
                 var data = _data[i++];
+                Assert.That(suite.GetAttribute("name"), Is.EqualTo(data.Name));
                 Assert.That(suite.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
                 Assert.That(suite.GetAttribute("result"), Is.EqualTo("Failed"));
                 Assert.That(suite.GetAttribute("passed", 0), Is.EqualTo(data.Passed));

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlOutputTest.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlOutputTest.cs
@@ -89,7 +89,7 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
             // Create a TestEngineResult from the string, just as the TestEngine does,
             // then add a test-run element to the result, wrapping the result so it
             // looks just like what the engine would return!
-            this.EngineResult = new TestEngineResult(xmlText).Aggregate("test-run", AssemblyName, AssemblyPath);
+            this.EngineResult = new TestEngineResult(xmlText).Aggregate("test-run", "2", AssemblyName, AssemblyPath);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -24,7 +24,6 @@
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="0.1.0-dev-00079" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -36,6 +36,7 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class ResultHelper
     {
+        private const string TEST_RUN_ELEMENT = "test-run";
         private const string TEST_SUITE_ELEMENT = "test-suite";
         private const string PROJECT_SUITE_TYPE = "Project";
 
@@ -50,9 +51,9 @@ namespace NUnit.Engine.Internal
         /// <param name="name">The name of the <see cref="TestEngineResult"/>.</param>
         /// <param name="fullName">The full name of the <see cref="TestEngineResult"/>.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string suiteType, string name, string fullName)
+        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string suiteType, string id, string name, string fullName)
         {
-            return new TestEngineResult(Aggregate(elementName, suiteType, name, fullName, result.XmlNodes));
+            return new TestEngineResult(Aggregate(elementName, suiteType, id, name, fullName, result.XmlNodes));
         }
 
         /// <summary>
@@ -63,9 +64,9 @@ namespace NUnit.Engine.Internal
         /// <param name="name">The name of the <see cref="TestEngineResult"/>.</param>
         /// <param name="fullName">The full name of the <see cref="TestEngineResult"/>.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string name, string fullName)
+        public static TestEngineResult Aggregate(this TestEngineResult result, string elementName, string id, string name, string fullName)
         {
-            return new TestEngineResult(Aggregate(elementName, name, fullName, result.XmlNodes));
+            return new TestEngineResult(Aggregate(elementName, id, name, fullName, result.XmlNodes));
         }
 
         /// <summary>
@@ -75,9 +76,14 @@ namespace NUnit.Engine.Internal
         /// <param name="name">The name of the <see cref="TestEngineResult"/>.</param>
         /// <param name="fullName">The full name of the <see cref="TestEngineResult"/>.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult MakePackageResult(this TestEngineResult result, string name, string fullName)
+        public static TestEngineResult MakeProjectResult(this TestEngineResult result, TestPackage package)
         {
-            return Aggregate(result, TEST_SUITE_ELEMENT, PROJECT_SUITE_TYPE, name, fullName);
+            return Aggregate(result, TEST_SUITE_ELEMENT, PROJECT_SUITE_TYPE, package.ID, package.Name, package.FullName);
+        }
+
+        public static TestEngineResult MakeTestRunResult(this TestEngineResult result, string id, string name, string fullName)
+        {
+            return Aggregate(result, TEST_RUN_ELEMENT, id, name, fullName);
         }
 
         #endregion
@@ -114,9 +120,9 @@ namespace NUnit.Engine.Internal
         /// <param name="fullName">The full name to associated with the root node.</param>
         /// <param name="resultNodes">A collection of XmlNodes to aggregate</param>
         /// <returns>A single XmlNode containing the aggregated list of XmlNodes.</returns>
-        public static XmlNode Aggregate(string elementName, string name, string fullName, IList<XmlNode> resultNodes)
+        public static XmlNode Aggregate(string elementName, string id, string name, string fullName, IList<XmlNode> resultNodes)
         {
-            return Aggregate(elementName, null, name, fullName, resultNodes);
+            return Aggregate(elementName, null, id, name, fullName, resultNodes);
         }
 
         /// <summary>
@@ -128,16 +134,17 @@ namespace NUnit.Engine.Internal
         /// <param name="fullName">The full name to associated with the root node.</param>
         /// <param name="resultNodes">A collection of XmlNodes to aggregate</param>
         /// <returns>A single XmlNode containing the aggregated list of XmlNodes.</returns>
-        public static XmlNode Aggregate(string elementName, string testType, string name, string fullName, IList<XmlNode> resultNodes)
+        public static XmlNode Aggregate(string elementName, string testType, string id, string name, string fullName, IList<XmlNode> resultNodes)
         {
             XmlNode combinedNode = XmlHelper.CreateTopLevelElement(elementName);
             if (testType != null)
                 combinedNode.AddAttribute("type", testType);
-            combinedNode.AddAttribute("id", "2"); // TODO: Should not be hard-coded
+            combinedNode.AddAttribute("id", id);
             if (name != null && name != string.Empty)
                 combinedNode.AddAttribute("name", name);
             if (fullName != null && fullName != string.Empty)
                 combinedNode.AddAttribute("fullname", fullName);
+            combinedNode.AddAttribute("runstate", "Runnable"); // If not, we would not have gotten this far
 
             string aggregateResult = "Inconclusive";
             string aggregateLabel = null;

--- a/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
@@ -43,6 +43,13 @@ namespace NUnit.Engine.Internal
             return package.SubPackages.Count > 0;
         }
 
+        public static bool IsProjectPackage(this TestPackage package)
+        {
+            // We may not have the project service available, so we assume that any expanded package
+            // is a project package. Check name to verify that it's not the anonymous command-line package.
+            return package.FullName != null && package.HasSubPackages();
+        }
+
         public static IList<TestPackage> Select(this TestPackage package, TestPackageSelectorDelegate selector)
         {
             var selection = new List<TestPackage>();

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -105,7 +105,11 @@ namespace NUnit.Engine.Runners
             foreach (ITestEngineRunner runner in Runners)
                 results.Add(runner.Explore(filter));
 
-            return ResultHelper.Merge(results);
+            var mergedResult = ResultHelper.Merge(results);
+
+            return TestPackage.IsProjectPackage()
+                ? mergedResult.MakeProjectResult(TestPackage)
+                : mergedResult;
         }
 
         /// <summary>
@@ -119,7 +123,11 @@ namespace NUnit.Engine.Runners
             foreach (var runner in Runners)
                 results.Add(runner.Load());
 
-            return ResultHelper.Merge(results);
+            var mergedResult = ResultHelper.Merge(results);
+
+            return TestPackage.IsProjectPackage()
+                ? mergedResult.MakeProjectResult(TestPackage)
+                : mergedResult;
         }
 
         /// <summary>
@@ -184,7 +192,11 @@ namespace NUnit.Engine.Runners
 #endif
             if (disposeRunners) Runners.Clear();
 
-            return ResultHelper.Merge(results);
+            var mergedResult = ResultHelper.Merge(results);
+
+            return TestPackage.IsProjectPackage()
+                ? mergedResult.MakeProjectResult(TestPackage)
+                : mergedResult;
         }
 
         private void RunTestsSequentially(ITestEventListener listener, TestFilter filter, List<TestEngineResult> results, bool disposeRunners)

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -111,7 +111,9 @@ namespace NUnit.Engine.Runners
                 result.Add(driverResult);
             }
 
-            return result;
+            return TestPackage.IsProjectPackage()
+                ? result.MakeProjectResult(TestPackage)
+                : result;
         }
 
         /// <summary>
@@ -154,7 +156,10 @@ namespace NUnit.Engine.Runners
                 result.Add(LoadDriver(driver, testFile, subPackage));
                 _drivers.Add(driver);
             }
-            return result;
+
+            return TestPackage.IsProjectPackage()
+                ? result.MakeProjectResult(TestPackage)
+                : result;
         }
 
         private static string LoadDriver(IFrameworkDriver driver, string testFile, TestPackage subPackage)
@@ -234,7 +239,9 @@ namespace NUnit.Engine.Runners
                     _assemblyResolver.RemovePathFromFile(package.FullName);
             }
 #endif
-            return result;
+            return TestPackage.IsProjectPackage()
+                ? result.MakeProjectResult(TestPackage)
+                : result;
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -76,7 +76,11 @@ namespace NUnit.Engine.Runners
             try
             {
                 CreateAgentAndRunner();
-                return _remoteRunner.Explore(filter);
+
+                var result = _remoteRunner.Explore(filter);
+                return TestPackage.IsProjectPackage()
+                    ? result.MakeProjectResult(TestPackage)
+                    : result;
             }
             catch (Exception e)
             {
@@ -98,7 +102,10 @@ namespace NUnit.Engine.Runners
             {
                 CreateAgentAndRunner();
 
-                return _remoteRunner.Load();
+                var result = _remoteRunner.Load();
+                return TestPackage.IsProjectPackage()
+                    ? result.MakeProjectResult(TestPackage)
+                    : result;
             }
             catch (Exception)
             {
@@ -169,7 +176,9 @@ namespace NUnit.Engine.Runners
 
                 var result = _remoteRunner.Run(listener, filter);
                 log.Info("Done running " + TestPackage.Name);
-                return result;
+                return TestPackage.IsProjectPackage()
+                    ? result.MakeProjectResult(TestPackage)
+                    : result;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
This will fix #53 but is currently partial only.

One thing leads to another! Currently, everything seems to be working correctly except for when you use `--process:Separate. When that happens with one or more projects in the command-line, the whole job of figuring out the proper hierarchy falls to the agent process. This is more work than the Process Runner and agent process were originally designed to handle so changes will be needed.

I see some choices for this issue...

1. Merge what's done and leave the `--process:Separate` case for fixing later. (3 PRs)
2. Put this on hold until the problem with `--process:Separate` can be resolved. (2 PRs)
3. Make resolving the --process:Separate part of this PR. (1 PR)

As anyone who knows me would guess, I prefer the 3 PR approach. I'd make them all steps in the same issue, however, since the problem really only comes up when trying to add XML elements for each project. Kind of depends on how comfortable folks are with merging code without knowing what the next step will be...