### PR TITLE
Refactor RunnerSelectionTests

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20OneAssemblyOneProjectExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20OneAssemblyOneProjectExpectedRunnerResults.cs
@@ -63,8 +63,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:
@@ -80,10 +80,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -99,28 +96,22 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 case DomainUsage.None:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(LocalTestRunner)
-                    };
+                    return RunnerResult.LocalTestRunner;
                 case DomainUsage.Single:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner)
-                    };
+                    return RunnerResult.TestDomainRunner;
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 default:
@@ -141,8 +132,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyListCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyListCtorExpectedRunnerResults.cs
@@ -44,7 +44,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         case DomainUsage.None:
                         case DomainUsage.Single:
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(ProcessRunner) };
+                            return RunnerResult.ProcessRunner;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }
@@ -52,13 +52,13 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                     switch (domainUsage)
                     {
                         case DomainUsage.Default:
-                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                            return RunnerResult.TestDomainRunner;
                         case DomainUsage.None:
-                            return new RunnerResult { TestRunner = typeof(LocalTestRunner) };
+                            return RunnerResult.LocalTestRunner;
                         case DomainUsage.Single:
-                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                            return RunnerResult.TestDomainRunner;
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                            return RunnerResult.TestDomainRunner;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }
@@ -69,7 +69,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         case DomainUsage.None:
                         case DomainUsage.Single:
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(ProcessRunner) };
+                            return RunnerResult.ProcessRunner;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }
@@ -85,7 +85,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                                 TestRunner = typeof(MultipleTestProcessRunner),
                                 SubRunners = new[]
                                 {
-                                    new RunnerResult {TestRunner = typeof(ProcessRunner)}
+                                    RunnerResult.ProcessRunner
                                 }
                             };
                         default:

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyStringCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleAssemblyStringCtorExpectedRunnerResults.cs
@@ -44,7 +44,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         case DomainUsage.None:
                         case DomainUsage.Single:
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(ProcessRunner) };
+                            return RunnerResult.ProcessRunner;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }
@@ -52,13 +52,13 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                     switch (domainUsage)
                     {
                         case DomainUsage.Default:
-                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                            return RunnerResult.TestDomainRunner;
                         case DomainUsage.None:
-                            return new RunnerResult { TestRunner = typeof(LocalTestRunner) };
+                            return RunnerResult.LocalTestRunner;
                         case DomainUsage.Single:
-                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                            return RunnerResult.TestDomainRunner;
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                            return RunnerResult.TestDomainRunner;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }
@@ -69,7 +69,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         case DomainUsage.None:
                         case DomainUsage.Single:
                         case DomainUsage.Multiple:
-                            return new RunnerResult { TestRunner = typeof(ProcessRunner) };
+                            return RunnerResult.ProcessRunner;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
                     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectListCtorExpectedRunnerResults.cs
@@ -63,7 +63,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:
@@ -79,10 +79,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -93,25 +90,13 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
             switch (domainUsage)
             {
                 case DomainUsage.Default:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner)
-                    };
+                    return RunnerResult.TestDomainRunner;
                 case DomainUsage.None:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(LocalTestRunner)
-                    };
+                    return RunnerResult.LocalTestRunner;
                 case DomainUsage.Single:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner)
-                    };
+                    return RunnerResult.TestDomainRunner;
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner),
-                    };
+                    return RunnerResult.TestDomainRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -125,10 +110,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectStringCtorExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20SingleProjectStringCtorExpectedRunnerResults.cs
@@ -63,8 +63,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:
@@ -80,10 +80,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -100,14 +97,14 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 case DomainUsage.None:
-                    return new RunnerResult { TestRunner = typeof(LocalTestRunner) };
+                    return RunnerResult.LocalTestRunner;
                 case DomainUsage.Single:
-                    return new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+                    return RunnerResult.TestDomainRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -126,8 +123,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20ThreeItemExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20ThreeItemExpectedRunnerResults.cs
@@ -63,9 +63,9 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:
@@ -81,10 +81,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -100,30 +97,24 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 case DomainUsage.None:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(LocalTestRunner)
-                    };
+                    return RunnerResult.LocalTestRunner;
                 case DomainUsage.Single:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner)
-                    };
+                    return RunnerResult.TestDomainRunner;
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 default:
@@ -144,9 +135,9 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20TwoAssemblyExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20TwoAssemblyExpectedRunnerResults.cs
@@ -62,8 +62,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult {TestRunner = typeof(ProcessRunner)},
-                            new RunnerResult {TestRunner = typeof(ProcessRunner)}
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:
@@ -79,10 +79,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -98,28 +95,22 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult {TestRunner = typeof(TestDomainRunner)},
-                            new RunnerResult {TestRunner = typeof(TestDomainRunner)}
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 case DomainUsage.None:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(LocalTestRunner)
-                    };
+                    return RunnerResult.LocalTestRunner;
                 case DomainUsage.Single:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner)
