### PR TITLE
Delay Creation of test engine runner and package expansion till actually needed

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
@@ -22,8 +22,6 @@
 // ***********************************************************************
 
 using System;
-using System.IO;
-using NUnit.Engine.Extensibility;
 
 namespace NUnit.Engine.Services.Tests.Fakes
 {
@@ -36,7 +34,7 @@ namespace NUnit.Engine.Services.Tests.Fakes
 
         string IRuntimeFrameworkService.SelectRuntimeFramework(TestPackage package)
         {
-            throw new NotImplementedException();
+            return string.Empty;
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/InProcessTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/InProcessTestRunnerFactoryTests.cs
@@ -58,7 +58,7 @@ namespace NUnit.Engine.Services.Tests
         // Single file
         [TestCase("x.dll",  null,      typeof(TestDomainRunner))]
         [TestCase("x.dll", "Single",   typeof(TestDomainRunner))]
-        [TestCase("x.dll", "Multiple", typeof(MultipleTestDomainRunner))]
+        [TestCase("x.dll", "Multiple", typeof(TestDomainRunner))]
         // Two files
         [TestCase("x.dll y.dll",  null,     typeof(MultipleTestDomainRunner))]
         [TestCase("x.dll y.dll", "Single",   typeof(TestDomainRunner))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20OneAssemblyOneProjectExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20OneAssemblyOneProjectExpectedRunnerResults.cs
@@ -60,11 +60,11 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) }
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
                         }
                     };
                 default:
@@ -82,12 +82,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
-                        }
+                        TestRunner = typeof(ProcessRunner)
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
@@ -101,7 +96,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Default:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(TestDomainRunner) },
@@ -111,31 +106,21 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                        }
+                        TestRunner = typeof(LocalTestRunner)
                     };
                 case DomainUsage.Single:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
-                        }
+                        TestRunner = typeof(TestDomainRunner)
                     };
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) }
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
                         }
                     };
                 default:
@@ -153,7 +138,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(ProcessRunner) },

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyListCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyListCtorExpectedRunnerResults.cs
@@ -58,14 +58,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         case DomainUsage.Single:
                             return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                         case DomainUsage.Multiple:
-                            return new RunnerResult
-                            {
-                                TestRunner = typeof(MultipleTestDomainRunner),
-                                SubRunners = new[]
-                                {
-                                    new RunnerResult {TestRunner = typeof(TestDomainRunner)}
-                                }
-                            };
+                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyStringCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyStringCtorExpectedRunnerResults.cs
@@ -58,7 +58,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         case DomainUsage.Single:
                             return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) };
+                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
@@ -60,10 +60,10 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(MultipleTestProcessRunner),
+                        TestRunner = typeof(AggregatingTestRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) }
                         }
                     };
                 default:
@@ -81,7 +81,11 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(ProcessRunner)
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new[]
+                        {
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                        }
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
@@ -110,11 +110,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(MultipleTestDomainRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
-                        }
+                        TestRunner = typeof(TestDomainRunner),
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
@@ -60,10 +60,10 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) }
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
                         }
                     };
                 default:
@@ -81,11 +81,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
-                        }
+                        TestRunner = typeof(ProcessRunner)
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
@@ -99,37 +95,25 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Default:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
-                        }
+                        TestRunner = typeof(TestDomainRunner)
                     };
                 case DomainUsage.None:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                        }
+                        TestRunner = typeof(LocalTestRunner)
                     };
                 case DomainUsage.Single:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
-                        }
+                        TestRunner = typeof(TestDomainRunner)
                     };
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) }
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
                         }
                     };
                 default:
@@ -147,11 +131,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
-                        }
+                        TestRunner = typeof(ProcessRunner)
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectStringCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectStringCtorExpectedRunnerResults.cs
@@ -92,7 +92,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Single:
                     return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                 case DomainUsage.Multiple:
