### PR TITLE
Incorporate test-suite elements for each project run

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ResultReporterTests.cs
@@ -199,7 +199,7 @@ namespace NUnit.ConsoleRunner.Tests
 
         private static TestEngineResult AddMetadata(TestEngineResult input)
         {
-            return input.Aggregate("test-run start-time=\"2015-10-19 02:12:28Z\" end-time=\"2015-10-19 02:12:29Z\" duration=\"0.348616\"", string.Empty, string.Empty);
+            return input.Aggregate("test-run start-time=\"2015-10-19 02:12:28Z\" end-time=\"2015-10-19 02:12:29Z\" duration=\"0.348616\"", string.Empty, string.Empty, string.Empty);
         }
 
         private string GetReport(TestDelegate del)

--- a/src/NUnitEngine/nunit.engine.tests/ResultHelperTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/ResultHelperTests.cs
@@ -61,12 +61,15 @@ namespace NUnit.Engine.Internal.Tests
         [Test]
         public void AggregateTestResult()
         {
-            TestEngineResult combined = result2.Aggregate("test-run", "NAME", "FULLNAME");
+            TestEngineResult combined = result2.Aggregate("test-run", "ID", "NAME", "FULLNAME");
             Assert.That(combined.IsSingle);
 
             XmlNode combinedNode = combined.Xml;
 
             Assert.That(combinedNode.Name, Is.EqualTo("test-run"));
+            Assert.That(combinedNode.Attributes["id"].Value, Is.EqualTo("ID"));
+            Assert.That(combinedNode.Attributes["name"].Value, Is.EqualTo("NAME"));
+            Assert.That(combinedNode.Attributes["fullname"].Value, Is.EqualTo("FULLNAME"));
             Assert.That(combinedNode.Attributes["result"].Value, Is.EqualTo("Failed"));
             Assert.That(combinedNode.Attributes["total"].Value, Is.EqualTo("42"));
             Assert.That(combinedNode.Attributes["passed"].Value, Is.EqualTo("31"));
@@ -79,13 +82,14 @@ namespace NUnit.Engine.Internal.Tests
         [Test]
         public void MergeAndAggregateTestResults()
         {
-            TestEngineResult combined = ResultHelper.Merge(twoResults).Aggregate("test-suite", "Project", "NAME", "FULLNAME");
+            TestEngineResult combined = ResultHelper.Merge(twoResults).Aggregate("test-suite", "Project", "ID", "NAME", "FULLNAME");
             Assert.That(combined.IsSingle);
 
             XmlNode combinedNode = combined.Xml;
 
             Assert.That(combinedNode.Name, Is.EqualTo("test-suite"));
             Assert.That(combinedNode.Attributes["type"].Value, Is.EqualTo("Project"));
+            Assert.That(combinedNode.Attributes["id"].Value, Is.EqualTo("ID"));
             Assert.That(combinedNode.Attributes["name"].Value, Is.EqualTo("NAME"));
             Assert.That(combinedNode.Attributes["fullname"].Value, Is.EqualTo("FULLNAME"));
             Assert.That(combinedNode.Attributes["result"].Value, Is.EqualTo("Failed"));
@@ -100,9 +104,10 @@ namespace NUnit.Engine.Internal.Tests
         [Test]
         public void AggregateXmlNodes()
         {
-            XmlNode combined = ResultHelper.Aggregate("test-run", "NAME", "FULLNAME", twoNodes);
+            XmlNode combined = ResultHelper.Aggregate("test-run", "ID", "NAME", "FULLNAME", twoNodes);
 
             Assert.That(combined.Name, Is.EqualTo("test-run"));
+            Assert.That(combined.Attributes["id"].Value, Is.EqualTo("ID"));
             Assert.That(combined.Attributes["name"].Value, Is.EqualTo("NAME"));
             Assert.That(combined.Attributes["fullname"].Value, Is.EqualTo("FULLNAME"));
             Assert.That(combined.Attributes["result"].Value, Is.EqualTo("Failed"));
@@ -114,7 +119,6 @@ namespace NUnit.Engine.Internal.Tests
             Assert.That(combined.Attributes["asserts"].Value, Is.EqualTo("93"));
         }
 
-        [Test]
         [TestCase("Skipped", "Skipped", "Skipped")]
         [TestCase("Passed", "Passed", "Passed")]
         [TestCase("Failed", "Failed", "Failed")]
@@ -139,7 +143,7 @@ namespace NUnit.Engine.Internal.Tests
             var firstEngineResult = new TestEngineResult(firstResultText);
             var secondEngineResult = new TestEngineResult(secondResultText);
             var data = new XmlNode[]{ firstEngineResult.Xml, secondEngineResult.Xml };
-            XmlNode combined = ResultHelper.Aggregate("test-run", "NAME", "FULLNAME", data);
+            XmlNode combined = ResultHelper.Aggregate("test-run", "ID", "NAME", "FULLNAME", data);
             Assert.That(combined.Attributes["result"].Value, Is.EqualTo(aggregateResult));
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -38,18 +38,9 @@ namespace NUnit.Engine.Runners.Tests
     [TestFixtureSource(nameof(FixtureData))]
     public class MasterTestRunnerTests : ITestEventListener
     {
-        private List<AssemblyData> _data = new List<AssemblyData>();
+        private TestRunData _testRunData;
+
         private List<string> _testFiles = new List<string>();
-        private List<string> _assemblies = new List<string>();
-
-        private int _numAssemblies = 0;
-        private int _totalTests = 0;
-        private int _totalPassed = 0;
-        private int _totalFailed = 0;
-        private int _totalSkipped = 0;
-        private int _totalInconclusive = 0;
-
-        private Type _expectedRunner;
 
         private TestPackage _package;
         private ServiceContext _services;
@@ -58,65 +49,58 @@ namespace NUnit.Engine.Runners.Tests
 
         public MasterTestRunnerTests(TestRunData testRunData)
         {
-            _expectedRunner = testRunData.ExpectedRunner;
+            _testRunData = testRunData;
 
             string testDirectory = TestContext.CurrentContext.TestDirectory;
 
             foreach (string file in testRunData.CommandLine.Split(new char[] { ',' }))
                 _testFiles.Add(Path.Combine(testDirectory, file));
-
-            foreach (var data in testRunData.AssemblyData)
-            {
-                _data.Add(data);
-                _numAssemblies++;
-                _assemblies.Add(Path.Combine(testDirectory, data.Name));
-                _totalTests += data.Tests;
-                _totalPassed += data.Passed;
-                _totalFailed += data.Failed;
-                _totalSkipped += data.Skipped;
-                _totalInconclusive += data.Inconclusive;
-            }
         }
 
-        static AssemblyData MockAssemblyData =
-            new AssemblyData("mock-assembly.dll", "Runnable", MockAssembly.Tests, MockAssembly.PassedInAttribute, MockAssembly.Failed, MockAssembly.Skipped, MockAssembly.Inconclusive);
+        static ResultData MockAssemblyData =
+            new ResultData("mock-assembly.dll", "Runnable", MockAssembly.Tests, MockAssembly.PassedInAttribute, MockAssembly.Failed, MockAssembly.Skipped, MockAssembly.Inconclusive);
 
-        static AssemblyData NoTestsAssemblyData =
-            new AssemblyData("notests-assembly.dll", "NotRunnable", 0, 0, 0, 0, 0);
+        static ResultData NoTestAssemblyData =
+            new ResultData("notest-assembly.dll", "NotRunnable", 0, 0, 0, 0, 0);
+
+        static ResultData Project1Data =
+            new ResultData("project1.nunit", "Runnable", MockAssemblyData);
+
+        static ResultData Project2Data =
+            new ResultData("project2.nunit", "Runnable", MockAssemblyData, MockAssemblyData);
 
         static TestRunData[] FixtureData = new TestRunData[]
         {
-            // NOTE: These tests document current behavior. In some cases
-            // we may want to change that behavior.
+            // NOTES: 
+            // 1. These tests document current behavior. In some cases we may want to change that behavior.
+            // 2. The .NET Standard builds don't seem to handle notest-assembly correctly, so those entries are commented out.
+            // 3. The .NET Standard 1.6 build is not intended to handle projects.
 #if NETCOREAPP1_1
             new TestRunData( "mock-assembly.dll", typeof(LocalTestRunner), MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "notests-assembly.dll", typeof(LocalTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "notests-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "mock-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData )
-            // .NET Standard 1.6 doesn't support projects.
+            //new TestRunData( "notest-assembly.dll", typeof(LocalTestRunner), NoTestAssemblyData ),
+            //new TestRunData( "notest-assembly.dll,notest-assembly.dll", typeof(AggregatingTestRunner), NoTestAssemblyData, NoTestAssemblyData ),
+            //new TestRunData( "mock-assembly.dll,notest-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestAssemblyData )
 #elif NETCOREAPP2_0
             new TestRunData( "mock-assembly.dll", typeof(LocalTestRunner), MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "notests-assembly.dll", typeof(LocalTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "notests-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "mock-assembly.dll,notests-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), MockAssemblyData ),
-            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "project3.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "project4.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit,notests-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData, MockAssemblyData, MockAssemblyData)
+            //new TestRunData( "notest-assembly.dll", typeof(LocalTestRunner), NoTestAssemblyData ),
+            //new TestRunData( "notest-assembly.dll,notest-assembly.dll", typeof(AggregatingTestRunner), NoTestAssemblyData, NoTestAssemblyData ),
+            //new TestRunData( "mock-assembly.dll,notest-assembly.dll", typeof(AggregatingTestRunner), MockAssemblyData, NoTestAssemblyData ),
+            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), Project1Data ),
+            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), Project2Data ),
+            new TestRunData( "project1.nunit,project2.nunit", typeof(AggregatingTestRunner), Project1Data, Project2Data ),
+            new TestRunData( "project1.nunit,mock-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), Project1Data, MockAssemblyData, Project2Data)
 #else
             new TestRunData( "mock-assembly.dll", typeof(TestDomainRunner), MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", typeof(MultipleTestDomainRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "notests-assembly.dll", typeof(TestDomainRunner), NoTestsAssemblyData ),
-            new TestRunData( "notests-assembly.dll,notests-assembly.dll", typeof(MultipleTestDomainRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "mock-assembly.dll,notests-assembly.dll", typeof(MultipleTestDomainRunner), MockAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), MockAssemblyData ),
-            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, MockAssemblyData ),
-            new TestRunData( "project3.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData ),
-            new TestRunData( "project4.nunit", typeof(AggregatingTestRunner), NoTestsAssemblyData, NoTestsAssemblyData ),
-            new TestRunData( "project1.nunit,notests-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), MockAssemblyData, NoTestsAssemblyData, MockAssemblyData, MockAssemblyData)
+            new TestRunData( "notest-assembly.dll", typeof(TestDomainRunner), NoTestAssemblyData ),
+            new TestRunData( "notest-assembly.dll,notest-assembly.dll", typeof(MultipleTestDomainRunner), NoTestAssemblyData, NoTestAssemblyData ),
+            new TestRunData( "mock-assembly.dll,notest-assembly.dll", typeof(MultipleTestDomainRunner), MockAssemblyData, NoTestAssemblyData ),
+            new TestRunData( "project1.nunit", typeof(AggregatingTestRunner), Project1Data ),
+            new TestRunData( "project2.nunit", typeof(AggregatingTestRunner), Project2Data ),
+            new TestRunData( "project1.nunit,project2.nunit", typeof(AggregatingTestRunner), Project1Data, Project2Data ),
+            new TestRunData( "project1.nunit,mock-assembly.dll,project2.nunit", typeof(AggregatingTestRunner), Project1Data, MockAssemblyData, Project2Data)
 #endif
         };
 
@@ -166,7 +150,7 @@ namespace NUnit.Engine.Runners.Tests
         {
             var prop = typeof(MasterTestRunner).GetField("_engineRunner", BindingFlags.NonPublic | BindingFlags.Instance);
             var runner = prop.GetValue(_runner);
-            Assert.That(runner, Is.TypeOf(_expectedRunner));
+            Assert.That(runner, Is.TypeOf(_testRunData.ExpectedRunner));
         }
 
         [Test]
@@ -175,20 +159,9 @@ namespace NUnit.Engine.Runners.Tests
             var result = _runner.Load();
 
             Assert.That(result.Name, Is.EqualTo("test-run"));
-            Assert.That(result.GetAttribute("testcasecount", -1), Is.EqualTo(_totalTests));
+            CheckResult(result, _testRunData);
 
-            var suites = result.SelectNodes("test-suite");
-            Assert.That(suites.Count, Is.EqualTo(_numAssemblies));
-
-            int i = 0;
-            foreach (XmlNode child in suites)
-            {
-                var data = _data[i++];
-                Assert.That(child.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
-                Assert.That(child.GetAttribute("runstate"), Is.EqualTo(data.RunState));
-            }
-
-            AssertThatIdsAreUnique(result);
+            CheckThatIdsAreUnique(result);
         }
 
         [Test]
@@ -198,27 +171,16 @@ namespace NUnit.Engine.Runners.Tests
             var result = _runner.Reload();
 
             Assert.That(result.Name, Is.EqualTo("test-run"));
-            Assert.That(result.GetAttribute("testcasecount", -1), Is.EqualTo(_totalTests));
+            CheckResult(result, _testRunData);
 
-            var suites = result.SelectNodes("test-suite");
-            Assert.That(suites.Count, Is.EqualTo(_numAssemblies));
-
-            int i = 0;
-            foreach (XmlNode child in result.SelectNodes("test-suite"))
-            {
-                var data = _data[i++];
-                Assert.That(child.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
-                Assert.That(child.GetAttribute("runstate"), Is.EqualTo(data.RunState));
-            }
-
-            AssertThatIdsAreUnique(result);
+            CheckThatIdsAreUnique(result);
         }
 
         [Test]
         public void CountTestCases()
         {
             int count = _runner.CountTestCases(TestFilter.Empty);
-            Assert.That(count, Is.EqualTo(_totalTests));
+            Assert.That(count, Is.EqualTo(_testRunData.Tests));
         }
 
         [Test]
@@ -227,20 +189,9 @@ namespace NUnit.Engine.Runners.Tests
             var result = _runner.Explore(TestFilter.Empty);
 
             Assert.That(result.Name, Is.EqualTo("test-run"));
-            Assert.That(result.GetAttribute("testcasecount", -1), Is.EqualTo(_totalTests));
+            CheckResult(result, _testRunData);
 
-            var suites = result.SelectNodes("test-suite");
-            Assert.That(suites.Count, Is.EqualTo(_numAssemblies));
-
-            int i = 0;
-            foreach (XmlNode suite in suites)
-            {
-                var data = _data[i++];
-                Assert.That(suite.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
-                Assert.That(suite.GetAttribute("runstate"), Is.EqualTo(data.RunState));
-            }
-
-            AssertThatIdsAreUnique(result);
+            CheckThatIdsAreUnique(result);
         }
 
         [Test]
@@ -248,7 +199,13 @@ namespace NUnit.Engine.Runners.Tests
         {
             _runner.Load(); // Make sure it's pre-loaded so we get count in start-run
             var result = _runner.Run(this, TestFilter.Empty);
-            CheckTestRunResult(result);
+
+            Assert.That(result.Name, Is.EqualTo("test-run"));
+            CheckTestRunResult(result, _testRunData);
+
+            CheckThatIdsAreUnique(result);
+
+            CheckTestRunEvents(_testRunData.Tests);
         }
 
 #if !NETCOREAPP1_1
@@ -257,60 +214,88 @@ namespace NUnit.Engine.Runners.Tests
         {
             _runner.Load(); // Make sure it's pre-loaded so we get count in start-run
             var testRun = _runner.RunAsync(this, TestFilter.Empty);
+
             testRun.Wait(-1);
-            CheckTestRunResult(testRun.Result);
+            Assert.That(testRun.Result.Name, Is.EqualTo("test-run"));
+            CheckTestRunResult(testRun.Result, _testRunData);
+
+            CheckThatIdsAreUnique(testRun.Result);
+
+            CheckTestRunEvents(_testRunData.Tests);
         }
 #endif
 
-#region Helper Methods
+        #region Helper Methods
 
-        private void CheckTestRunResult(XmlNode result)
+        private void CheckResult(XmlNode result, ResultData expected)
         {
-            Assert.That(result.Name, Is.EqualTo("test-run"));
-            Assert.That(result.GetAttribute("testcasecount", -1), Is.EqualTo(_totalTests));
-            Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
-            Assert.That(result.GetAttribute("passed", -1), Is.EqualTo(_totalPassed));
-            Assert.That(result.GetAttribute("failed", -1), Is.EqualTo(_totalFailed));
-            Assert.That(result.GetAttribute("skipped", -1), Is.EqualTo(_totalSkipped));
-            Assert.That(result.GetAttribute("inconclusive", -1), Is.EqualTo(_totalInconclusive));
+            if (expected.Name != null)
+                Assert.That(result.GetAttribute("name"), Is.EqualTo(expected.Name));
+            Assert.That(result.GetAttribute("testcasecount", -1), Is.EqualTo(expected.Tests));
+            Assert.That(result.GetAttribute("runstate"), Is.EqualTo(expected.RunState));
 
-            var suites = result.SelectNodes("test-suite");
-            Assert.That(suites.Count, Is.EqualTo(_numAssemblies));
-
-            int i = 0;
-            foreach (XmlNode suite in suites)
+            if (expected.ContainedResults.Length > 0)
             {
-                var data = _data[i++];
-                Assert.That(suite.GetAttribute("testcasecount", -1), Is.EqualTo(data.Tests));
-                Assert.That(suite.GetAttribute("result"), Is.EqualTo("Failed"));
-                Assert.That(suite.GetAttribute("passed", 0), Is.EqualTo(data.Passed));
-                Assert.That(suite.GetAttribute("failed", 0), Is.EqualTo(data.Failed));
-                Assert.That(suite.GetAttribute("skipped", 0), Is.EqualTo(data.Skipped));
-                Assert.That(suite.GetAttribute("inconclusive", 0), Is.EqualTo(data.Inconclusive));
+                var suites = result.SelectNodes("test-suite");
+                Assert.That(suites.Count, Is.EqualTo(expected.ContainedResults.Length));
+
+                int i = 0;
+                foreach (XmlNode suite in suites)
+                {
+                    var data = expected.ContainedResults[i++];
+                    CheckResult(suite, data);
+                }
             }
-
-            AssertThatIdsAreUnique(result);
-
-            Assert.That(_events[0].Name, Is.EqualTo("start-run"));
-            Assert.That(_events[0].GetAttribute("count", -1), Is.EqualTo(_totalTests), "Start-run count value");
-            Assert.That(_events[_events.Count - 1].Name, Is.EqualTo("test-run"));
-            Assert.That(_events.Count(x => x.Name == "test-case"), Is.EqualTo(_totalTests));
         }
 
-        private void AssertThatIdsAreUnique(XmlNode test)
+        private void CheckTestRunResult(XmlNode result, ResultData expected)
         {
-            AssertThatIdsAreUnique(test, new Dictionary<string, bool>());
+            if (expected.Name != null)
+                Assert.That(result.GetAttribute("name"), Is.EqualTo(expected.Name));
+            Assert.That(result.GetAttribute("testcasecount", -1), Is.EqualTo(expected.Tests));
+            Assert.That(result.GetAttribute("result"), Is.EqualTo("Failed"));
+            Assert.That(result.GetAttribute("passed", -1), Is.EqualTo(expected.Passed));
+            Assert.That(result.GetAttribute("failed", -1), Is.EqualTo(expected.Failed));
+            Assert.That(result.GetAttribute("skipped", -1), Is.EqualTo(expected.Skipped));
+            Assert.That(result.GetAttribute("inconclusive", -1), Is.EqualTo(expected.Inconclusive));
+
+            if (expected.ContainedResults.Length > 0)
+            {
+                var suites = result.SelectNodes("test-suite");
+                Assert.That(suites.Count, Is.EqualTo(expected.ContainedResults.Length));
+
+                int i = 0;
+                foreach (XmlNode suite in suites)
+                {
+                    var data = expected.ContainedResults[i++];
+                    CheckTestRunResult(suite, data);
+                }
+            }
         }
 
-        private void AssertThatIdsAreUnique(XmlNode test, Dictionary<string, bool> dict)
+        private void CheckThatIdsAreUnique(XmlNode test)
+        {
+            CheckThatIdsAreUnique(test, new Dictionary<string, bool>());
+        }
+
+        private void CheckThatIdsAreUnique(XmlNode test, Dictionary<string, bool> dict)
         {
             foreach (XmlNode child in test.SelectNodes("test-suite"))
-                AssertThatIdsAreUnique(child, dict);
+                CheckThatIdsAreUnique(child, dict);
 
             string id = test.GetAttribute("id");
             Assert.That(dict, Does.Not.ContainKey(id));
 
             dict.Add(id, true);
+        }
+
+        private void CheckTestRunEvents(int expectedTests)
+        {
+            Assert.That(_events[0].Name, Is.EqualTo("start-run"));
+            Assert.That(_events[0].GetAttribute("count", -1), Is.EqualTo(expectedTests), "Start-run count value");
+            Assert.That(_events[_events.Count - 1].Name, Is.EqualTo("test-run"));
+
+            Assert.That(_events.Count(x => x.Name == "test-case"), Is.EqualTo(expectedTests));
         }
 
         void ITestEventListener.OnTestEvent(string report)
@@ -322,39 +307,40 @@ namespace NUnit.Engine.Runners.Tests
 
         #region Nested Helper Classes
 
-        public class TestRunData
+        public class TestRunData : ResultData
         {
+            private const string Q = "\"";
+
             public string CommandLine;
             public Type ExpectedRunner;
-            public AssemblyData[] AssemblyData;
+            public ResultData[] ResultData;
 
-            public TestRunData(string commandLine, Type expectedRunner, params AssemblyData[] assemblyData)
+            public TestRunData(string commandLine, Type expectedRunner, params ResultData[] containedResults)
+                : base(containedResults)
             {
                 CommandLine = commandLine;
                 ExpectedRunner = expectedRunner;
-                AssemblyData = assemblyData;
             }
 
             public override string ToString()
             {
-                var sb = new StringBuilder(ExpectedRunner.Name);
-                foreach (var assembly in AssemblyData)
-                    sb.Append($", {assembly.Name}");
-                return sb.ToString();
+                return Q + CommandLine + Q;
             }
         }
 
-        public class AssemblyData
+        public class ResultData
         {
             public string Name;
             public string RunState;
-            public int Tests;
-            public int Passed;
-            public int Failed;
-            public int Skipped;
-            public int Inconclusive;
+            public ResultData[] ContainedResults = new ResultData[0];
 
-            public AssemblyData(string name, string runstate, int tests, int passing, int failed, int skipped, int inconclusive)
+            public int Tests = 0;
+            public int Passed = 0;
+            public int Failed = 0;
+            public int Skipped = 0;
+            public int Inconclusive = 0;
+
+            public ResultData(string name, string runstate, int tests, int passing, int failed, int skipped, int inconclusive)
             {
                 Name = name;
                 RunState = runstate;
@@ -363,6 +349,28 @@ namespace NUnit.Engine.Runners.Tests
                 Failed = failed;
                 Skipped = skipped;
                 Inconclusive = inconclusive;
+            }
+
+            // Constructor used for fixture data - top level only
+            public ResultData(params ResultData[] containedResults)
+                : this(null, "Runnable", containedResults)
+            {
+            }
+
+            public ResultData(string name, string runstate, params ResultData[] containedResults)
+            {
+                Name = name;
+                RunState = runstate;
+                ContainedResults = containedResults;
+
+                foreach (var result in containedResults)
+                {
+                    Tests += result.Tests;
+                    Passed += result.Passed;
+                    Failed += result.Failed;
+                    Skipped += result.Skipped;
+                    Inconclusive += result.Inconclusive;
+                }
             }
         }
         #endregion

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -209,20 +209,20 @@ namespace NUnit.Engine.Runners.Tests
         }
 
 #if !NETCOREAPP1_1
-        //[Test]
-        //public void RunAsync()
-        //{
-        //    _runner.Load(); // Make sure it's pre-loaded so we get count in start-run
-        //    var testRun = _runner.RunAsync(this, TestFilter.Empty);
+        [Test]
+        public void RunAsync()
+        {
+            _runner.Load(); // Make sure it's pre-loaded so we get count in start-run
+            var testRun = _runner.RunAsync(this, TestFilter.Empty);
 
-        //    testRun.Wait(-1);
-        //    Assert.That(testRun.Result.Name, Is.EqualTo("test-run"));
-        //    CheckTestRunResult(testRun.Result, _testRunData);
+            testRun.Wait(-1);
+            Assert.That(testRun.Result.Name, Is.EqualTo("test-run"));
+            CheckTestRunResult(testRun.Result, _testRunData);
 
-        //    CheckThatIdsAreUnique(testRun.Result);
+            CheckThatIdsAreUnique(testRun.Result);
 
-        //    CheckTestRunEvents();
-        //}
+            CheckTestRunEvents();
+        }
 #endif
 
         #region Helper Methods

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlOutputTest.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlOutputTest.cs
@@ -89,7 +89,7 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
             // Create a TestEngineResult from the string, just as the TestEngine does,
             // then add a test-run element to the result, wrapping the result so it
             // looks just like what the engine would return!
-            this.EngineResult = new TestEngineResult(xmlText).Aggregate("test-run", AssemblyName, AssemblyPath);
+            this.EngineResult = new TestEngineResult(xmlText).Aggregate("test-run", "ID", AssemblyName, AssemblyPath);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/CallbackHandler.cs
+++ b/src/NUnitEngine/nunit.engine/CallbackHandler.cs
@@ -47,7 +47,7 @@ namespace NUnit.Engine
             throw new NotImplementedException();
         }
 