-                    };
+                    return RunnerResult.TestDomainRunner;
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult {TestRunner = typeof(TestDomainRunner)},
-                            new RunnerResult {TestRunner = typeof(TestDomainRunner)}
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 default:
@@ -140,8 +131,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult {TestRunner = typeof(ProcessRunner)},
-                            new RunnerResult {TestRunner = typeof(ProcessRunner)}
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20TwoProjectExpectedRunnerResults.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/Results/Net20TwoProjectExpectedRunnerResults.cs
@@ -63,8 +63,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:
@@ -80,10 +80,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                 case DomainUsage.None:
                 case DomainUsage.Single:
                 case DomainUsage.Multiple:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(ProcessRunner)
-                    };
+                    return RunnerResult.ProcessRunner;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(domainUsage), domainUsage, ExceptionMessage);
             }
@@ -99,28 +96,22 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 case DomainUsage.None:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(LocalTestRunner)
-                    };
+                    return RunnerResult.LocalTestRunner;
                 case DomainUsage.Single:
-                    return new RunnerResult
-                    {
-                        TestRunner = typeof(TestDomainRunner)
-                    };
+                    return RunnerResult.TestDomainRunner;
                 case DomainUsage.Multiple:
                     return new RunnerResult
                     {
                         TestRunner = typeof(MultipleTestDomainRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) },
-                            new RunnerResult { TestRunner = typeof(TestDomainRunner) }
+                            RunnerResult.TestDomainRunner,
+                            RunnerResult.TestDomainRunner
                         }
                     };
                 default:
@@ -141,8 +132,8 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.Results
                         TestRunner = typeof(MultipleTestProcessRunner),
                         SubRunners = new[]
                         {
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) },
-                            new RunnerResult { TestRunner = typeof(ProcessRunner) }
+                            RunnerResult.ProcessRunner,
+                            RunnerResult.ProcessRunner
                         }
                     };
                 default:

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerResult.cs
@@ -24,42 +24,18 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using NUnit.Engine.Runners;
 
 namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
 {
-    public class RunnerResult<TRUNNER> : RunnerResult where TRUNNER : ITestEngineRunner
-    {
-        public RunnerResult()
-        {
-            TestRunner = typeof(TRUNNER);
-        }
-    }
-
-    public class RunnerResult<TRUNNER, TSUB1, TSUB2> : RunnerResult<TRUNNER>
-        where TRUNNER : NUnit.Engine.Runners.AggregatingTestRunner
-        where TSUB1 : ITestEngineRunner
-        where TSUB2 : ITestEngineRunner
-    {
-        public RunnerResult()
-        {
-            SubRunners = new RunnerResult[] { new RunnerResult<TSUB1>(), new RunnerResult<TSUB2>() };
-        }
-    }
-
-    public class RunnerResult<TRUNNER, TSUB1, TSUB2, TSUB3> : RunnerResult<TRUNNER>
-        where TRUNNER : NUnit.Engine.Runners.AggregatingTestRunner
-        where TSUB1 : ITestEngineRunner
-        where TSUB2 : ITestEngineRunner
-        where TSUB3 : ITestEngineRunner
-    {
-        public RunnerResult()
-        {
-            SubRunners = new RunnerResult[] { new RunnerResult<TSUB1>(), new RunnerResult<TSUB2>(), new RunnerResult<TSUB3>() };
-        }
-    }
-
     public class RunnerResult
     {
+#if !NETCOREAPP
+        public static RunnerResult TestDomainRunner => new RunnerResult { TestRunner = typeof(TestDomainRunner) };
+        public static RunnerResult ProcessRunner => new RunnerResult { TestRunner = typeof(ProcessRunner) };
+#endif
+        public static RunnerResult LocalTestRunner => new RunnerResult { TestRunner = typeof(LocalTestRunner) };
+
         public Type TestRunner { get; set; }
 
         public ICollection<RunnerResult> SubRunners { get; set; } = new List<RunnerResult>();

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -30,7 +30,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
 #if NETCOREAPP1_1 || NETCOREAPP2_0
     internal static class NetStandardTestCases
     {
-        public class TestRunnerFactoryData : NUnit.Framework.TestCaseData
+        public class TestRunnerFactoryData : TestCaseData
         {
             public TestRunnerFactoryData(string testName, TestPackage package, RunnerResult result)
                 : base(package, result)
@@ -46,38 +46,53 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                 yield return new TestRunnerFactoryData(
                     "SingleAssembly (string ctor)",
                     new TestPackage("a.dll"),
-                    new RunnerResult<LocalTestRunner>()
+                    RunnerResult.LocalTestRunner
                 );
 
                 yield return new TestRunnerFactoryData(
                     "Single assembly (list ctor)",
                     new TestPackage(new[] { "a.dll" }),
-                    new RunnerResult<LocalTestRunner>()
+                    RunnerResult.LocalTestRunner
                 );
 
                 yield return new TestRunnerFactoryData(
                     "Two assemblies",
                     new TestPackage(new[] { "a.dll", "b.dll" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
-                );
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new[]
+                        {
+                            RunnerResult.LocalTestRunner,
+                            RunnerResult.LocalTestRunner
+                        }
+                    });
 
 #if NETCOREAPP2_0
                 yield return new TestRunnerFactoryData(
                     "SingleProject (list ctor)",
                     new TestPackage(new[] { "a.nunit" }),
-                    new RunnerResult<LocalTestRunner>()
+                    RunnerResult.LocalTestRunner
                 );
 
                 yield return new TestRunnerFactoryData(
                     "Single project (string ctor)",
                     new TestPackage("a.nunit"),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new[]
+                        {
+                            RunnerResult.LocalTestRunner,
+                            RunnerResult.LocalTestRunner
+                        }
+                    }
                 );
 
                 yield return new TestRunnerFactoryData(
                     "Single unknown extension (list ctor)",
                     new TestPackage(new[] { "a.junk" }),
-                    new RunnerResult<LocalTestRunner>()
+                    RunnerResult.LocalTestRunner
                 );
 
                 yield return new TestRunnerFactoryData(
@@ -93,11 +108,11 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                                 TestRunner = typeof(AggregatingTestRunner),
                                 SubRunners = new List<RunnerResult>
                                 {
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                    RunnerResult.LocalTestRunner,
+                                    RunnerResult.LocalTestRunner
                                 }
                             },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                            RunnerResult.LocalTestRunner
                         }
                     }
                 );
