### PR TITLE
Fix logging when including exception

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ExceptionHelperTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ExceptionHelperTests.cs
@@ -49,7 +49,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCaseSource(nameof(TestCases))]
         public void StackTraceContainsAllInnerExceptions(Exception ex, params Type[] expectedExceptions)
         {
-            var stackTrace = ExceptionHelper.BuildStackTrace(ex);
+            var stackTrace = ExceptionHelper.BuildMessageAndStackTrace(ex);
 
             Assert.Multiple(() =>
             {

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -281,7 +281,7 @@ namespace NUnit.ConsoleRunner
             {
                 writer.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessage(engineException));
                 writer.WriteLine();
-                writer.WriteLine(ColorStyle.Error, ExceptionHelper.BuildStackTrace(engineException));
+                writer.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessageAndStackTrace(engineException));
             }
 
             return ConsoleRunner.UNEXPECTED_ERROR;

--- a/src/NUnitConsole/nunit3-console/Program.cs
+++ b/src/NUnitConsole/nunit3-console/Program.cs
@@ -148,7 +148,7 @@ namespace NUnit.ConsoleRunner
                     {
                         OutWriter.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessage(ex));
                         OutWriter.WriteLine();
-                        OutWriter.WriteLine(ColorStyle.Error, ExceptionHelper.BuildStackTrace(ex));
+                        OutWriter.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessageAndStackTrace(ex));
                         return ConsoleRunner.UNEXPECTED_ERROR;
                     }
                     finally

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -144,7 +144,7 @@ namespace NUnit.Agent
             }
             catch (Exception ex)
             {
-                log.Error("Exception in RemoteTestAgent. {0}", ExceptionHelper.BuildStackTrace(ex));
+                log.Error("Exception in RemoteTestAgent. {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
                 Environment.Exit(AgentExitCodes.UNEXPECTED_EXCEPTION);
             }
             log.Info("Agent process {0} exiting cleanly", pid);

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -144,7 +144,7 @@ namespace NUnit.Agent
             }
             catch (Exception ex)
             {
-                log.Error("Exception in RemoteTestAgent", ex);
+                log.Error("Exception in RemoteTestAgent. {0}", ExceptionHelper.BuildStackTrace(ex));
                 Environment.Exit(AgentExitCodes.UNEXPECTED_EXCEPTION);
             }
             log.Info("Agent process {0} exiting cleanly", pid);

--- a/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent-x86.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
+    <Compile Include="..\nunit.engine\Internal\ExceptionHelper.cs" Link="ExceptionHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\nunit.ico">

--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs" LinkBase="Properties" />
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
+    <Compile Include="..\nunit.engine\Internal\ExceptionHelper.cs" Link="ExceptionHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\..\nunit.ico">

--- a/src/NUnitEngine/nunit.engine.api/ILogger.cs
+++ b/src/NUnitEngine/nunit.engine.api/ILogger.cs
@@ -37,9 +37,9 @@ namespace NUnit.Engine
         /// <summary>
         /// Logs the specified message at the error level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The arguments.</param>
-        void Error(string message, params object[] args);
+        void Error(string format, params object[] args);
 
         /// <summary>
         /// Logs the specified message at the warning level.
@@ -50,9 +50,9 @@ namespace NUnit.Engine
         /// <summary>
         /// Logs the specified message at the warning level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The arguments.</param>
-        void Warning(string message, params object[] args);
+        void Warning(string format, params object[] args);
 
         /// <summary>
         /// Logs the specified message at the info level.
@@ -63,9 +63,9 @@ namespace NUnit.Engine
         /// <summary>
         /// Logs the specified message at the info level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The arguments.</param>
-        void Info(string message, params object[] args);
+        void Info(string format, params object[] args);
 
         /// <summary>
         /// Logs the specified message at the debug level.
@@ -76,8 +76,8 @@ namespace NUnit.Engine
         /// <summary>
         /// Logs the specified message at the debug level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The arguments.</param>
-        void Debug(string message, params object[] args);
+        void Debug(string format, params object[] args);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -102,7 +102,7 @@ namespace NUnit.Engine.Agents
             }
             catch (Exception ex)
             {
-                log.Error("Unable to connect: {0}", ExceptionHelper.BuildStackTrace(ex));
+                log.Error("Unable to connect: {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
             }
 
             try
@@ -112,7 +112,7 @@ namespace NUnit.Engine.Agents
             }
             catch (Exception ex)
             {
-                log.Error("RemoteTestAgent: Failed to register with TestAgency. {0}", ExceptionHelper.BuildStackTrace(ex));
+                log.Error("RemoteTestAgent: Failed to register with TestAgency. {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
                 return false;
             }
 

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -26,6 +26,7 @@ using System;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
 using System.Threading;
+using NUnit.Common;
 using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Agents
@@ -101,7 +102,7 @@ namespace NUnit.Engine.Agents
             }
             catch (Exception ex)
             {
-                log.Error("Unable to connect", ex);
+                log.Error("Unable to connect: {0}", ExceptionHelper.BuildStackTrace(ex));
             }
 
             try
