### PR TITLE
Disable new MSBuild GenerateSupportedRuntime functionality, which breaks framework targetting

### DIFF
--- a/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
@@ -12,6 +12,7 @@
     <PlatformTarget>x86</PlatformTarget>
     <IntermediateOutputPath>obj\$(Configuration)\x86\</IntermediateOutputPath>
     <LangVersion>7</LangVersion>
+    <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Runtime.Remoting" />

--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -10,6 +10,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <LangVersion>7</LangVersion>
+    <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Runtime.Remoting" />


### PR DESCRIPTION
There was a recent change to MSBuild (https://github.com/dotnet/sdk/pull/2447) which had the effect of preventing the NUnit console from running any .NET 4.0+ test assemblies.

The MSBuild change automatically inserted `supportedRuntime` tags into the app.config, when there were none. This overrode the `complus_version` environment variable, which the console uses to ensure that the agent process is launched on the correct .NET Framework version to run each test assembly.

The new MSBuild functionality (GenerateSupportedRuntimes) caused the agent to always launch under .NET 2.0. This prevented the NUnit running any assemblies above .NET 4.0. Adding these two lines to the agent csproj's prevents this behaviour from taking place, which is currently required if we wish to continue targeting specific .NET Framework versions through `complus_version`. (The real solution may be to stop doing that undocumented solution however - I'm not sure what other solutions there are)

dotnet/sdk bug report also incoming, will link back