### PR TITLE
Add comment explaining use of TestPackage IDs

### DIFF
--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -31,7 +31,17 @@ namespace NUnit.Engine
     /// TestPackage holds information about a set of test files to
     /// be loaded by a TestRunner. Each TestPackage represents
     /// tests for one or more test files. TestPackages may be named
-    /// or anonymous, depending on how they are constructed.
+    /// or anonymous, depending on the constructor used.
+    /// 
+    /// Upon construction, a package is given an ID (string), which
+    /// remains unchanged for the lifetime of the TestPackage instance.
+    /// The package ID is passed to the test framework for use in generating
+    /// test IDs.
+    /// 
+    /// A runner that reloads test assemblies and wants the ids to remain stable
+    /// should avoid creating a new package but should instead use the original
+    /// package, changing settings as needed. This gives the best chance for the
+    /// tests in the reloaded assembly to match those originally loaded.
     /// </summary>
 #if !NETSTANDARD1_6
     [Serializable]


### PR DESCRIPTION
Closes #607

I don't think #607 needs any code changes. This just documents how packages generate an ID on creation and how they should be used by runners.