@@ -111,7 +112,7 @@ namespace NUnit.Engine.Agents
             }
             catch (Exception ex)
             {
-                log.Error("RemoteTestAgent: Failed to register with TestAgency", ex);
+                log.Error("RemoteTestAgent: Failed to register with TestAgency. {0}", ExceptionHelper.BuildStackTrace(ex));
                 return false;
             }
 

--- a/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DomainDetailsBuilder.cs
@@ -65,12 +65,12 @@ namespace NUnit.Engine.Internal
             catch (AppDomainUnloadedException ex)
             {
                 sb.AppendLine("Application domain was unloaded before all details could be read.");
-                Log.Error(ExceptionHelper.BuildStackTrace(ex));
+                Log.Error(ExceptionHelper.BuildMessageAndStackTrace(ex));
             }
             catch (Exception ex)
             {
                 sb.AppendLine($"Error trying to read application domain details: {ex.Message}");
-                Log.Error(ExceptionHelper.BuildStackTrace(ex));
+                Log.Error(ExceptionHelper.BuildMessageAndStackTrace(ex));
             }
             return sb.ToString();
         }

--- a/src/NUnitEngine/nunit.engine/Internal/ExceptionHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ExceptionHelper.cs
@@ -60,7 +60,7 @@ namespace NUnit.Common
         /// </summary>
         /// <param name="exception">The exception.</param>
         /// <returns>A combined stack trace.</returns>
-        public static string BuildStackTrace(Exception exception)
+        public static string BuildMessageAndStackTrace(Exception exception)
         {
             var sb = new StringBuilder("--");
             sb.AppendLine(exception.GetType().Name);

--- a/src/NUnitEngine/nunit.engine/Internal/Logging/Logger.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/Logging/Logger.cs
@@ -31,28 +31,26 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public class Logger : ILogger
     {
-        private readonly static string TIME_FMT = "HH:mm:ss.fff";
-        private readonly static string TRACE_FMT = "{0} {1,-5} [{2,2}] {3}: {4}";
+        private const string TimeFmt = "HH:mm:ss.fff";
+        private const string TraceFmt = "{0} {1,-5} [{2,2}] {3}: {4}";
 
-        private string name;
-        private string fullname;
-        private InternalTraceLevel maxLevel;
-        private TextWriter writer;
+        private readonly string _name;
+        private readonly InternalTraceLevel _maxLevel;
+        private readonly TextWriter _writer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Logger"/> class.
         /// </summary>
-        /// <param name="name">The name.</param>
+        /// <param name="fullName">The name.</param>
         /// <param name="level">The log level.</param>
         /// <param name="writer">The writer where logs are sent.</param>
-        public Logger(string name, InternalTraceLevel level, TextWriter writer)
+        public Logger(string fullName, InternalTraceLevel level, TextWriter writer)
         {
-            this.maxLevel = level;
-            this.writer = writer;
-            this.fullname = this.name = name;
-            int index = fullname.LastIndexOf('.');
-            if (index >= 0)
-                this.name = fullname.Substring(index + 1);
+            _maxLevel = level;
+            _writer = writer;
+
+            var index = fullName.LastIndexOf('.');
+            _name = index >= 0 ? fullName.Substring(index + 1) : fullName;
         }
 
         #region Error
@@ -68,11 +66,11 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Logs the message at error level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The message arguments.</param>
-        public void Error(string message, params object[] args)
+        public void Error(string format, params object[] args)
         {
-            Log(InternalTraceLevel.Error, message, args);
+            Log(InternalTraceLevel.Error, format, args);
         }
 
         #endregion
@@ -90,11 +88,11 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Logs the message at warning level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The message arguments.</param>
-        public void Warning(string message, params object[] args)
+        public void Warning(string format, params object[] args)
         {
-            Log(InternalTraceLevel.Warning, message, args);
+            Log(InternalTraceLevel.Warning, format, args);
         }
         #endregion
 
@@ -111,11 +109,11 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Logs the message at info level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The message arguments.</param>
-        public void Info(string message, params object[] args)
+        public void Info(string format, params object[] args)
         {
-            Log(InternalTraceLevel.Info, message, args);
+            Log(InternalTraceLevel.Info, format, args);
         }
         #endregion
 
@@ -132,11 +130,11 @@ namespace NUnit.Engine.Internal
         /// <summary>
         /// Logs the message at debug level.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="format">The message.</param>
         /// <param name="args">The message arguments.</param>
-        public void Debug(string message, params object[] args)
+        public void Debug(string format, params object[] args)
         {
-            Log(InternalTraceLevel.Verbose, message, args);
+            Log(InternalTraceLevel.Verbose, format, args);
         }
         #endregion
 
@@ -144,27 +142,27 @@ namespace NUnit.Engine.Internal
 
         private void Log(InternalTraceLevel level, string message)
         {
-            if (writer != null && this.maxLevel >= level)
+            if (_writer != null && _maxLevel >= level)
                 WriteLog(level, message);
         }
 
         private void Log(InternalTraceLevel level, string format, params object[] args)
         {
-            if (this.maxLevel >= level)
-                WriteLog(level, string.Format( format, args ) );
+            if (_maxLevel >= level)
+                WriteLog(level, string.Format(format, args));
         }
 
         private void WriteLog(InternalTraceLevel level, string message)
         {
-            writer.WriteLine(TRACE_FMT,
-                DateTime.Now.ToString(TIME_FMT),
-                level == InternalTraceLevel.Verbose ? "Debug" : level.ToString(),
+            _writer.WriteLine(TraceFmt,
+                DateTime.Now.ToString(TimeFmt),
+                level,
 #if NET20
                 System.Threading.Thread.CurrentThread.ManagedThreadId,
 #else
                 Environment.CurrentManagedThreadId,
 #endif
-                name, message);
+                _name, message);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Internal/TcpChannelUtils.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TcpChannelUtils.cs
@@ -124,7 +124,7 @@ namespace NUnit.Engine.Internal
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to create/register channel. {0}", ExceptionHelper.BuildStackTrace(ex));
+                    Log.Error("Failed to create/register channel. {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
                     Thread.Sleep(300);
                 }
 

--- a/src/NUnitEngine/nunit.engine/Internal/TcpChannelUtils.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TcpChannelUtils.cs
@@ -124,7 +124,7 @@ namespace NUnit.Engine.Internal
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to create/register channel. {0}", ExceptionHelper.BuildMessageAndStackTrace(ex));
+                    Log.Error("Failed to create/register channel." + Environment.NewLine + ExceptionHelper.BuildMessageAndStackTrace(ex));
                     Thread.Sleep(300);
                 }
 

--- a/src/NUnitEngine/nunit.engine/Internal/TcpChannelUtils.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TcpChannelUtils.cs
@@ -29,6 +29,7 @@ using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;
 using System.Runtime.Serialization.Formatters;
 using System.Threading;
+using NUnit.Common;
 
 namespace NUnit.Engine.Internal
 {
@@ -123,7 +124,7 @@ namespace NUnit.Engine.Internal
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Failed to create/register channel", ex);
+                    Log.Error("Failed to create/register channel. {0}", ExceptionHelper.BuildStackTrace(ex));
                     Thread.Sleep(300);
                 }
 

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -80,7 +80,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildStackTrace(e));
+                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 return CreateFailedResult(e);
             }
         }