@@ -115,11 +130,11 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                                 TestRunner = typeof(AggregatingTestRunner),
                                 SubRunners = new List<RunnerResult>
                                 {
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                    RunnerResult.LocalTestRunner,
+                                    RunnerResult.LocalTestRunner
                                 }
                             },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                            RunnerResult.LocalTestRunner
                         }
                     }
                 );
@@ -137,12 +152,12 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                                 TestRunner = typeof(AggregatingTestRunner),
                                 SubRunners = new List<RunnerResult>
                                 {
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                    RunnerResult.LocalTestRunner,
+                                    RunnerResult.LocalTestRunner
                                 }
                             },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                            RunnerResult.LocalTestRunner,
+                            RunnerResult.LocalTestRunner
                         }
                     }
                 );
@@ -155,15 +170,15 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                         TestRunner = typeof(AggregatingTestRunner),
                         SubRunners = new List<RunnerResult>
                         {
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            RunnerResult.LocalTestRunner,
+                            RunnerResult.LocalTestRunner,
                             new RunnerResult
                             {
                                 TestRunner = typeof(AggregatingTestRunner),
                                 SubRunners = new List<RunnerResult>
                                 {
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                    RunnerResult.LocalTestRunner,
+                                    RunnerResult.LocalTestRunner
                                 }
                             }
                         }
@@ -173,7 +188,15 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                 yield return new TestRunnerFactoryData(
                     "Two unknown extensions",
                     new TestPackage(new[] { "a.junk", "b.junk" }),
-                    new RunnerResult<AggregatingTestRunner, LocalTestRunner, LocalTestRunner>()
+                    new RunnerResult
+                    {
+                        TestRunner = typeof(AggregatingTestRunner),
+                        SubRunners = new[]
+                        {
+                            RunnerResult.LocalTestRunner,
+                            RunnerResult.LocalTestRunner
+                        }
+                    }
                 );
 
                 yield return new TestRunnerFactoryData(
@@ -184,15 +207,15 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                         TestRunner = typeof(AggregatingTestRunner),
                         SubRunners = new List<RunnerResult>
                         {
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                            new RunnerResult { TestRunner = typeof(LocalTestRunner) },
+                            RunnerResult.LocalTestRunner,
+                            RunnerResult.LocalTestRunner,
                             new RunnerResult
                             {
                                 TestRunner = typeof(AggregatingTestRunner),
                                 SubRunners = new List<RunnerResult>
                                 {
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) },
-                                    new RunnerResult { TestRunner = typeof(LocalTestRunner) }
+                                    RunnerResult.LocalTestRunner,
+                                    RunnerResult.LocalTestRunner
                                 }
                             }
                         }


### PR DESCRIPTION
As discussed in #622 

- Refactor tests to remove some boilerplate code and make more maintainable
- Pull out generic classes used for .NET Standard results, to maintain consistent 'tree' information for all tests.

@CharliePoole - what do you think to this, as a way of cutting down on the amount of code to type?