### PR TITLE
Fix agent crash when WorkDirectory path terminates in slash

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -114,13 +114,12 @@ namespace NUnit.Agent
             // Create TestEngine - this program is
             // conceptually part of  the engine and
             // can access its internals as needed.
-            TestEngine engine = new TestEngine();
-
-            // TODO: We need to get this from somewhere. Argument?
-            engine.InternalTraceLevel = InternalTraceLevel.Debug;
+            var engine = new TestEngine
+            {
+                InternalTraceLevel = traceLevel
+            };
 
             // Custom Service Initialization
-            //log.Info("Adding Services");
             engine.Services.Add(new ExtensionService());
             engine.Services.Add(new DomainManager());
             engine.Services.Add(new InProcessTestRunnerFactory());

--- a/src/NUnitEngine/nunit.engine.tests/Internal/ProcessUtilsTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/ProcessUtilsTests.cs
@@ -1,0 +1,123 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Joseph N. Musser II
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using NUnit.Engine.Internal;
+using NUnit.Framework;
+using System.Text;
+
+namespace NUnit.Engine.Tests.Internal
+{
+    public static class ProcessUtilsTests
+    {
+        private static string EscapeProcessArgument(string value, bool alwaysQuote = false)
+        {
+            var builder = new StringBuilder();
+            ProcessUtils.EscapeProcessArgument(builder, value, alwaysQuote);
+            return builder.ToString();
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_null()
+        {
+            Assert.That(EscapeProcessArgument(null), Is.EqualTo("\"\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_null_alwaysQuote()
+        {
+            Assert.That(EscapeProcessArgument(null, true), Is.EqualTo("\"\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_empty()
+        {
+            Assert.That(EscapeProcessArgument(string.Empty), Is.EqualTo("\"\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_empty_alwaysQuote()
+        {
+            Assert.That(EscapeProcessArgument(string.Empty, true), Is.EqualTo("\"\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_simple()
+        {
+            Assert.That(EscapeProcessArgument("123"), Is.EqualTo("123"));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_simple_alwaysQuote()
+        {
+            Assert.That(EscapeProcessArgument("123", true), Is.EqualTo("\"123\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_ending_backslash()
+        {
+            Assert.That(EscapeProcessArgument("123\\"), Is.EqualTo("123\\"));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_ending_backslash_alwaysQuote()
+        {
+            Assert.That(EscapeProcessArgument("123\\", true), Is.EqualTo("\"123\\\\\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_spaces_and_ending_backslash()
+        {
+            Assert.That(EscapeProcessArgument(" 1 2 3 \\"), Is.EqualTo("\" 1 2 3 \\\\\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_spaces()
+        {
+            Assert.That(EscapeProcessArgument(" 1 2 3 "), Is.EqualTo("\" 1 2 3 \""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_quotes()
+        {
+            Assert.That(EscapeProcessArgument("\"1\"2\"3\""), Is.EqualTo("\"\\\"1\\\"2\\\"3\\\"\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_slashes()
+        {
+            Assert.That(EscapeProcessArgument("1\\2\\\\3\\\\\\"), Is.EqualTo("1\\2\\\\3\\\\\\"));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_with_slashes_alwaysQuote()
+        {
+            Assert.That(EscapeProcessArgument("1\\2\\\\3\\\\\\", true), Is.EqualTo("\"1\\2\\\\3\\\\\\\\\\\\\""));
+        }
+
+        [Test]
+        public static void EscapeProcessArgument_slashes_followed_by_quotes()
+        {
+            Assert.That(EscapeProcessArgument("\\\\\""), Is.EqualTo("\"\\\\\\\\\\\"\""));
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Internal/ProcessUtils.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ProcessUtils.cs
@@ -32,7 +32,7 @@ namespace NUnit.Engine.Internal
 
         /// <summary>
         /// Escapes arbitrary values so that the process receives the exact string you intend and injection is impossible.
-        /// Spec: https://msdn.microsoft.com/en-us/library/bb776391.aspx
+        /// Spec: https://docs.microsoft.com/en-gb/windows/desktop/api/shellapi/nf-shellapi-commandlinetoargvw
         /// </summary>
         public static void EscapeProcessArgument(this StringBuilder builder, string literalValue, bool alwaysQuote = false)
         {

--- a/src/NUnitEngine/nunit.engine/Internal/ProcessUtils.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ProcessUtils.cs
@@ -1,0 +1,95 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Joseph N. Musser II
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Text;
+
+namespace NUnit.Engine.Internal
+{
+    internal static class ProcessUtils
+    {
+        private static readonly char[] CharsThatRequireQuoting = { ' ', '"' };
+        private static readonly char[] CharsThatRequireEscaping = { '\\', '"' };
+
+        /// <summary>
+        /// Escapes arbitrary values so that the process receives the exact string you intend and injection is impossible.
+        /// Spec: https://msdn.microsoft.com/en-us/library/bb776391.aspx
+        /// </summary>
+        public static void EscapeProcessArgument(this StringBuilder builder, string literalValue, bool alwaysQuote = false)
+        {
+            if (string.IsNullOrEmpty(literalValue))
+            {
+                builder.Append("\"\"");
+                return;
+            }
+
+            if (literalValue.IndexOfAny(CharsThatRequireQuoting) == -1) // Happy path
+            {
+                if (!alwaysQuote)
+                {
+                    builder.Append(literalValue);
+                    return;
+                }
+                if (literalValue[literalValue.Length - 1] != '\\')
+                {
+                    builder.Append('"').Append(literalValue).Append('"');
+                    return;
+                }
+            }
+
+            builder.Append('"');
+
+            var nextPosition = 0;
+            while (true)
+            {
+                var nextEscapeChar = literalValue.IndexOfAny(CharsThatRequireEscaping, nextPosition);
+                if (nextEscapeChar == -1) break;
+
+                builder.Append(literalValue, nextPosition, nextEscapeChar - nextPosition);
+                nextPosition = nextEscapeChar + 1;
+
+                switch (literalValue[nextEscapeChar])
+                {
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\\':
+                        var numBackslashes = 1;
+                        while (nextPosition < literalValue.Length && literalValue[nextPosition] == '\\')
+                        {
+                            numBackslashes++;
+                            nextPosition++;
+                        }
+                        if (nextPosition == literalValue.Length || literalValue[nextPosition] == '"')
+                            numBackslashes <<= 1;
+
+                        for (; numBackslashes != 0; numBackslashes--)
+                            builder.Append('\\');
+                        break;
+                }
+            }
+
+            builder.Append(literalValue, nextPosition, literalValue.Length - nextPosition);
+            builder.Append('"');
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -26,6 +26,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Diagnostics;
+using System.Text;
 using NUnit.Common;
 using NUnit.Engine.Agents;
 using NUnit.Engine.Internal;
@@ -178,15 +179,17 @@ namespace NUnit.Engine.Services
             bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
             string workDirectory = package.GetSetting(EnginePackageSettings.WorkDirectory, string.Empty);
 
+            var agentArgs = new StringBuilder();
+
             // Set options that need to be in effect before the package
             // is loaded by using the command line.
-            string agentArgs = "--pid=" + Process.GetCurrentProcess().Id.ToString();
+            agentArgs.Append("--pid=").Append(Process.GetCurrentProcess().Id);
             if (traceLevel != "Off")
-                agentArgs += " --trace:" + traceLevel;
+                agentArgs.Append(" --trace:").EscapeProcessArgument(traceLevel);
             if (debugAgent)
-                agentArgs += " --debug-agent";
+                agentArgs.Append(" --debug-agent");
             if (workDirectory != string.Empty)
-                agentArgs += " --work=\"" + workDirectory + "\"";
+                agentArgs.Append(" --work=").EscapeProcessArgument(workDirectory);
 
             log.Info("Getting {0} agent for use under {1}", useX86Agent ? "x86" : "standard", targetRuntime);
 


### PR DESCRIPTION
Fixes #605. (Regression)

Given this was a regression, I applied a more heavy-weight fix, by using @jnm2's ProcessUtils class that Joseph was planning to merge as part of #576. (Joseph - I presumed you'd be happy for me to do this, can you just confirm that? 😄)

This area could probably do with some mock-based unit testing somehow...but that's non-trivial, and I'm not too keen to put the effort in before we're about to fully refactor the agent communication.