@@ -126,7 +126,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Warning("Failed to unload the remote runner. {0}", ExceptionHelper.BuildStackTrace(e));
+                log.Warning("Failed to unload the remote runner. {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 _remoteRunner = null;
                 throw;
             }
@@ -148,7 +148,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to count remote tests {0}", ExceptionHelper.BuildStackTrace(e));
+                log.Error("Failed to count remote tests {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 return 0;
             }
         }
@@ -173,7 +173,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildStackTrace(e));
+                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 return CreateFailedResult(e);
             }
         }
@@ -198,7 +198,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildStackTrace(e));
+                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 var result = new AsyncTestEngineResult();
                 result.SetResult(CreateFailedResult(e));
                 return result;
@@ -219,7 +219,7 @@ namespace NUnit.Engine.Runners
                 }
                 catch (Exception e)
                 {
-                    log.Error("Failed to stop the remote run. {0}", ExceptionHelper.BuildStackTrace(e));
+                    log.Error("Failed to stop the remote run. {0}", ExceptionHelper.BuildMessageAndStackTrace(e));
                 }
             }
         }
@@ -245,7 +245,7 @@ namespace NUnit.Engine.Runners
                     // Save and log the unload error
                     unloadException = ex;
                     log.Error(ExceptionHelper.BuildMessage(ex));
-                    log.Error(ExceptionHelper.BuildStackTrace(ex));
+                    log.Error(ExceptionHelper.BuildMessageAndStackTrace(ex));
                 }
 
                 if (_agent != null && _agency.IsAgentRunning(_agent.Id))
