### PR TITLE
Remove extra ..\ in the Addins file for NuGet v2 Extensions

### DIFF
--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,2 +1,2 @@
-../../../NUnit.Extension.*/**/tools/     # nuget v2 layout
+../../NUnit.Extension.*/**/tools/        # nuget v2 layout
 ../../../../NUnit.Extension.*/**/tools/  # nuget v3 layout

--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,2 +1,3 @@
 ../../NUnit.Extension.*/**/tools/        # nuget v2 layout
+../../../NUnit.Extension.*/**/tools/     
 ../../../../NUnit.Extension.*/**/tools/  # nuget v3 layout


### PR DESCRIPTION
Fixes #583 

@ChrisMaddock can you take a look at this? Did you add the extra `..\` to the v2 packages for a reason? Do we need to add a third line with each level of parents?