-                    return new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) };
+                    return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectStringCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectStringCtorExpectedRunnerResults.cs
@@ -58,7 +58,15 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) };
+                    return new RunnerResult
+                    {
+                        TestRunner = typeof(MultipleTestProcessRunner),
+                        SubRunners = new[]
+                        {
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                        }
+                    };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -86,12 +94,19 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
             switch (domainUsage)
             {
                 case DomainUsage.Default:
-                    return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                case DomainUsage.Multiple:
+                    return new RunnerResult
+                    {
+                        TestRunner = typeof(MultipleTestDomainRunner),
+                        SubRunners = new[]
+                        {
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                        }
+                    };
                 case DomainUsage.None:
                     return new RunnerResult { TestRunner = typeof(LocalTestRunner) };
                 case DomainUsage.Single:
-                    return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
-                case DomainUsage.Multiple:
                     return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
@@ -106,7 +121,15 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult { TestRunner = typeof(ProcessRunner) };
+                    return new RunnerResult
+                    {
+                        TestRunner = typeof(MultipleTestProcessRunner),
+                        SubRunners = new[]
+                        {
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                        }
+                    };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20ThreeItemExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20ThreeItemExpectedRunnerResults.cs
@@ -60,12 +60,12 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) }
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
                         }
                     };
                 default:
@@ -83,13 +83,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
-                        }
+                        TestRunner = typeof(ProcessRunner)
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
@@ -103,7 +97,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Default:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(TestDomainRunner) },
@@ -114,34 +108,22 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                        }
+                        TestRunner = typeof(LocalTestRunner)
                     };
                 case DomainUsage.Single:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(TestDomainRunner)
+                    };
+                case DomainUsage.Multiple:
+                    return new RunnerResult
+                    {
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(TestDomainRunner) },
                             new RunnerResult { TestRunner = typeof(TestDomainRunner) },
                             new RunnerResult { TestRunner = typeof(TestDomainRunner) }
-                        }
-                    };
-                case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) }
                         }
                     };
                 default:
@@ -159,7 +141,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(ProcessRunner) },

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20TwoProjectExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20TwoProjectExpectedRunnerResults.cs
@@ -60,11 +60,11 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestProcessRunner) }
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
+                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
                         }
                     };
                 default:
@@ -82,12 +82,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
-                        }
+                        TestRunner = typeof(ProcessRunner)
                     };
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
@@ -101,7 +96,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Default:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(TestDomainRunner) },
@@ -111,31 +106,21 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                        }
+                        TestRunner = typeof(LocalTestRunner)
                     };
                 case DomainUsage.Single:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
-                        SubRunners = new[]
-                        {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
-                        }
+                        TestRunner = typeof(TestDomainRunner)
                     };
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(MultipleTestDomainRunner) }
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
+                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
                         }
                     };
                 default:
@@ -153,7 +138,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
-                        TestRunner = typeof(AggregatingTestRunner),
+                        TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
                             new RunnerResult { TestRunner = typeof(ProcessRunner) },

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
@@ -60,8 +60,6 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
 
     public class RunnerResult
     {
-        public RunnerResult() { }
-
         public Type TestRunner { get; set; }
 
         public ICollection<RunnerResult> SubRunners { get; set; } = new List<RunnerResult>();
@@ -75,12 +73,13 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
                 return sb.ToString().Trim();
 
             sb.AppendLine("SubRunners:");
+            sb.AppendLine("[");
 
             foreach (var subRunner in SubRunners)
             {
                 sb.AppendLine($"\t{subRunner}");
             }
-
+            sb.AppendLine("]");
             return sb.ToString().Trim();
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
@@ -27,8 +27,41 @@ using System.Text;
 
 namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
 {
+    public class RunnerResult<TRUNNER> : RunnerResult where TRUNNER : ITestEngineRunner
+    {
+        public RunnerResult()
+        {
+            TestRunner = typeof(TRUNNER);
+        }
+    }
+
+    public class RunnerResult<TRUNNER, TSUB1, TSUB2> : RunnerResult<TRUNNER>
+        where TRUNNER : NUnit.Engine.Runners.AggregatingTestRunner
+        where TSUB1 : ITestEngineRunner
+        where TSUB2 : ITestEngineRunner
+    {
+        public RunnerResult()
+        {
+            SubRunners = new RunnerResult[] { new RunnerResult<TSUB1>(), new RunnerResult<TSUB2>() };
+        }
+    }
+
+    public class RunnerResult<TRUNNER, TSUB1, TSUB2, TSUB3> : RunnerResult<TRUNNER>
+        where TRUNNER : NUnit.Engine.Runners.AggregatingTestRunner
+        where TSUB1 : ITestEngineRunner
+        where TSUB2 : ITestEngineRunner
+        where TSUB3 : ITestEngineRunner
+    {
+        public RunnerResult()
+        {
+            SubRunners = new RunnerResult[] { new RunnerResult<TSUB1>(), new RunnerResult<TSUB2>(), new RunnerResult<TSUB3>() };
+        }
+    }
+
     public class RunnerResult
     {
+        public RunnerResult() { }
+
         public Type TestRunner { get; set; }
 
         public ICollection<RunnerResult> SubRunners { get; set; } = new List<RunnerResult>();

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -71,7 +71,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                 yield return new TestRunnerFactoryData(
                     "Single project (string ctor)",
                     new TestPackage("a.nunit"),
-                    new RunnerResult<LocalTestRunner>()
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
                 );
 
                 yield return new TestRunnerFactoryData(
@@ -83,25 +83,91 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                 yield return new TestRunnerFactoryData(
                     "Two projects",
                     new TestPackage(new[] { "a.nunit", "b.nunit" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new List<RunnerResult>
+                        {
+                            new RunnerResult
+                            {
+                                TestRunner = typeof(AggregatingTestRunner),
+                                SubRunners = new List<RunnerResult>
+                                {
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                }
+                            },
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                        }
+                    }
                 );
 
                 yield return new TestRunnerFactoryData(
                     "One project, one assembly",
                     new TestPackage(new[] { "a.nunit", "a.dll" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new List<RunnerResult>
+                        {
+                            new RunnerResult
+                            {
+                                TestRunner = typeof(AggregatingTestRunner),
+                                SubRunners = new List<RunnerResult>
+                                {
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                }
+                            },
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                        }
+                    }
                 );
 
                 yield return new TestRunnerFactoryData(
                     "Two projects, one assembly",
                     new TestPackage(new[] { "a.nunit", "b.nunit", "a.dll" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new List<RunnerResult>
+                        {
+                            new RunnerResult
+                            {
+                                TestRunner = typeof(AggregatingTestRunner),
+                                SubRunners = new List<RunnerResult>
+                                {
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                }
+                            },
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                        }
+                    }
                 );
 
                 yield return new TestRunnerFactoryData(
-                    "Two assemblies, oneproject",
+                    "Two assemblies, one project",
                     new TestPackage(new[] { "a.dll", "b.dll", "a.nunit" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new List<RunnerResult>
+                        {
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            new RunnerResult
+                            {
+                                TestRunner = typeof(AggregatingTestRunner),
+                                SubRunners = new List<RunnerResult>
+                                {
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                }
+                            }
+                        }
+                    }
                 );
 
                 yield return new TestRunnerFactoryData(
@@ -113,7 +179,24 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                 yield return new TestRunnerFactoryData(
                     "One assembly, one project, one unknown",
                     new TestPackage(new[] { "a.junk", "a.dll", "a.nunit" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new List<RunnerResult>
+                        {
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            new RunnerResult
+                            {
+                                TestRunner = typeof(AggregatingTestRunner),
+                                SubRunners = new List<RunnerResult>
+                                {
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                }
+                            }
+                        }
+                    }
                 );
 #endif
             }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -30,138 +30,91 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
 #if NETCOREAPP1_1 || NETCOREAPP2_0
     internal static class NetStandardTestCases
     {
+        public class TestRunnerFactoryData : NUnit.Framework.TestCaseData
+        {
+            public TestRunnerFactoryData(string testName, TestPackage package, RunnerResult result)
+                : base(package, result)
+            {
+                SetName($"{{m}}({testName}");
+            }
+        }
+
         public static IEnumerable<TestCaseData> TestCases
         {
             get
             {
-                var testName = "Single assembly (string ctor)";
-                var package = TestPackageFactory.OneAssemblyStringCtor();
-                var expected = new RunnerResult { TestRunner = typeof(LocalTestRunner) };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "SingleAssembly (string ctor)",
+                    new TestPackage("a.dll"),
+                    new RunnerResult<LocalTestRunner>()
+                );
 
-                testName = "Single assembly (list ctor)";
-                package = TestPackageFactory.OneAssemblyListCtor();
-                expected = new RunnerResult { TestRunner = typeof(LocalTestRunner) };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Single assembly (list ctor)",
+                    new TestPackage(new[] { "a.dll" }),
+                    new RunnerResult<LocalTestRunner>()
+                );
 
-                testName = "Two assemblies";
-                package = TestPackageFactory.TwoAssemblies();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Two assemblies",
+                    new TestPackage(new[] { "a.dll", "b.dll" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 
 #if NETCOREAPP2_0
-                testName = "Single project (list ctor)";
-                package = TestPackageFactory.OneProjectListCtor();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(LocalTestRunner)
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "SingleProject (list ctor)",
+                    new TestPackage(new[] { "a.nunit" }),
+                    new RunnerResult<LocalTestRunner>()
+                );
 
-                testName = "Single project (string ctor)";
-                package = TestPackageFactory.OneProjectStringCtor();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(LocalTestRunner)
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Single project (string ctor)",
+                    new TestPackage("a.nunit"),
+                    new RunnerResult<LocalTestRunner>()
+                );
 
-                testName = "Single unknown extension (list ctor)";
-                package = TestPackageFactory.OneUnknownExtension();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(LocalTestRunner)
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Single unknown extension (list ctor)",
+                    new TestPackage(new[] { "a.junk" }),
+                    new RunnerResult<LocalTestRunner>()
+                );
 
-                testName = "Two projects";
-                package = TestPackageFactory.TwoProjects();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Two projects",
+                    new TestPackage(new[] { "a.nunit", "b.nunit" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 
-                testName = "One project, one assembly";
-                package = TestPackageFactory.OneProjectOneAssembly();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "One project, one assembly",
+                    new TestPackage(new[] { "a.nunit", "a.dll" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 
-                testName = "Two projects, one assembly";
-                package = TestPackageFactory.TwoProjectsOneAssembly();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Two projects, one assembly",
+                    new TestPackage(new[] { "a.nunit", "b.nunit", "a.dll" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 
-                testName = "Two assemblies, one project";
-                package = TestPackageFactory.TwoAssembliesOneProject();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Two assemblies, oneproject",
+                    new TestPackage(new[] { "a.dll", "b.dll", "a.nunit" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 
-                testName = "Two unknown extensions";
-                package = TestPackageFactory.TwoUnknownExtension();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "Two unknown extensions",
+                    new TestPackage(new[] { "a.junk", "b.junk" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 
-                testName = "One assembly, one project, one unknown";
-                package = TestPackageFactory.OneAssemblyOneProjectOneUnknown();
-                expected = new RunnerResult
-                {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
-                };
-                yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
+                yield return new TestRunnerFactoryData(
+                    "One assembly, one project, one unknown",
+                    new TestPackage(new[] { "a.junk", "a.dll", "a.nunit" }),
+                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner, LocalTestRunner>()
+                );
 #endif
             }
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -62,11 +62,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                 package = TestPackageFactory.OneProjectListCtor();
                 expected = new RunnerResult
                 {
-                    TestRunner = typeof(AggregatingTestRunner),
-                    SubRunners = new[]
-                    {
-                        new RunnerResult { TestRunner = typeof(LocalTestRunner) }
-                    }
+                    TestRunner = typeof(LocalTestRunner)
                 };
                 yield return new TestCaseData(package, expected).SetName($"{{m}}({testName})");
 

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -242,7 +242,8 @@ namespace NUnit.Engine.Runners
 
 #region Helper Methods
 
-        private ITestEngineRunner GetEngineRunner()
+        //Exposed for testing
+        internal ITestEngineRunner GetEngineRunner()
         {
             if (_engineRunner == null)
             {

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -66,32 +66,17 @@ namespace NUnit.Engine.Services
         /// <returns>A TestRunner</returns>
         public override ITestEngineRunner MakeTestRunner(TestPackage package)
         {
-            int assemblyCount = 0;
-            int projectCount = 0;
-
-            foreach (var subPackage in package.SubPackages)
-            {
-                var testFile = subPackage.FullName;
-
-                if (PathUtils.IsAssemblyFileType(testFile))
-                    assemblyCount++;
 #if !NETSTANDARD1_6
-                else if (_projectService.CanLoadFrom(testFile))
-                    projectCount++;
-#endif
-            }
-
-            // If we have multiple projects or a project plus assemblies
-            // then defer to the AggregatingTestRunner, which will make
-            // the decision on a file by file basis so that each project
-            // runs with its own settings. Note that bad extensions are
-            // ignored rather than assumed to be projects. This doesn't
-            // really matter since they will result in an error anyway.
-            if (projectCount > 1 || projectCount > 0 && assemblyCount > 0)
+            // If we have any projects, then defer to the AggregatingTestRunner, 
+            // which will make the decision on a file by file basis so that each
+            // project runs with its own settings. Bad extensions are ignored
+            // since they will result in an error anyway.
+            if (ProjectCount(package) > 0)
                 return new AggregatingTestRunner(ServiceContext, package);
+#endif
 
 #if NETSTANDARD1_6 || NETSTANDARD2_0
-            if (projectCount > 0 || package.SubPackages.Count > 1)
+            if (package.SubPackages.Count > 1)
                 return new AggregatingTestRunner(ServiceContext, package);
 
             return base.MakeTestRunner(package);
@@ -104,9 +89,7 @@ namespace NUnit.Engine.Services
             {
                 default:
                 case ProcessModel.Default:
-                    if (projectCount > 0)
-                        return new AggregatingTestRunner(ServiceContext, package);
-                    else if (package.SubPackages.Count > 1)
+                    if (package.SubPackages.Count > 1)
                         return new MultipleTestProcessRunner(this.ServiceContext, package);
                     else
                         return new ProcessRunner(this.ServiceContext, package);
@@ -118,14 +101,12 @@ namespace NUnit.Engine.Services
                     return new ProcessRunner(this.ServiceContext, package);
 
                 case ProcessModel.InProcess:
-                    if (projectCount > 0)
-                        return new AggregatingTestRunner(ServiceContext, package);
-                    else
-                        return base.MakeTestRunner(package);
+                    return base.MakeTestRunner(package);
             }
         }
 
-        // TODO: Review this method once we have a gui - not used by console runner
+        // TODO: Review this method once used by a gui - the implementation is
+        // overly simplistic. It is not currently used by any known runner.
         public override bool CanReuse(ITestEngineRunner runner, TestPackage package)
         {
             ProcessModel processModel = GetTargetProcessModel(package);
@@ -141,18 +122,50 @@ namespace NUnit.Engine.Services
                     return base.CanReuse(runner, package);
             }
         }
+#endif
 
-#region Helper Methods
+        #region Helper Methods
 
+#if !NETSTANDARD1_6
+        /// <summary>
+        /// Examine the immediate subpackages of a test package, if any
+        /// and count how many subpackages are found. Currently this is
+        /// only called (and only makes sense to call) from a top-level
+        /// package representing the command-line because that's the
+        /// only place packages may appear.
+        /// </summary>
+        /// <param name="package">A TestPackage</param>
+        /// <returns>Count of project subpackaegs</returns>
+        private int ProjectCount(TestPackage package)
+        {
+            int projectCount = 0;
+
+            foreach (var subPackage in package.SubPackages)
+            {
+                var testFile = subPackage.FullName;
+
+                if (_projectService.CanLoadFrom(testFile))
+                    projectCount++;
+            }
+
+            return projectCount;
+        }
+
+#if !NETSTANDARD2_0
+        /// <summary>
+        /// Get the specified target process model for the package.
+        /// </summary>
+        /// <param name="package">A TestPackage</param>
+        /// <returns>The string representation of the process model or "Default" if none was specified.</returns>
         private ProcessModel GetTargetProcessModel(TestPackage package)
         {
             return (ProcessModel)System.Enum.Parse(
                 typeof(ProcessModel),
                 package.GetSetting(EnginePackageSettings.ProcessModel, "Default"));
         }
+#endif
+#endif
 
 #endregion
-
-#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -66,15 +66,6 @@ namespace NUnit.Engine.Services
         /// <returns>A TestRunner</returns>
         public override ITestEngineRunner MakeTestRunner(TestPackage package)
         {
-#if !NETSTANDARD1_6
-            // If we have any projects, then defer to the AggregatingTestRunner, 
-            // which will make the decision on a file by file basis so that each
-            // project runs with its own settings. Bad extensions are ignored
-            // since they will result in an error anyway.
-            if (ProjectCount(package) > 0)
-                return new AggregatingTestRunner(ServiceContext, package);
-#endif
-
 #if NETSTANDARD1_6 || NETSTANDARD2_0
             if (package.SubPackages.Count > 1)
                 return new AggregatingTestRunner(ServiceContext, package);
@@ -124,7 +115,7 @@ namespace NUnit.Engine.Services
         }
 #endif
 
-        #region Helper Methods
+#region Helper Methods
 
 #if !NETSTANDARD1_6
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -117,32 +117,7 @@ namespace NUnit.Engine.Services
 
 #region Helper Methods
 
-#if !NETSTANDARD1_6
-        /// <summary>
-        /// Examine the immediate subpackages of a test package, if any
-        /// and count how many subpackages are found. Currently this is
-        /// only called (and only makes sense to call) from a top-level
-        /// package representing the command-line because that's the
-        /// only place packages may appear.
-        /// </summary>
-        /// <param name="package">A TestPackage</param>
-        /// <returns>Count of project subpackaegs</returns>
-        private int ProjectCount(TestPackage package)
-        {
-            int projectCount = 0;
-
-            foreach (var subPackage in package.SubPackages)
-            {
-                var testFile = subPackage.FullName;
-
-                if (_projectService.CanLoadFrom(testFile))
-                    projectCount++;
-            }
-
-            return projectCount;
-        }
-
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
         /// <summary>
         /// Get the specified target process model for the package.
         /// </summary>
@@ -154,7 +129,6 @@ namespace NUnit.Engine.Services
                 typeof(ProcessModel),
                 package.GetSetting(EnginePackageSettings.ProcessModel, "Default"));
         }
-#endif
 #endif
 
 #endregion

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -55,13 +55,11 @@ namespace NUnit.Engine.Services
             {
                 default:
                 case DomainUsage.Default:
+                case DomainUsage.Multiple:
                     if (package.SubPackages.Count > 1)
                         return new MultipleTestDomainRunner(this.ServiceContext, package);
                     else
                         return new TestDomainRunner(this.ServiceContext, package);
-
-                case DomainUsage.Multiple:
-                    return new MultipleTestDomainRunner(ServiceContext, package);
 
                 case DomainUsage.None:
                     return new LocalTestRunner(ServiceContext, package);


### PR DESCRIPTION
Fixes #22 and I believe that the first commit fixes #617. The engine runner is no longer created till needed.

@ChrisMaddock could you take a look and see if you agree with that last point? I would have prefered to explicitly initialize the engine runner in one spot, but without significant restructuring there is no such spot. I used a method rather than a property to do the initialization, because it seemed more expressive of what's happening to me.