-        public virtual void RaiseCallbackEvent(string eventArgument)
+        public void RaiseCallbackEvent(string eventArgument)
         {
             Result = eventArgument;
         }

--- a/src/NUnitEngine/nunit.engine/CallbackHandler.cs
+++ b/src/NUnitEngine/nunit.engine/CallbackHandler.cs
@@ -31,10 +31,6 @@ namespace NUnit.Engine
     {
         public string Result { get; private set; }
 
-        public virtual void ReportProgress(string report)
-        {
-        }
-
         #region MarshalByRefObject Overrides
 
         public override object InitializeLifetimeService()
@@ -51,10 +47,9 @@ namespace NUnit.Engine
             throw new NotImplementedException();
         }
 
-        public void RaiseCallbackEvent(string eventArgument)
+        public virtual void RaiseCallbackEvent(string eventArgument)
         {
             Result = eventArgument;
-            ReportProgress(eventArgument);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -122,7 +122,7 @@ namespace NUnit.Engine.Drivers
         {
             CheckLoadWasCalled();
 
-            CallbackHandler handler = new RunTestsCallbackHandler(listener);
+            var handler = new RunTestsCallbackHandler(listener);
 
             log.Info("Running {0} - see separate log file", Path.GetFileName(_testAssemblyPath));
             CreateObject(RUN_ACTION, _frameworkController, filter, handler);

--- a/src/NUnitEngine/nunit.engine/RunTestsCallbackHandler.cs
+++ b/src/NUnitEngine/nunit.engine/RunTestsCallbackHandler.cs
@@ -74,24 +74,36 @@ namespace NUnit.Engine
 
         private bool IsFinalResult(string eventArgument)
         {
+            // TODO: If we add a prefix to the final result in the next framework
+            // release, then we can immediately recognize the final result but we
+            // would need to continue to examine the non-final result in case the
+            // the framework in use were an older version. Building in more knowledge
+            // of framework versions is probably not a good idea, since it would be
+            // potentially fragile as changes were made.
+
             // Eliminate all events except for test-suite
-            if (!eventArgument.StartsWith("<test-suite"))
+            if (!eventArgument.StartsWith("<test-suite", StringComparison.Ordinal))
                 return false;
+            // Return for all test cases, for example, 90% of events
 
             // Eliminate suites that do not represent an assembly
             if (!eventArgument.Contains("type=\"Assembly\""))
-                return false;
+                return false; 
+            // Return for all except the assembly result. Remaining code is only
+            // executed twice per assembly.
 
             // Heuristic: only final results may have an environment element
             if (eventArgument.Contains("<environment"))
                 return true;
+            // For the actual final result, the current framework version returns
+            // true at this point. Only older versions need further checking.
 
             // Heuristic: only final results may have a settings element
             if (eventArgument.Contains("<settings"))
                 return true;
 
             // Heuristic: only final results have nested suites
-            return eventArgument.IndexOf("<test-suite", 12) > 0;
+            return eventArgument.IndexOf("<test-suite", 12, StringComparison.Ordinal) > 0;
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -271,7 +271,7 @@ namespace NUnit.Engine.Runners
         }
 
         // The TestEngineResult returned to MasterTestRunner contains no info
-        // about projects. At this point, if thre are any projects, the result
+        // about projects. At this point, if there are any projects, the result
         // needs to be modified to include info about them. Doing it this way
         // allows the lower-level runners to be completely ignorant of projects
         private TestEngineResult PrepareResult(TestEngineResult result)


### PR DESCRIPTION
Fixes #53 

This PR is an alternate approach to that of PR #582. All the work is done in the MasterTestRunner, so that the internal runners don't need to know about projects at all.

I think this is the better approach, subject to the proviso that it relies on the order in which assemblies appear in the tree. That is, they must appear in the same order as the files entered on the command-line: all the assemblies associated with the first project, then all those associated with the second, etc..

This isn't currently a problem, because that's how the implementation currently works. It is mentioned because that ordering could change at some future time. However, the PR has tests that would fail in such a case. The original approach would then have to be used, with every lower-level test engine runner needing to be able to handle projects.

I should mention - in case anyone thinks of it in the review - that I initially tried to do this using a dictionary, looking up the full path of each assembly to incorporate in a project. Unfortunately, that approach would be broken for the current framework release, which does not include the full path of assemblies in the XML. :-(

If everyone agrees on this approach, then this is ready for review and eventual merging. Once it is merged, similar code will be removed from the TestCentric GUI.