### PR TITLE
Test double-negative filters

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -54,14 +54,18 @@ namespace NUnit.Engine.Services.Tests
             _driver.Load(mockAssemblyPath, new Dictionary<string, object>());
         }
 
+        // TODO: Uncomment the "double negative" tests when we are using an updated framework that handles them correctly.
         [TestCase("<filter/>", MockAssembly.Tests)]
         [TestCase("<filter><test>NUnit.Tests.Assemblies.MockTestFixture</test></filter>", MockTestFixture.Tests)]
+        //[TestCase("<filter><not><not><test>NUnit.Tests.Assemblies.MockTestFixture</test></not></not></filter>", MockTestFixture.Tests)]
         [TestCase("<filter><test>NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest</test></filter>", 1)]
+        //[TestCase("<filter><not><not><test>NUnit.Tests.Assemblies.MockTestFixture.IgnoreTest</test></not></not></filter>", 1)]
         [TestCase("<filter><class>NUnit.Tests.Assemblies.MockTestFixture</class></filter>", MockTestFixture.Tests)]
         [TestCase("<filter><name>IgnoreTest</name></filter>", 1)]
         [TestCase("<filter><name>MockTestFixture</name></filter>", MockTestFixture.Tests + NUnit.Tests.TestAssembly.MockTestFixture.Tests)]
         [TestCase("<filter><method>IgnoreTest</method></filter>", 1)]
         [TestCase("<filter><cat>FixtureCategory</cat></filter>", MockTestFixture.Tests)]
+        //[TestCase("<filter><not><not><cat>FixtureCategory</cat></not></not></filter>", MockTestFixture.Tests)]
         public void UsingXml(string filter, int count)
         {
             Assert.That(_driver.CountTestCases(filter), Is.EqualTo(count));

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
@@ -69,6 +69,8 @@ namespace NUnit.Engine.Tests
         [TestCase("cat==Urgent && test=='My.Tests' || cat == high", "<or><and><cat>Urgent</cat><test>My.Tests</test></and><cat>high</cat></or>")]
         [TestCase("cat==Urgent && (test=='My.Tests' || cat == high)", "<and><cat>Urgent</cat><or><test>My.Tests</test><cat>high</cat></or></and>")]
         [TestCase("cat==Urgent && !(test=='My.Tests' || cat == high)", "<and><cat>Urgent</cat><not><or><test>My.Tests</test><cat>high</cat></or></not></and>")]
+        [TestCase("!(test!='My.Tests')", "<not><not><test>My.Tests</test></not></not>")]
+        [TestCase("!(cat!=Urgent)", "<not><not><cat>Urgent</cat></not></not>")]
         public void TestParser(string input, string output)
         {
             Assert.That(_parser.Parse(input), Is.EqualTo(output));


### PR DESCRIPTION
This PR simply adds some tests to verify that issue #606 is not an engine problem. Other tests are also added, but commented out, which are intended to verify that these filters actually work properly. 

They don't (work properly) but that's a framework issue. This can be merged to ensure that the console and engine keep working correctly, since there were not tests of this pattern before.