@@ -266,7 +266,7 @@ namespace NUnit.Engine.Runners
                         else
                         {
 
-                            var stopError = $"Agent connection was forcibly closed. Exit code was {exitCode?.ToString() ?? "unknown"}. {ExceptionHelper.BuildMessage(se)}{Environment.NewLine}{ExceptionHelper.BuildStackTrace(se)}";
+                            var stopError = $"Agent connection was forcibly closed. Exit code was {exitCode?.ToString() ?? "unknown"}. {ExceptionHelper.BuildMessage(se)}{Environment.NewLine}{ExceptionHelper.BuildMessageAndStackTrace(se)}";
                             log.Error(stopError);
 
                             // Stop error with no unload error, just rethrow
@@ -279,7 +279,7 @@ namespace NUnit.Engine.Runners
                     }
                     catch (Exception e)
                     {
-                        var stopError = $"Failed to stop the remote agent. {ExceptionHelper.BuildMessage(e)}{Environment.NewLine}{ExceptionHelper.BuildStackTrace(e)}";
+                        var stopError = $"Failed to stop the remote agent. {ExceptionHelper.BuildMessage(e)}{Environment.NewLine}{ExceptionHelper.BuildMessageAndStackTrace(e)}";
                         log.Error(stopError);
 
                         // Stop error with no unload error, just rethrow
@@ -345,7 +345,7 @@ namespace NUnit.Engine.Runners
 
             var failure = suite.AddElement("failure");
             failure.AddElementWithCDataSection("message", ExceptionHelper.BuildMessage(e));
-            failure.AddElementWithCDataSection("stack-trace", ExceptionHelper.BuildStackTrace(e));
+            failure.AddElementWithCDataSection("stack-trace", ExceptionHelper.BuildMessageAndStackTrace(e));
 
             return new TestEngineResult(suite);
         }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -266,7 +266,7 @@ namespace NUnit.Engine.Runners
                         else
                         {
 
-                            var stopError = $"Agent connection was forcibly closed. Exit code was {exitCode?.ToString() ?? "unknown"}. {ExceptionHelper.BuildMessage(se)}{Environment.NewLine}{ExceptionHelper.BuildMessageAndStackTrace(se)}";
+                            var stopError = $"Agent connection was forcibly closed. Exit code was {exitCode?.ToString() ?? "unknown"}. {Environment.NewLine}{ExceptionHelper.BuildMessageAndStackTrace(se)}";
                             log.Error(stopError);
 
                             // Stop error with no unload error, just rethrow
@@ -279,7 +279,7 @@ namespace NUnit.Engine.Runners
                     }
                     catch (Exception e)
                     {
-                        var stopError = $"Failed to stop the remote agent. {ExceptionHelper.BuildMessage(e)}{Environment.NewLine}{ExceptionHelper.BuildMessageAndStackTrace(e)}";
+                        var stopError = "Failed to stop the remote agent." + Environment.NewLine + ExceptionHelper.BuildMessageAndStackTrace(e);
                         log.Error(stopError);
 
                         // Stop error with no unload error, just rethrow

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -80,7 +80,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to run remote tests {0}", e.Message);
+                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildStackTrace(e));
                 return CreateFailedResult(e);
             }
         }
@@ -126,7 +126,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Warning("Failed to unload the remote runner. {0}", e.Message);
+                log.Warning("Failed to unload the remote runner. {0}", ExceptionHelper.BuildStackTrace(e));
                 _remoteRunner = null;
                 throw;
             }
@@ -148,7 +148,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to count remote tests {0}", e.Message);
+                log.Error("Failed to count remote tests {0}", ExceptionHelper.BuildStackTrace(e));
                 return 0;
             }
         }
@@ -173,7 +173,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to run remote tests {0}", e.Message);
+                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildStackTrace(e));
                 return CreateFailedResult(e);
             }
         }
@@ -198,7 +198,7 @@ namespace NUnit.Engine.Runners
             }
             catch (Exception e)
             {
-                log.Error("Failed to run remote tests {0}", e.Message);
+                log.Error("Failed to run remote tests {0}", ExceptionHelper.BuildStackTrace(e));
                 var result = new AsyncTestEngineResult();
                 result.SetResult(CreateFailedResult(e));
                 return result;
@@ -219,7 +219,7 @@ namespace NUnit.Engine.Runners
                 }
                 catch (Exception e)
                 {
-                    log.Error("Failed to stop the remote run. {0}", e.Message);
+                    log.Error("Failed to stop the remote run. {0}", ExceptionHelper.BuildStackTrace(e));
                 }
             }
         }


### PR DESCRIPTION
There was a convention in this repo to log like this:

```
log.Error("Exception in RemoteTestAgent", ex);
```

The assumption being that this commits both message and exception to the log.

That's not actually how our logger works - the first parameter is expected to be a format-string, so if it doesn't contain a `{0}`, then the exception information is never logged.

Given this is a public interface, I've just fixed our usages of it, rather than redefining the interface. I've also made use of ExceptionHelper, as per https://github.com/nunit/nunit-console/pull/576#discussion_r272793843. 🙂 