### PR TITLE
WIP: Expand projects before building TestRunner tree

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -56,5 +56,20 @@ namespace NUnit.Engine.Services.Tests.Fakes
         {
             return Path.GetExtension(path) == _supportedExtension;
         }
+
+        internal void ExpandAllProjects(TestPackage package)
+        {
+            if (package == null) throw new ArgumentNullException(nameof(package));
+
+            foreach (var subPackage in package.SubPackages)
+            {
+                ExpandAllProjects(subPackage);
+            }
+
+            if (package.Name != null)
+            {
+                ((IProjectService)this).ExpandProjectPackage(package);
+            }
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
@@ -35,19 +35,31 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
 
         public override string ToString()
         {
+            return Environment.NewLine + ToString(0) + Environment.NewLine;
+        }
+
+        private string ToString(int level)
+        {
+            var tabs = new string('\t', level);
+
             var sb = new StringBuilder();
-            sb.AppendLine($"TestRunner: {TestRunner.Name}");
+            sb.AppendLine($"{tabs}TestRunner: {TestRunner.Name}");
 
             if (SubRunners.Count == 0)
                 return sb.ToString().Trim();
 
-            sb.AppendLine("SubRunners:");
+            level++;
+            tabs = new string('\t', level);
+
+            sb.AppendLine(tabs + "SubRunners:");
+
+            level++;
+            tabs = new string('\t', level);
 
             foreach (var subRunner in SubRunners)
             {
-                sb.AppendLine($"\t{subRunner}");
+                sb.AppendLine($"{tabs}{subRunner.ToString(level)}");
             }
-
             return sb.ToString().Trim();
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -39,6 +39,9 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
     public class RunnerSelectionTests
     {
         private DefaultTestRunnerFactory _factory;
+#if !NETCOREAPP1_1
+        private FakeProjectService _projectService;
+#endif
 
         [OneTimeSetUp]
         public void SetUp()
@@ -46,11 +49,12 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
             var services = new ServiceContext();
 #if !NETCOREAPP1_1
             services.Add(new ExtensionService());
-            var projectService = new FakeProjectService();
-            projectService.Add(TestPackageFactory.FakeProject, "a.dll", "b.dll");
-            services.Add(projectService);
+            _projectService = new FakeProjectService();
+            _projectService.Add(TestPackageFactory.FakeProject, "a.dll", "b.dll");
+            services.Add(_projectService);
 #endif
             _factory = new DefaultTestRunnerFactory();
+
             services.Add(_factory);
             _factory.StartService();
         }
@@ -58,6 +62,10 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
         [TestCaseSource(nameof(TestCases))]
         public void RunnerSelectionTest(TestPackage package, RunnerResult expected)
         {
+#if !NETCOREAPP1_1
+            _projectService.ExpandAllProjects(package);
+#endif
+
             var runner = _factory.MakeTestRunner(package);
             var result = GetRunnerResult(runner);
             Assert.That(result, Is.EqualTo(expected).Using(RunnerResultComparer.Instance));

--- a/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/TestPackageExtensions.cs
@@ -43,6 +43,11 @@ namespace NUnit.Engine.Internal
             return package.SubPackages.Count > 0;
         }
 
+        public static bool HasMultipleAssemblies(this TestPackage package)
+        {
+            return package.Select(p => p.IsAssemblyPackage()).Count > 1;
+        }
+
         public static IList<TestPackage> Select(this TestPackage package, TestPackageSelectorDelegate selector)
         {
             var selection = new List<TestPackage>();

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -43,13 +43,13 @@ namespace NUnit.Engine.Runners
         // MasterTestRunner is the only runner that is passed back
         // to users asking for an ITestRunner. The actual details of
         // execution are handled by various internal runners, which
-        // impement ITestEngineRunner.
+        // implement ITestEngineRunner.
         //
         // Explore and execution results from MasterTestRunner are
         // returned as XmlNodes, created from the internal 
         // TestEngineResult representation.
         // 
-        // MasterTestRUnner is responsible for creating the test-run
+        // MasterTestRunner is responsible for creating the test-run
         // element, which wraps all the individual assembly and project
         // results.
 
@@ -66,11 +66,8 @@ namespace NUnit.Engine.Runners
 
         public MasterTestRunner(IServiceLocator services, TestPackage package)
         {
-            if (services == null) throw new ArgumentNullException("services");
-            if (package == null) throw new ArgumentNullException("package");
-
-            _services = services;
-            TestPackage = package;
+            _services = services ?? throw new ArgumentNullException(nameof(services));
+            TestPackage = package ?? throw new ArgumentNullException(nameof(package));
 
             // Get references to the services we use
             _projectService = _services.GetService<IProjectService>();
@@ -80,9 +77,9 @@ namespace NUnit.Engine.Runners
 #if !NETSTANDARD1_6
             _extensionService = _services.GetService<ExtensionService>();
 #endif
-            _engineRunner = _services.GetService<ITestRunnerFactory>().MakeTestRunner(package);
-
             InitializePackage();
+
+            _engineRunner = _services.GetService<ITestRunnerFactory>().MakeTestRunner(package);
         }
 
 #region Properties
@@ -335,9 +332,9 @@ namespace NUnit.Engine.Runners
             return topLevelResult;
         }
 
-        private void EnsurePackagesAreExpanded(TestPackage package)
+        internal void EnsurePackagesAreExpanded(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException("package");
+            if (package == null) throw new ArgumentNullException(nameof(package));
 
             foreach (var subPackage in package.SubPackages)
             {
@@ -352,7 +349,7 @@ namespace NUnit.Engine.Runners
 
         private bool IsProjectPackage(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException("package");
+            if (package == null) throw new ArgumentNullException(nameof(package));
 
             return
                 _projectService != null

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestDomainRunner.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using NUnit.Engine.Internal;
+
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
 namespace NUnit.Engine.Runners
 {
@@ -41,7 +43,7 @@ namespace NUnit.Engine.Runners
 
         protected override ITestEngineRunner CreateRunner(TestPackage package)
         {
-            return new TestDomainRunner(Services, package);
+            return package.HasSubPackages() ? (ITestEngineRunner)new MultipleTestDomainRunner(Services, package) : new TestDomainRunner(Services, package);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -23,6 +23,7 @@
 
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
+using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Runners
 {
@@ -54,7 +55,7 @@ namespace NUnit.Engine.Runners
 
         protected override ITestEngineRunner CreateRunner(TestPackage package)
         {
-            return new ProcessRunner(Services, package);
+            return package.HasSubPackages() ? (ITestEngineRunner)new MultipleTestProcessRunner(Services, package) : new ProcessRunner(Services, package);
         }
 
         #endregion

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -45,7 +45,9 @@ namespace NUnit.Engine.Services
         public virtual ITestEngineRunner MakeTestRunner(TestPackage package)
         {
 #if NETSTANDARD1_6 || NETSTANDARD2_0
-            return new LocalTestRunner(ServiceContext, package);
+            return package.HasMultipleAssemblies() ? 
+                (ITestEngineRunner)new AggregatingTestRunner(ServiceContext, package) : 
+                new LocalTestRunner(ServiceContext, package);
 #else
             DomainUsage domainUsage = (DomainUsage)System.Enum.Parse(
                 typeof(DomainUsage),
@@ -55,7 +57,7 @@ namespace NUnit.Engine.Services
             {
                 default:
                 case DomainUsage.Default:
-                    if (package.SubPackages.Count > 1)
+                    if (package.HasMultipleAssemblies())
                         return new MultipleTestDomainRunner(this.ServiceContext, package);
                     else
                         return new TestDomainRunner(this.ServiceContext, package);


### PR DESCRIPTION
WIP, will fix #617. Branched off #616, so should be easier to look at once that's merged.

I've had a first attempt at working this out. Current status: it needs tidying up, unit tests need updating and I need to do a lot more manual testing.

After expanding the packages and tidying up, I found that MultipleProcessRunner and MultipleDomainRunner would only ever create their 'single' versions (e.g. ProcessRunner) as subrunners - I made a change there so a MultipleXRunner will create Multiple or Single version, depending on the subpackages. I think this will also fix some outstanding bugs.

An example path down the tree before:
```
AggregatingTestRunner (Command Line) -> ProcessRunner (a.nunit) -> MultipleTestDomainRunner (a.nunit) -> TestDomainRunner (a.dll) + TestDomainRunner (b.dll)
```
And after:
```
MultipleProcessRunner (Command Line) -> MultipleProcessRunner (a.nunit) -> ProcessRunner (a.dll) + ProcessRunner (b.dll)
```
These changes also mean that AggregatingTestRunner now has very limited use, as there's no need to "defer a decision until later". It's only remaining use is in the .NET Standard engine to aggregate multiple LocalTestRunners - I'm tempted to make a MultipleLocalRunner class, and make AggTestRunner abstract. I think that might make the inheritance structure a little clearer here.

cc @CharliePoole, if you're interested after our discussion on #617. Would be keen to hear about any issues you foresee.