### PR TITLE
#endregions

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/CommandLineTests.cs
@@ -35,8 +35,6 @@ namespace NUnit.ConsoleRunner.Tests
     [TestFixture]
     public class CommandLineTests
     {
-        #region Argument Preprocessor Tests
-
         [TestCase("--arg", "--arg")]
         [TestCase("--ArG", "--ArG")]
         [TestCase("--arg1 --arg2", "--arg1", "--arg2")]
@@ -150,10 +148,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(arglist, Is.EqualTo(lines));
             Assert.That(options.ErrorMessages, Is.EqualTo(expectedErrors));
         }
-
-        #endregion
-
-        #region General Tests
 
         [Test]
         public void NoInputFiles()
@@ -406,10 +400,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(options.ErrorMessages[1], Is.EqualTo("Invalid argument: -assembly:Tests.dll"));
         }
 
-        #endregion
-
-        #region Timeout Option
-
         [Test]
         public void TimeoutIsMinusOneIfNoOptionIsProvided()
         {
@@ -439,10 +429,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(options.Validate(), Is.False);
             Assert.That(options.DefaultTimeout, Is.EqualTo(-1));
         }
-
-        #endregion
-
-        #region EngineResult Option
 
         [Test]
         public void ResultOptionWithFilePath()
@@ -591,10 +577,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(options.ErrorMessages, Has.Exactly(1).Contains($"{missingXslt} could not be found").IgnoreCase);
         }
 
-        #endregion
-
-        #region Explore Option
-
         [Test]
         public void ExploreOptionWithoutPath()
         {
@@ -698,10 +680,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(expectedTeamCity, Is.EqualTo(actualTeamCity));
         }
 
-        #endregion
-
-        #region Testlist Option
-
         [Test]
         public void ShouldNotFailOnEmptyLine()
         {
@@ -712,10 +690,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.That(options.ErrorMessages, Is.Empty);
             Assert.That(options.TestList, Is.EqualTo(new[] {"AmazingTest"}));
         }
-
-        #endregion
-
-        #region Test Parameters
 
         [Test]
         public void SingleDeprecatedTestParameter()
@@ -893,10 +867,6 @@ namespace NUnit.ConsoleRunner.Tests
                 Console.WriteLine("   Name: {0} Value: {1}", name, TestContext.Parameters[name]);
         }
 
-        #endregion
-
-        #region Helper Methods
-
         private static IFileSystem GetFileSystemContainingFile(string fileName)
         {
             var fileSystem = new VirtualFileSystem();
@@ -917,8 +887,6 @@ namespace NUnit.ConsoleRunner.Tests
             Assert.IsNotNull(property, "The property '{0}' is not defined", propertyName);
             return property;
         }
-
-        #endregion
 
         internal sealed class DefaultOptionsProviderStub : IDefaultOptionsProvider
         {

--- a/src/NUnitConsole/nunit3-console/ColorConsole.cs
+++ b/src/NUnitConsole/nunit3-console/ColorConsole.cs
@@ -160,8 +160,6 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        #region Implementation of IDisposable
-
         /// <summary>
         /// If color is enabled, restores the console colors to their defaults
         /// </summary>
@@ -169,7 +167,5 @@ namespace NUnit.ConsoleRunner
         {
             Console.ForegroundColor = _originalColor;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/ColorConsoleWriter.cs
+++ b/src/NUnitConsole/nunit3-console/ColorConsoleWriter.cs
@@ -47,7 +47,6 @@ namespace NUnit.ConsoleRunner
             _colorEnabled = colorEnabled;
         }
 
-        #region Extended Methods
         /// <summary>
         /// Writes the value with the specified style.
         /// </summary>
@@ -125,7 +124,5 @@ namespace NUnit.ConsoleRunner
             WriteLabel(label, option, valueStyle);
             WriteLine();
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
+++ b/src/NUnitConsole/nunit3-console/CommandLineOptions.cs
@@ -49,8 +49,6 @@ namespace NUnit.Common
         /// </summary>
         protected readonly IFileSystem _fileSystem;
 
-        #region Constructor
-
         internal CommandLineOptions(IDefaultOptionsProvider defaultOptionsProvider, IFileSystem fileSystem, params string[] args)
         {
             // Apply default options
@@ -71,10 +69,6 @@ namespace NUnit.Common
             if (args != null)
                 Parse(args);
         }
-
-        #endregion
-
-        #region Properties
 
         // Action to Perform
 
@@ -158,10 +152,6 @@ namespace NUnit.Common
 
         public IList<string> ErrorMessages { get; } = new List<string>();
 
-        #endregion
-
-        #region Public Methods
-
         public bool Validate()
         {
             if (!validated)
@@ -173,10 +163,6 @@ namespace NUnit.Common
 
             return ErrorMessages.Count == 0;
         }
-
-        #endregion
-
-        #region Helper Methods
 
         protected virtual void CheckOptionCombinations()
         {
@@ -420,7 +406,5 @@ namespace NUnit.Common
 
             outputSpecifications.Add(spec);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -35,8 +35,6 @@ namespace NUnit.Common
     /// </summary>
     public class ConsoleOptions : CommandLineOptions
     {
-        #region Constructors
-
         internal ConsoleOptions(
             IDefaultOptionsProvider provider,
             IFileSystem fileSystem,
@@ -46,10 +44,6 @@ namespace NUnit.Common
         }
 
         public ConsoleOptions(params string[] args) : base(args) { }
-
-        #endregion
-
-        #region Properties
 
         public string ActiveConfig { get; private set; }
         public bool ActiveConfigSpecified { get { return ActiveConfig != null; } }
@@ -93,10 +87,6 @@ namespace NUnit.Common
 
         public string PrincipalPolicy { get; private set; }
 
-        #endregion
-
-        #region Overrides
-
         protected override void CheckOptionCombinations()
         {
             base.CheckOptionCombinations();
@@ -106,10 +96,6 @@ namespace NUnit.Common
             if (IntPtr.Size == 8 && RunAsX86 && ProcessModel == "InProcess")
                 ErrorMessages.Add("The --x86 and --inprocess options are incompatible.");
         }
-
-        #endregion
-
-        #region Configure Additional Options for Console
 
         protected override void ConfigureOptions()
         {
@@ -176,10 +162,6 @@ namespace NUnit.Common
                 v => DebugAgent = v != null);
 #endif
         }
-
-        #endregion
-
-        #region Pre-Parse Arguments Files
 
         private int _nesting = 0;
 
@@ -258,7 +240,5 @@ namespace NUnit.Common
 
             return GetArgs(sb.ToString());
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -40,8 +40,6 @@ namespace NUnit.ConsoleRunner
     /// </summary>
     public class ConsoleRunner
     {
-        #region Console Runner Return Codes
-
         public static readonly int OK = 0;
         public static readonly int INVALID_ARG = -1;
         public static readonly int INVALID_ASSEMBLY = -2;
@@ -49,10 +47,6 @@ namespace NUnit.ConsoleRunner
         public static readonly int INVALID_TEST_FIXTURE = -4;
         //public static readonly int UNLOAD_ERROR = -5;         //No longer in use
         public static readonly int UNEXPECTED_ERROR = -100;
-
-        #endregion
-
-        #region Instance Fields
 
         private ITestEngine _engine;
         private ConsoleOptions _options;
@@ -63,10 +57,6 @@ namespace NUnit.ConsoleRunner
         private ExtendedTextWriter _outWriter;
 
         private string _workDirectory;
-
-        #endregion
-
-        #region Constructor
 
         public ConsoleRunner(ITestEngine engine, ConsoleOptions options, ExtendedTextWriter writer)
         {
@@ -88,10 +78,6 @@ namespace NUnit.ConsoleRunner
             // Enable TeamCityEventListener immediately, before the console is redirected
             _extensionService.EnableExtension("NUnit.Engine.Listeners.TeamCityEventListener", _options.TeamCity);
         }
-
-        #endregion
-
-        #region Execute Method
 
         /// <summary>
         /// Executes tests according to the provided commandline options.
@@ -138,10 +124,6 @@ namespace NUnit.ConsoleRunner
                 _outWriter.WriteLine(ColorStyle.Default, "    " + file);
             _outWriter.WriteLine();
         }
-
-        #endregion
-
-        #region Helper Methods
 
         private int ExploreTests(TestPackage package, TestFilter filter)
         {
@@ -527,9 +509,6 @@ namespace NUnit.ConsoleRunner
 
             return true;
         }
-
-        #endregion
-
     }
 }
 

--- a/src/NUnitConsole/nunit3-console/ConsoleTestResult.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleTestResult.cs
@@ -60,8 +60,6 @@ namespace NUnit.ConsoleRunner
             FullName = resultNode.GetAttribute("fullname");
         }
 
-        #region Properties
-
         public string Result { get; private set; }
         public string Label { get; private set; }
         public string Site { get; private set; }
@@ -100,10 +98,6 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        #endregion
-
-        #region Public Methods
-
         public void WriteResult(ExtendedTextWriter writer)
         {
             int numAsserts = Assertions.Count;
@@ -124,10 +118,6 @@ namespace NUnit.ConsoleRunner
             else
                 WriteResult(writer, ReportID, Status, FullName, Message, StackTrace);
         }
-
-        #endregion
-
-        #region Helper Methods
 
         private void WriteResult(ExtendedTextWriter writer, string reportID, string status, string fullName, string message, string stackTrace)
         {
@@ -164,10 +154,6 @@ namespace NUnit.ConsoleRunner
                 : null;
         }
 
-        #endregion
-
-        #region Nested AssertionResult Class
-
         public struct AssertionResult
         {
             public AssertionResult(XmlNode assertion)
@@ -179,7 +165,5 @@ namespace NUnit.ConsoleRunner
             public string Message { get; private set; }
             public string StackTrace { get; private set; }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -31,8 +31,6 @@ namespace NUnit
     /// </summary>
     public static class EnginePackageSettings
     {
-        #region Engine Settings - Used by the Engine itself
-
         /// <summary>
         /// The name of the config to use in loading a project.
         /// If not specified, the first config found is used.
@@ -151,7 +149,5 @@ namespace NUnit
         /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
         /// </summary>
         public const string PrincipalPolicy = "PrincipalPolicy";
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/ExtendedTextWrapper.cs
+++ b/src/NUnitConsole/nunit3-console/ExtendedTextWrapper.cs
@@ -41,8 +41,6 @@ namespace NUnit.ConsoleRunner
             _writer = writer;
         }
 
-        #region TextWriter Overrides
-
         /// <summary>
         /// Write a single char value
         /// </summary>
@@ -82,10 +80,6 @@ namespace NUnit.ConsoleRunner
         {
             _writer.Dispose();
         }
-
-        #endregion
-
-        #region Extended Methods
 
         /// <summary>
         /// Writes the value with the specified style.
@@ -150,7 +144,5 @@ namespace NUnit.ConsoleRunner
         {
             WriteLabelLine(label, option);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/ExtendedTextWriter.cs
+++ b/src/NUnitConsole/nunit3-console/ExtendedTextWriter.cs
@@ -31,8 +31,6 @@ namespace NUnit.ConsoleRunner
     /// </summary>
     public abstract class ExtendedTextWriter : TextWriter
     {
-        #region Extended Methods
-
         /// <summary>
         /// Writes the value with the specified style.
         /// </summary>
@@ -76,7 +74,5 @@ namespace NUnit.ConsoleRunner
         /// <param name="option">The option.</param>
         /// <param name="valueStyle">The color to display the value with</param>
         public abstract void WriteLabelLine(string label, object option, ColorStyle valueStyle);
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/FrameworkPackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/FrameworkPackageSettings.cs
@@ -30,8 +30,6 @@ namespace NUnit
     /// </summary>
     public static class FrameworkPackageSettings
     {
-        #region Settings u
-
         /// <summary>
         /// Flag (bool) indicating whether tests are being debugged.
         /// </summary>
@@ -114,7 +112,5 @@ namespace NUnit
         /// Parameters to be passed on to the tests, already parsed into an IDictionary&lt;string, string>. Replaces <see cref="TestParameters"/>.
         /// </summary>
         public const string TestParametersDictionary = "TestParametersDictionary";
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/Options.cs
+++ b/src/NUnitConsole/nunit3-console/Options.cs
@@ -158,13 +158,10 @@ namespace NUnit.Options
             this.c = c;
         }
 
-        #region ICollection
         void ICollection.CopyTo (Array array, int index)  {(values as ICollection).CopyTo (array, index);}
         bool ICollection.IsSynchronized                   {get {return (values as ICollection).IsSynchronized;}}
         object ICollection.SyncRoot                       {get {return (values as ICollection).SyncRoot;}}
-        #endregion
 
-        #region ICollection<T>
         public void Add (string item)                       {values.Add (item);}
         public void Clear ()                                {values.Clear ();}
         public bool Contains (string item)                  {return values.Contains (item);}
@@ -172,17 +169,11 @@ namespace NUnit.Options
         public bool Remove (string item)                    {return values.Remove (item);}
         public int Count                                    {get {return values.Count;}}
         public bool IsReadOnly                              {get {return false;}}
-        #endregion
 
-        #region IEnumerable
         IEnumerator IEnumerable.GetEnumerator () {return values.GetEnumerator ();}
-        #endregion
 
-        #region IEnumerable<T>
         public IEnumerator<string> GetEnumerator () {return values.GetEnumerator ();}
-        #endregion
 
-        #region IList
         int IList.Add (object value)                {return (values as IList).Add (value);}
         bool IList.Contains (object value)          {return (values as IList).Contains (value);}
         int IList.IndexOf (object value)            {return (values as IList).IndexOf (value);}
@@ -191,9 +182,7 @@ namespace NUnit.Options
         void IList.RemoveAt (int index)             {(values as IList).RemoveAt (index);}
         bool IList.IsFixedSize                      {get {return false;}}
         object IList.this [int index]               {get {return this [index];} set {(values as IList)[index] = value;}}
-        #endregion
 
-        #region IList<T>
         public int IndexOf (string item)            {return values.IndexOf (item);}
         public void Insert (int index, string item) {values.Insert (index, item);}
         public void RemoveAt (int index)            {values.RemoveAt (index);}
@@ -220,7 +209,6 @@ namespace NUnit.Options
                 values [index] = value;
             }
         }
-        #endregion
 
         public List<string> ToList ()
         {

--- a/src/NUnitConsole/nunit3-console/OutputSpecification.cs
+++ b/src/NUnitConsole/nunit3-console/OutputSpecification.cs
@@ -33,8 +33,6 @@ namespace NUnit.Common
     /// </summary>
     public class OutputSpecification
     {
-        #region Constructor
-
         /// <summary>
         /// Construct an OutputSpecification from an option value.
         /// </summary>
@@ -88,10 +86,6 @@ namespace NUnit.Common
                 Format = "nunit3";
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         /// Gets the path to which output will be written
         /// </summary>
@@ -106,8 +100,6 @@ namespace NUnit.Common
         /// Gets the file name of a transform to be applied
         /// </summary>
         public string Transform { get; private set; }
-
-        #endregion
 
         public override string ToString()
         {

--- a/src/NUnitConsole/nunit3-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit3-console/ResultReporter.cs
@@ -74,8 +74,6 @@ namespace NUnit.ConsoleRunner
             WriteSummaryReport();
         }
 
-        #region Summary Report
-
         internal void WriteRunSettingsReport()
         {
             var firstSuite = ResultNode.SelectSingleNode("test-suite");
@@ -157,10 +155,6 @@ namespace NUnit.ConsoleRunner
             Writer.WriteLine();
         }
 
-        #endregion
-
-        #region Errors, Failures and Warnings Report
-
         public void WriteErrorsFailuresAndWarningsReport()
         {
             ReportIndex = 0;
@@ -236,10 +230,6 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        #endregion
-
-        #region Not Run Report
-
         public void WriteNotRunReport()
         {
             ReportIndex = 0;
@@ -269,10 +259,6 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        #endregion
-
-        #region Helper Methods
-
         private void WriteSummaryCount(string label, int count)
         {
             Writer.WriteLabel(label, count.ToString(CultureInfo.CurrentUICulture));
@@ -282,7 +268,5 @@ namespace NUnit.ConsoleRunner
         {
             Writer.WriteLabel(label, count.ToString(CultureInfo.CurrentUICulture), count > 0 ? color : ColorStyle.Value);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit3-console/ResultSummary.cs
@@ -34,8 +34,6 @@ namespace NUnit.ConsoleRunner
     /// </summary>
     public class ResultSummary
     {
-        #region Constructor
-
         public ResultSummary(XmlNode result)
         {
             if (result.Name != "test-run")
@@ -45,10 +43,6 @@ namespace NUnit.ConsoleRunner
 
             Summarize(result, false);
         }
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         /// Gets the number of test cases for which results
@@ -147,10 +141,6 @@ namespace NUnit.ConsoleRunner
         /// Invalid test fixture(s) were found
         /// </summary>
         public int InvalidTestFixtures { get; private set; }
-
-        #endregion
-
-        #region Helper Methods
 
         private void InitializeCounters()
         {
@@ -253,7 +243,5 @@ namespace NUnit.ConsoleRunner
             foreach (XmlNode childResult in nodes)
                 Summarize(childResult, failedInFixtureTearDown);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -52,8 +52,6 @@ namespace NUnit.ConsoleRunner
             _displayBeforeOutput = _displayBeforeTest || _displayAfterTest || labelsOption == "ON";
         }
 
-        #region ITestEventHandler Members
-
         public void OnTestEvent(string report)
         {
             var doc = new XmlDocument();
@@ -79,10 +77,6 @@ namespace NUnit.ConsoleRunner
                     break;
             }
         }
-
-        #endregion
-
-        #region Individual Handlers
 
         private void TestStarted(XmlNode testResult)
         {
@@ -218,15 +212,9 @@ namespace NUnit.ConsoleRunner
             }
         }
 
-        #endregion
-
-        #region InitializeLifetimeService
-
         public override object InitializeLifetimeService()
         {
             return null;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IProject.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IProject.cs
@@ -30,8 +30,6 @@ namespace NUnit.Engine.Extensibility
     /// </summary>
     public interface IProject
     {
-        #region Properties
-
         /// <summary>
         /// Gets the path to the file storing this project, if any.
         /// If the project has not been saved, this is null.
@@ -48,10 +46,6 @@ namespace NUnit.Engine.Extensibility
         /// Gets a list of the configs for this project
         /// </summary>
         IList<string> ConfigNames { get; }
-
-        #endregion
-        
-        #region Methods
 
         /// <summary>
         /// Gets a test package for the primary or active
@@ -71,7 +65,5 @@ namespace NUnit.Engine.Extensibility
         /// <param name="configName">The name of the config to use</param>
         /// <returns>A TestPackage for the named configuration.</returns>
         TestPackage GetTestPackage(string configName);
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/IExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IExtensionService.cs
@@ -32,8 +32,6 @@ namespace NUnit.Engine
     /// </summary>
     public interface IExtensionService
     {
-        #region Public Properties
-
         /// <summary>
         /// Gets an enumeration of all ExtensionPoints in the engine.
         /// </summary>
@@ -60,8 +58,6 @@ namespace NUnit.Engine
         /// <param name="typeName"></param>
         /// <param name="enabled"></param>
         void EnableExtension(string typeName, bool enabled);
-
-        #endregion
     }
 }
 

--- a/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
@@ -69,7 +69,6 @@ namespace NUnit.Engine
             return Activator.CreateInstance(engineType) as ITestEngine;
         }
 #else
-        #region Public Methods
 
         /// <summary>
         /// Create an instance of the test engine.
@@ -109,10 +108,6 @@ namespace NUnit.Engine
                 throw new Exception("Failed to load the test engine", ex);
             }
         }
-
-        #endregion
-
-        #region Private Methods
 
         private static Assembly FindNewestEngine(Version minVersion)
         {
@@ -189,7 +184,6 @@ namespace NUnit.Engine
             catch (Exception) { }
             return null;
         }
-        #endregion
 #endif
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -48,8 +48,6 @@ namespace NUnit.Engine
 #endif
     public class TestPackage
     {
-        #region Constructors
-
         /// <summary>
         /// Construct a named TestPackage, specifying a file path for
         /// the assembly or project to be used.
@@ -88,10 +86,6 @@ namespace NUnit.Engine
             return (_nextID++).ToString();
         }
 
-        #endregion
-
-        #region Properties
-
         /// <summary>
         /// Every test package gets a unique ID used to prefix test IDs within that package.
         /// </summary>
@@ -124,10 +118,6 @@ namespace NUnit.Engine
         /// Gets the settings dictionary for this package.
         /// </summary>
         public IDictionary<string,object> Settings { get; private set; }
-
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         /// Add a subproject to the package.
@@ -172,7 +162,5 @@ namespace NUnit.Engine
                 ? (T)Settings[name]
                 : defaultSetting;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -51,7 +51,6 @@ namespace NUnit.Engine.Drivers.Tests
             _driver = new NUnit3FrameworkDriver(AppDomain.CurrentDomain, assemblyName);
         }
 
-        #region Construction Test
         //[Test]
         //public void ConstructController()
         //{
@@ -66,9 +65,7 @@ namespace NUnit.Engine.Drivers.Tests
             var assemblyName = typeof(NUnit.Framework.TestAttribute).Assembly.GetName();
             Assert.That(new NUnit3FrameworkDriver(AppDomain.CurrentDomain, assemblyName), Throws.ArgumentException);
         }
-        #endregion
 
-        #region Load
         [Test]
         public void Load_GoodFile_ReturnsRunnableSuite()
         {
@@ -80,9 +77,7 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(result.GetAttribute("testcasecount"), Is.EqualTo(MockAssembly.Tests.ToString()));
             Assert.That(result.SelectNodes("test-suite").Count, Is.EqualTo(0), "Load result should not have child tests");
         }
-        #endregion
 
-        #region Explore
         [Test]
         public void Explore_AfterLoad_ReturnsRunnableSuite()
         {
@@ -105,9 +100,7 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
             Assert.That(ex.Message, Is.EqualTo(LOAD_MESSAGE));
         }
-        #endregion
 
-        #region CountTests
         [Test]
         public void CountTestsAction_AfterLoad_ReturnsCorrectCount()
         {
@@ -124,9 +117,7 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(ex, Is.TypeOf<InvalidOperationException>());
             Assert.That(ex.Message, Is.EqualTo(LOAD_MESSAGE));
         }
-        #endregion
 
-        #region RunTests
         [Test]
         public void RunTestsAction_AfterLoad_ReturnsRunnableSuite()
         {
@@ -162,17 +153,13 @@ namespace NUnit.Engine.Drivers.Tests
             var ex = Assert.Catch(() => _driver.Run(new NullListener(), invalidFilter));
             Assert.That(ex, Is.TypeOf<NUnitEngineException>());
         }
-        #endregion
 
-        #region Helper Methods
         private static string GetSkipReason(XmlNode result)
         {
             var propNode = result.SelectSingleNode(string.Format("properties/property[@name='{0}']", PropertyNames.SkipReason));
             return propNode == null ? null : propNode.GetAttribute("value");
         }
-        #endregion
 
-        #region Nested Callback Class
         private class CallbackEventHandler : System.Web.UI.ICallbackEventHandler
         {
             private string _result;
@@ -187,9 +174,7 @@ namespace NUnit.Engine.Drivers.Tests
                 _result = eventArgument;
             }
         }
-        #endregion
 
-        #region Nested NullListener Class
         public class NullListener : ITestEventListener
         {
             public void OnTestEvent(string testEvent)
@@ -197,7 +182,6 @@ namespace NUnit.Engine.Drivers.Tests
                 // No action
             }
         }
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -110,13 +110,7 @@ namespace NUnit.Engine.Drivers.Tests
             Assert.That(result.SelectSingleNode("reason/message").InnerText, Is.EqualTo(_expectedReason));
         }
 
-        #region Abstract Properties and Methods
-
         protected abstract IFrameworkDriver CreateDriver(string filePath);
-
-        #endregion
-
-        #region Helper Methods
 
         private IFrameworkDriver GetDriver(string filePath)
         {
@@ -131,9 +125,6 @@ namespace NUnit.Engine.Drivers.Tests
             return propNode == null ? null : propNode.GetAttribute("value");
         }
 
-        #endregion
-
-        #region Nested NullListener Class
         private class NullListener : ITestEventListener
         {
             public void OnTestEvent(string testEvent)
@@ -141,7 +132,6 @@ namespace NUnit.Engine.Drivers.Tests
                 // No action
             }
         }
-        #endregion
     }
 
     public class InvalidAssemblyFrameworkDriverTests : NotRunnableFrameworkDriverTests

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -217,8 +217,6 @@ namespace NUnit.Engine.Runners.Tests
         }
 #endif
 
-        #region Helper Methods
-
         private void CheckResult(XmlNode result, ResultData expected)
         {
             if (expected.Name != null)
@@ -306,10 +304,6 @@ namespace NUnit.Engine.Runners.Tests
             _events.Add(XmlHelper.CreateXmlNode(report));
         }
 
-        #endregion
-
-        #region Nested Helper Classes
-
         public class TestRunData : ResultData
         {
             private const string Q = "\"";
@@ -377,6 +371,5 @@ namespace NUnit.Engine.Runners.Tests
                 }
             }
         }
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -111,8 +111,6 @@ namespace NUnit.Engine.Services.Tests
             CheckDomainIsUnloaded(domain);
         }
 
-        #region Helper Methods
-
         private void CheckDomainIsUnloaded(AppDomain domain)
         {
             // HACK: Either the Assert will succeed or the
@@ -130,8 +128,6 @@ namespace NUnit.Engine.Services.Tests
 
             Assert.That(unloaded, Is.True, "Domain was not unloaded");
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
@@ -163,8 +163,6 @@ namespace NUnit.Engine.Services.Tests
             CheckListContains( 1, 2, 3, 4 );
         }
 
-        #region Helper Methods
-
         // Set RecentFiles to a list of known values up
         // to a maximum. Most recent will be "1", next 
         // "2", and so on...
@@ -203,7 +201,5 @@ namespace NUnit.Engine.Services.Tests
             for (int index = 0; index < files.Count; index++)
                 Assert.That(files[index], Is.EqualTo(item[index].ToString()), "Item");
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/RemoteTestAgent.cs
@@ -42,8 +42,6 @@ namespace NUnit.Engine.Agents
     {
         private static readonly Logger log = InternalTrace.GetLogger(typeof(RemoteTestAgent));
 
-        #region Fields
-
         private readonly string _agencyUrl;
 
         private ITestEngineRunner _runner;
@@ -54,10 +52,6 @@ namespace NUnit.Engine.Agents
         private TcpChannel _channel;
         private ITestAgency _agency;
 
-        #endregion
-
-        #region Constructor
-
         /// <summary>
         /// Construct a RemoteTestAgent
         /// </summary>
@@ -67,18 +61,10 @@ namespace NUnit.Engine.Agents
             _agencyUrl = agencyUrl;
         }
 
-        #endregion
-
-        #region Properties
-
         public int ProcessId
         {
             get { return System.Diagnostics.Process.GetCurrentProcess().Id; }
         }
-
-        #endregion
-
-        #region Public Methods
 
         public override ITestEngineRunner CreateRunner(TestPackage package)
         {
@@ -153,10 +139,6 @@ namespace NUnit.Engine.Agents
             return stopSignal.WaitOne(timeout);
         }
 
-        #endregion
-
-        #region ITestEngineRunner Members
-
         /// <summary>
         /// Explore a loaded TestPackage and return information about
         /// the tests found.
@@ -228,8 +210,6 @@ namespace NUnit.Engine.Agents
             if (_runner != null)
                 _runner.StopRun(force);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine/Agents/TestAgent.cs
@@ -34,14 +34,8 @@ namespace NUnit.Engine.Agents
     /// </summary>
     public abstract class TestAgent : MarshalByRefObject, ITestAgent, IDisposable
     {
-        #region Private Fields
-
         private readonly Guid agentId;
         private readonly IServiceLocator services;
-
-        #endregion
-
-        #region Constructors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestAgent"/> class.
@@ -54,10 +48,6 @@ namespace NUnit.Engine.Agents
             this.services = services;
         }
 
-        #endregion
-
-        #region Protected Properties
-
         /// <summary>
         /// The services available to the agent
         /// </summary>
@@ -65,10 +55,6 @@ namespace NUnit.Engine.Agents
         {
             get { return services; }
         }
-
-        #endregion
-
-        #region ITestAgent members
 
         /// <summary>
         /// Gets a Guid that uniquely identifies this agent.
@@ -94,10 +80,6 @@ namespace NUnit.Engine.Agents
         /// </summary>
         public abstract ITestEngineRunner CreateRunner(TestPackage package);
 
-        #endregion
-
-        #region IDisposable Members
-
         public void Dispose()
         {
             GC.SuppressFinalize(this);
@@ -119,9 +101,7 @@ namespace NUnit.Engine.Agents
                 _disposed = true;
             }
         }
-        #endregion
 
-        #region InitializeLifeTimeService
         /// <summary>
         /// Overridden to cause object to live indefinitely
         /// </summary>
@@ -129,7 +109,6 @@ namespace NUnit.Engine.Agents
         {
             return null;
         }
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/AsyncTestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine/AsyncTestEngineResult.cs
@@ -83,8 +83,6 @@ namespace NUnit.Engine
         /// </summary>
         public bool IsComplete { get { return _result != null; } }
 
-#region ITestRun Members
-
         XmlNode ITestRun.Result
         {
             get { return EngineResult.Xml; }
@@ -94,7 +92,5 @@ namespace NUnit.Engine
         {
             return Wait(timeout);
         }
-
-#endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/CallbackHandler.cs
+++ b/src/NUnitEngine/nunit.engine/CallbackHandler.cs
@@ -31,16 +31,10 @@ namespace NUnit.Engine
     {
         public string Result { get; private set; }
 
-        #region MarshalByRefObject Overrides
-
         public override object InitializeLifetimeService()
         {
             return null;
         }
-
-        #endregion
-
-        #region ICallbackEventHandler Members
 
         public string GetCallbackResult()
         {
@@ -51,8 +45,6 @@ namespace NUnit.Engine
         {
             Result = eventArgument;
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnit3FrameworkDriver.cs
@@ -156,8 +156,6 @@ namespace NUnit.Engine.Drivers
             return handler.Result;
         }
 
-        #region Helper Methods
-
         private void CheckLoadWasCalled()
         {
             if (_frameworkController == null)
@@ -181,8 +179,6 @@ namespace NUnit.Engine.Drivers
                 throw new NUnitEngineException("The NUnit 3 driver encountered an error while executing reflected code.", ex.InnerException);
             }
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Drivers/NUnitNetStandardDriver.cs
+++ b/src/NUnitEngine/nunit.engine/Drivers/NUnitNetStandardDriver.cs
@@ -160,8 +160,6 @@ namespace NUnit.Engine.Drivers
             return ExecuteMethod(EXPLORE_METHOD, filter) as string;
         }
 
-#region Helper Methods
-
         void CheckLoadWasCalled()
         {
             if (_frameworkController == null)
@@ -198,8 +196,6 @@ namespace NUnit.Engine.Drivers
             }
             return method.Invoke(_frameworkController, args);
         }
-
-#endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/EnginePackageSettings.cs
@@ -31,8 +31,6 @@ namespace NUnit
     /// </summary>
     public static class EnginePackageSettings
     {
-        #region Engine Settings - Used by the Engine itself
-
         /// <summary>
         /// The name of the config to use in loading a project.
         /// If not specified, the first config found is used.
@@ -157,7 +155,5 @@ namespace NUnit
         /// This path is provided to tests by the framework TestContext.
         /// </summary>
         public const string WorkDirectory = "WorkDirectory";
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionPoint.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionPoint.cs
@@ -45,8 +45,6 @@ namespace NUnit.Engine.Extensibility
             Extensions = new List<ExtensionNode>();
         }
 
-        #region IExtensionPoint Members
-
         /// <summary>
         /// Gets the unique path identifying this extension point.
         /// </summary>
@@ -70,18 +68,10 @@ namespace NUnit.Engine.Extensibility
             get { return this.Extensions.ToArray(); }
         }
 
-        #endregion
-
-        #region Other Properties
-
         /// <summary>
         /// Gets a list of ExtensionNodes for extensions installed on this extension point.
         /// </summary>
         public List<ExtensionNode> Extensions { get; private set; }
-
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         /// Install an extension at this extension point. If the
@@ -113,8 +103,6 @@ namespace NUnit.Engine.Extensibility
         {
             Extensions.Remove(extension);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Internal/AssemblyHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/AssemblyHelper.cs
@@ -33,8 +33,6 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class AssemblyHelper
     {
-        #region GetDirectoryName
-
         /// <summary>
         /// Gets the path to the directory from which an assembly was loaded.
         /// </summary>
@@ -44,10 +42,6 @@ namespace NUnit.Engine.Internal
         {
             return Path.GetDirectoryName(GetAssemblyPath(assembly));
         }
-
-        #endregion
-
-        #region GetAssemblyPath
 
         /// <summary>
         /// Gets the path from which an assembly was loaded.
@@ -65,10 +59,6 @@ namespace NUnit.Engine.Internal
 
             return assembly.Location;
         }
-
-        #endregion
-
-        #region Helper Methods
 
         private static bool IsFileUri(string uri)
         {
@@ -101,8 +91,6 @@ namespace NUnit.Engine.Internal
 
             return codeBase.Substring(start);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Internal/CecilExtensions.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/CecilExtensions.cs
@@ -33,8 +33,6 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class CecilExtensions
     {
-        #region TypeDefinition Extensions
-
         public static List<CustomAttribute> GetAttributes(this TypeDefinition type, string fullName)
         {
             var attributes = new List<CustomAttribute>();
@@ -59,10 +57,6 @@ namespace NUnit.Engine.Internal
             return null;
         }
 
-        #endregion
-
-        #region CustomAttribute Extensions
-
         public static object GetNamedArgument(this CustomAttribute attr, string name)
         {
             foreach (var property in attr.Properties)
@@ -71,7 +65,5 @@ namespace NUnit.Engine.Internal
 
             return null;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/DirectoryFinder.cs
@@ -36,8 +36,6 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class DirectoryFinder
     {
-        #region Public Methods
-
         /// <summary>
         /// Get a list of diretories matching and extended wildcard pattern.
         /// Each path component may have wildcard characters and a component
@@ -123,10 +121,6 @@ namespace NUnit.Engine.Internal
             return null;
         }
 
-        #endregion
-
-        #region Helper Methods
-
         private static List<DirectoryInfo> ExpandOneStep(IList<DirectoryInfo> dirList, string pattern)
         {
             var newList = new List<DirectoryInfo>();
@@ -157,7 +151,5 @@ namespace NUnit.Engine.Internal
 
             return newList;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/Logging/Logger.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/Logging/Logger.cs
@@ -53,7 +53,6 @@ namespace NUnit.Engine.Internal
             _name = index >= 0 ? fullName.Substring(index + 1) : fullName;
         }
 
-        #region Error
         /// <summary>
         /// Logs the message at error level.
         /// </summary>
@@ -73,9 +72,6 @@ namespace NUnit.Engine.Internal
             Log(InternalTraceLevel.Error, format, args);
         }
 
-        #endregion
-
-        #region Warning
         /// <summary>
         /// Logs the message at warm level.
         /// </summary>
@@ -94,9 +90,7 @@ namespace NUnit.Engine.Internal
         {
             Log(InternalTraceLevel.Warning, format, args);
         }
-        #endregion
 
-        #region Info
         /// <summary>
         /// Logs the message at info level.
         /// </summary>
@@ -115,9 +109,7 @@ namespace NUnit.Engine.Internal
         {
             Log(InternalTraceLevel.Info, format, args);
         }
-        #endregion
 
-        #region Debug
         /// <summary>
         /// Logs the message at debug level.
         /// </summary>
@@ -136,9 +128,6 @@ namespace NUnit.Engine.Internal
         {
             Log(InternalTraceLevel.Verbose, format, args);
         }
-        #endregion
-
-        #region Helper Methods
 
         private void Log(InternalTraceLevel level, string message)
         {
@@ -164,7 +153,5 @@ namespace NUnit.Engine.Internal
 #endif
                 _name, message);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/NUnitConfiguration.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/NUnitConfiguration.cs
@@ -34,10 +34,7 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class NUnitConfiguration
     {
-        #region Public Properties
-
 #if !NETSTANDARD1_6
-        #region EngineDirectory
 
         private static string _engineDirectory;
         public static string EngineDirectory
@@ -52,10 +49,7 @@ namespace NUnit.Engine.Internal
             }
         }
 
-        #endregion
 #endif
-
-        #region ApplicationDataDirectory
 
         private static string _applicationDirectory;
         public static string ApplicationDirectory
@@ -76,9 +70,5 @@ namespace NUnit.Engine.Internal
                 return _applicationDirectory;
             }
         }
-
-        #endregion
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/PathUtils.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/PathUtils.cs
@@ -43,8 +43,6 @@ namespace NUnit.Engine.Internal
         protected static char DirectorySeparatorChar = Path.DirectorySeparatorChar;
         protected static char AltDirectorySeparatorChar = Path.AltDirectorySeparatorChar;
 
-        #region Public methods
-
         /// <summary>
         /// Returns a boolean indicating whether the specified path
         /// is that of an assembly - that is a dll or exe file.
@@ -188,10 +186,6 @@ namespace NUnit.Engine.Internal
                 result = Path.Combine(result, path);
             return result;
         }
-        
-        #endregion
-
-        #region Helper Methods
 
         private static bool IsWindows()
         {
@@ -228,7 +222,5 @@ namespace NUnit.Engine.Internal
             else
                 return path1.Equals(path2);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ResultHelper.cs
@@ -40,8 +40,6 @@ namespace NUnit.Engine.Internal
         private const string TEST_SUITE_ELEMENT = "test-suite";
         private const string PROJECT_SUITE_TYPE = "Project";
 
-        #region TestEngineResult extension methods
-
         /// <summary>
         /// Aggregate the XmlNodes under a TestEngineResult into a single XmlNode.
         /// </summary>
@@ -93,10 +91,6 @@ namespace NUnit.Engine.Internal
             return Aggregate(result, TEST_RUN_ELEMENT, package.ID, package.Name, package.FullName);
         }
 
-        #endregion
-
-        #region Methods that operate on a list of TestEngineResults
-
         /// <summary>
         /// Merges multiple test engine results into a single result. The
         /// result element contains all the XML nodes found in the input.
@@ -114,10 +108,6 @@ namespace NUnit.Engine.Internal
 
             return mergedResult;
         }
-
-        #endregion
-
-        #region Methods that operate on a list of XmlNodes
 
         /// <summary>
         /// Aggregates a collection of XmlNodes under a single XmlNode.
@@ -237,7 +227,5 @@ namespace NUnit.Engine.Internal
 
             return combinedNode;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/ServerBase.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ServerBase.cs
@@ -119,8 +119,6 @@ namespace NUnit.Engine.Internal
             }
         }
 
-        #region IDisposable Members
-
         public void Dispose()
         {
             GC.SuppressFinalize(this);
@@ -140,14 +138,10 @@ namespace NUnit.Engine.Internal
             }
         }
 
-        #endregion
-
-        #region InitializeLifetimeService
         public override object InitializeLifetimeService()
         {
             return null;
         }
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsGroup.cs
@@ -40,8 +40,6 @@ namespace NUnit.Engine.Internal
 
         public event SettingsEventHandler Changed;
 
-        #region ISettings Members
-
         /// <summary>
         /// Load the value of one of the group's settings
         /// </summary>
@@ -142,7 +140,5 @@ namespace NUnit.Engine.Internal
             if (Changed != null)
                 Changed(this, new SettingsEventArgs(settingName));
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsStore.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsStore.cs
@@ -42,8 +42,6 @@ namespace NUnit.Engine.Internal
         private string _settingsFile;
         private bool _writeable;
 
-        #region Constructors
-
         /// <summary>
         /// Construct a SettingsStore without a backing file - used for testing.
         /// </summary>
@@ -59,10 +57,6 @@ namespace NUnit.Engine.Internal
             _settingsFile = Path.GetFullPath(settingsFile);
             _writeable = writeable;
         }
-
-        #endregion
-
-        #region Public Methods
 
         public void LoadSettings()
         {
@@ -176,7 +170,5 @@ namespace NUnit.Engine.Internal
                 throw;
             }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/InternalEnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine/InternalEnginePackageSettings.cs
@@ -31,8 +31,6 @@ namespace NUnit.Engine
     /// </summary>
     internal static class InternalEnginePackageSettings
     {
-        #region Internal Settings - Used only within the engine
-
         /// <summary>
         /// If the package represents an assembly, then this is the CLR version
         /// stored in the assembly image. If it represents a project or other
@@ -56,7 +54,5 @@ namespace NUnit.Engine
         /// The FrameworkName specified on a TargetFrameworkAttribute for the assembly
         /// </summary>
         public const string ImageTargetFrameworkName = "ImageTargetFrameworkName";
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/RunTestsCallbackHandler.cs
+++ b/src/NUnitEngine/nunit.engine/RunTestsCallbackHandler.cs
@@ -39,16 +39,10 @@ namespace NUnit.Engine
             _listener = listener ?? new NullListener();
         }
 
-        #region MarshalByRefObject Overrides
-
         public override object InitializeLifetimeService()
         {
             return null;
         }
-
-        #endregion
-
-        #region ICallbackEventHandler Members
 
         public string GetCallbackResult()
         {
@@ -62,10 +56,6 @@ namespace NUnit.Engine
             else
                 ReportProgress(eventArgument);
         }
-
-        #endregion
-
-        #region Helper Methods
 
         private void ReportProgress(string state)
         {
@@ -106,16 +96,12 @@ namespace NUnit.Engine
             return eventArgument.IndexOf("<test-suite", 12, StringComparison.Ordinal) > 0;
         }
 
-        #endregion
-
-        #region Nested NullListener class
         class NullListener : ITestEventListener
         {
             public void OnTestEvent(string report)
             {
             }
         }
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AbstractTestRunner.cs
@@ -42,8 +42,6 @@ namespace NUnit.Engine.Runners
             TestPackage = package;
         }
 
-        #region Properties
-
         /// <summary>
         /// Our Service Context
         /// </summary>
@@ -68,10 +66,6 @@ namespace NUnit.Engine.Runners
         {
             get { return LoadResult != null;  }
         }
-
-        #endregion
-
-        #region Abstract and Virtual Template Methods
 
         /// <summary>
         /// Loads the TestPackage for exploration or execution.
@@ -137,10 +131,6 @@ namespace NUnit.Engine.Runners
         /// </summary>
         /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
         public abstract void StopRun(bool force);
-
-        #endregion
-
-        #region ITestEngineRunner Members
 
         /// <summary>
         /// Explores the TestPackage and returns information about
@@ -215,10 +205,6 @@ namespace NUnit.Engine.Runners
         }
 #endif
 
-        #endregion
-
-        #region IDisposable Members
-
         public void Dispose()
         {
             Dispose(true);
@@ -237,7 +223,5 @@ namespace NUnit.Engine.Runners
                 _disposed = true;
             }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -90,8 +90,6 @@ namespace NUnit.Engine.Runners
         {
         }
 
-        #region AbstractTestRunner Overrides
-
         /// <summary>
         /// Explore a TestPackage and return information about
         /// the tests found.
@@ -249,8 +247,6 @@ namespace NUnit.Engine.Runners
             if (_unloadExceptions.Count > 0)
                 throw new NUnitEngineUnloadException(_unloadExceptions);
         }
-
-        #endregion
 
         protected virtual ITestEngineRunner CreateRunner(TestPackage package)
         {

--- a/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/DirectTestRunner.cs
@@ -79,8 +79,6 @@ namespace NUnit.Engine.Runners
 #endif
         }
 
-        #region AbstractTestRunner Overrides
-
         /// <summary>
         /// Explores a previously loaded TestPackage and returns information
         /// about the tests found.
@@ -258,16 +256,10 @@ namespace NUnit.Engine.Runners
             }
         }
 
-        #endregion
-
-        #region Helper Methods
-
         private void EnsurePackageIsLoaded()
         {
             if (!IsPackageLoaded)
                 LoadResult = LoadPackage();
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -89,8 +89,6 @@ namespace NUnit.Engine.Runners
             ValidatePackageSettings();
         }
 
-        #region Properties
-
         /// <summary>
         /// The TestPackage for which this is the runner
         /// </summary>
@@ -108,10 +106,6 @@ namespace NUnit.Engine.Runners
         {
             get { return LoadResult != null; }
         }
-
-#endregion
-
-#region ITestRunner Members
 
         /// <summary>
         /// Get a flag indicating whether a test is running
@@ -214,10 +208,6 @@ namespace NUnit.Engine.Runners
             return LoadResult.Xml;
         }
 
-#endregion
-
-#region IDisposable
-
         public void Dispose()
         {
             Dispose(true);
@@ -237,10 +227,6 @@ namespace NUnit.Engine.Runners
                 _disposed = true;
             }
         }
-
-#endregion
-
-#region Helper Methods
 
         //Exposed for testing
         internal ITestEngineRunner GetEngineRunner()
@@ -541,7 +527,5 @@ namespace NUnit.Engine.Runners
             var filterElement = doc.ImportNode(tempNode, true);
             resultNode.InsertAfter(filterElement, null);
         }
-
-#endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestDomainRunner.cs
@@ -37,14 +37,10 @@ namespace NUnit.Engine.Runners
         /// <param name="package">The package.</param>
         public MultipleTestDomainRunner(IServiceLocator services, TestPackage package) : base(services, package) { }
 
-        #region AggregatingTestRunner Overrides
-
         protected override ITestEngineRunner CreateRunner(TestPackage package)
         {
             return new TestDomainRunner(Services, package);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -41,8 +41,6 @@ namespace NUnit.Engine.Runners
         {
         }
 
-        #region AggregatingTestRunner Overrides
-
         public override int LevelOfParallelism
         {
             get
@@ -56,8 +54,6 @@ namespace NUnit.Engine.Runners
         {
             return new ProcessRunner(Services, package);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -57,8 +57,6 @@ namespace NUnit.Engine.Runners
             _agency = Services.GetService<TestAgency>();
         }
 
-        #region AbstractTestRunner Overrides
-
         /// <summary>
         /// Explore a TestPackage and return information about
         /// the tests found.
@@ -294,10 +292,6 @@ namespace NUnit.Engine.Runners
             }
         }
 
-        #endregion
-
-        #region Helper Methods
-
         private void CreateAgentAndRunner()
         {
             if (_agent == null)
@@ -343,8 +337,6 @@ namespace NUnit.Engine.Runners
 
             return new TestEngineResult(suite);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Runners/TestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestDomainRunner.cs
@@ -39,8 +39,6 @@ namespace NUnit.Engine.Runners
             _domainManager = Services.GetService<DomainManager>();
         }
 
-        #region DirectTestRunner Overrides
-
         protected override TestEngineResult LoadPackage()
         {
             TestDomain = _domainManager.CreateDomain(TestPackage);
@@ -59,8 +57,6 @@ namespace NUnit.Engine.Runners
                 this.TestDomain = null;
             }
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -59,8 +59,6 @@ namespace NUnit.Engine
         // move all this functionality to services, eliminating the
         // use of public static properties here.
 
-        #region Static Fields
-
         /// <summary>
         /// DefaultVersion is an empty Version, used to indicate that
         /// NUnit should select the CLR version to use for the test.
@@ -72,10 +70,6 @@ namespace NUnit.Engine
 
         private static readonly string DEFAULT_WINDOWS_MONO_DIR =
             Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Mono");
-
-        #endregion
-
-        #region Constructors
 
         /// <summary>
         /// Construct from a runtime type and version. If the version has
@@ -170,10 +164,6 @@ namespace NUnit.Engine
             if (Runtime == RuntimeType.Mono && version.Major == 1)
                 this.FrameworkVersion = new Version(1, 0);
         }
-
-        #endregion
-
-        #region Static Properties
 
         /// <summary>
         /// Static method to return a RuntimeFramework object
@@ -311,10 +301,6 @@ namespace NUnit.Engine
             }
         }
 
-        #endregion
-
-        #region Instance Properties
-
         /// <summary>
         /// Gets the unique Id for this runtime, such as "net-4.5"
         /// </summary>
@@ -390,10 +376,6 @@ namespace NUnit.Engine
         /// Returns the Display name for this framework
         /// </summary>
         public string DisplayName { get; private set; }
-
-        #endregion
-
-        #region Public Methods
 
         /// <summary>
         /// Parses a string representing a RuntimeFramework.
@@ -485,10 +467,6 @@ namespace NUnit.Engine
             return FrameworkVersion >= requested.FrameworkVersion;
         }
 
-        #endregion
-
-        #region Helper Methods - General
-
         private static bool IsRuntimeTypeName(string name)
         {
             foreach (string item in Enum.GetNames(typeof(RuntimeType)))
@@ -543,10 +521,6 @@ namespace NUnit.Engine
 
             FindDefaultMonoFramework();
         }
-
-        #endregion
-
-        #region Helper Methods - Mono
 
         private static void FindDefaultMonoFramework()
         {
@@ -685,8 +659,6 @@ namespace NUnit.Engine
 
             _availableFrameworks.Add(framework);
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/ServiceContext.cs
+++ b/src/NUnitEngine/nunit.engine/ServiceContext.cs
@@ -33,34 +33,20 @@ namespace NUnit.Engine
     /// </summary>
     public class ServiceContext : IServiceLocator
     {
-        #region Constructor
-
         public ServiceContext()
         {
             ServiceManager = new ServiceManager();
         }
 
-        #endregion
-
-        #region Properties
-
         public ServiceManager ServiceManager { get; private set; }
 
         public int ServiceCount { get { return ServiceManager.ServiceCount; } }
-
-        #endregion
-
-        #region Methods
 
         public void Add(IService service)
         {
             ServiceManager.AddService(service);
             service.ServiceContext = this;
         }
-
-        #endregion
-
-        #region IServiceLocator Implementation
 
         public T GetService<T>() where T : class
         {
@@ -71,7 +57,5 @@ namespace NUnit.Engine
         {
             return ServiceManager.GetService(serviceType);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentDataBase.cs
@@ -111,8 +111,6 @@ namespace NUnit.Engine.Services
             }
         }
 
-        #region Methods not currently used
-
         // These methods are not currently used, but are  being
         // maintained (and tested) for now since TestAgency is 
         // undergoing some changes and may need them again.
@@ -133,10 +131,6 @@ namespace NUnit.Engine.Services
             }
         }
 
-        #endregion
-
-        #region Nested Snapshot Class used in Testing
-
         public class Snapshot
         {
             public Snapshot(IEnumerable<AgentRecord> data)
@@ -154,8 +148,6 @@ namespace NUnit.Engine.Services
             public ICollection<Guid> Guids { get; private set; }
             public ICollection<AgentRecord> Records { get; private set; }
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -37,8 +37,6 @@ namespace NUnit.Engine.Services
         private IProjectService _projectService;
 #endif
 
-        #region Service Overrides
-
         public override void StartService()
         {
 #if !NETSTANDARD1_6
@@ -53,8 +51,6 @@ namespace NUnit.Engine.Services
             Status = ServiceStatus.Started;
 #endif
         }
-
-        #endregion
 
         /// <summary>
         /// Returns a test runner based on the settings in a TestPackage.
@@ -115,8 +111,6 @@ namespace NUnit.Engine.Services
         }
 #endif
 
-#region Helper Methods
-
 #if !NETSTANDARD1_6 && !NETSTANDARD2_0
         /// <summary>
         /// Get the specified target process model for the package.
@@ -130,7 +124,5 @@ namespace NUnit.Engine.Services
                 package.GetSetting(EnginePackageSettings.ProcessModel, "Default"));
         }
 #endif
-
-#endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DomainManager.cs
@@ -48,7 +48,6 @@ namespace NUnit.Engine.Services
         private static readonly PropertyInfo TargetFrameworkNameProperty =
             typeof(AppDomainSetup).GetProperty("TargetFrameworkName", BindingFlags.Public | BindingFlags.Instance);
 
-        #region Create and Unload Domains
         /// <summary>
         /// Construct an application domain for running a test package
         /// </summary>
@@ -142,9 +141,6 @@ namespace NUnit.Engine.Services
             new DomainUnloader(domain).Unload();
         }
 
-        #endregion
-
-        #region Nested DomainUnloader Class
         class DomainUnloader
         {
             private readonly AppDomain _domain;
@@ -202,9 +198,6 @@ namespace NUnit.Engine.Services
                 }
             }
         }
-        #endregion
-
-        #region Helper Methods
 
         /// <summary>
         /// Figure out the ApplicationBase for a package
@@ -367,8 +360,6 @@ namespace NUnit.Engine.Services
             if ((thread.ThreadState & System.Threading.ThreadState.WaitSleepJoin) != 0)
                 thread.Interrupt();
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DriverService.cs
@@ -41,8 +41,6 @@ namespace NUnit.Engine.Services
     {
         readonly IList<IDriverFactory> _factories = new List<IDriverFactory>();
 
-        #region IDriverService Members
-
         /// <summary>
         /// Get a driver suitable for use with a particular test assembly.
         /// </summary>
@@ -117,10 +115,6 @@ namespace NUnit.Engine.Services
                                                                               "Either assembly contains no tests or proper test driver has not been found.", assemblyPath));
         }
 
-        #endregion
-
-        #region Service Overrides
-
         public override void StartService()
         {
             Guard.OperationValid(ServiceContext != null, "Can't start DriverService outside of a ServiceContext");
@@ -152,7 +146,5 @@ namespace NUnit.Engine.Services
                 throw;
             }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -49,8 +49,6 @@ namespace NUnit.Engine.Services
         private readonly List<ExtensionNode> _extensions = new List<ExtensionNode>();
         private readonly List<ExtensionAssembly> _assemblies = new List<ExtensionAssembly>();
 
-        #region IExtensionService Members
-
         /// <summary>
         /// Gets an enumeration of all ExtensionPoints in the engine.
         /// </summary>
@@ -94,10 +92,6 @@ namespace NUnit.Engine.Services
                     node.Enabled = enabled;
         }
 
-        #endregion
-
-        #region Public Methods - Extension Points
-
         /// <summary>
         /// Get an ExtensionPoint based on its unique identifying path.
         /// </summary>
@@ -130,10 +124,6 @@ namespace NUnit.Engine.Services
             return null;
         }
 
-        #endregion
-
-        #region Public Methods - Extensions
-
         public IEnumerable<ExtensionNode> GetExtensionNodes(string path)
         {
             var ep = GetExtensionPoint(path);
@@ -164,10 +154,6 @@ namespace NUnit.Engine.Services
                 yield return (T)node.ExtensionObject;
         }
 
-        #endregion
-
-        #region Service Overrides
-
         public override void StartService()
         {
             try
@@ -195,10 +181,6 @@ namespace NUnit.Engine.Services
                 throw;
             }
         }
-
-        #endregion
-
-        #region Helper Methods - Extension Points
 
         /// <summary>
         /// Find the extension points in a loaded assembly.
@@ -291,10 +273,6 @@ namespace NUnit.Engine.Services
                 ? DeduceExtensionPointFromType(baseType)
                 : null;
         }
-
-        #endregion
-
-        #region Helper Methods - Extensions
 
         /// <summary>
         /// Find candidate extension assemblies starting from a
@@ -552,8 +530,6 @@ namespace NUnit.Engine.Services
 
             return true;
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/InProcessTestRunnerFactory.cs
@@ -32,8 +32,6 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class InProcessTestRunnerFactory : Service, ITestRunnerFactory
     {
-        #region ITestRunnerFactory Members
-
         /// <summary>
         /// Returns a test runner based on the settings in a TestPackage.
         /// Any setting that is "consumed" by the factory is removed, so
@@ -74,7 +72,5 @@ namespace NUnit.Engine.Services
         {
             return false;
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -36,8 +36,6 @@ namespace NUnit.Engine.Services
     {
         Dictionary<string, ExtensionNode> _extensionIndex = new Dictionary<string, ExtensionNode>();
 
-        #region IProjectService Members
-
         public bool CanLoadFrom(string path)
         {
             ExtensionNode node = GetNodeForPath(path);
@@ -93,10 +91,6 @@ namespace NUnit.Engine.Services
             }
         }
 
-        #endregion
-
-        #region Service Overrides
-
         public override void StartService()
         {
             if (Status == ServiceStatus.Stopped)
@@ -137,10 +131,6 @@ namespace NUnit.Engine.Services
             }
         }
 
-        #endregion
-
-        #region Helper Methods
-
         private IProject LoadFrom(string path)
         {
             if (File.Exists(path))
@@ -166,8 +156,6 @@ namespace NUnit.Engine.Services
 
             return _extensionIndex[ext];
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RecentFilesService.cs
@@ -36,18 +36,12 @@ namespace NUnit.Engine.Services
 
         private const int MAX_FILES = 24;
 
-        #region Properties
-
         public int MaxFiles
         {
             get { return MAX_FILES; }
             set { /* Noop in this implementation */ }
             // NOTE: we retain the setter to avoid changing the interface
         }
-
-        #endregion
-
-        #region Public Methods
 
         public IList<string> Entries { get { return _fileEntries; } }
         
@@ -64,9 +58,6 @@ namespace NUnit.Engine.Services
             if( _fileEntries.Count > MAX_FILES )
                 _fileEntries.RemoveAt( MAX_FILES );
         }
-        #endregion
-
-        #region Helper Methods for saving and restoring the settings
 
         private void LoadEntriesFromSettings()
         {
@@ -111,9 +102,6 @@ namespace NUnit.Engine.Services
         {
             return string.Format( "{0}.File{1}", prefix, index );
         }
-        #endregion
-
-        #region Service Overrides
 
         public override void StopService()
         {
@@ -151,7 +139,5 @@ namespace NUnit.Engine.Services
                 throw;
             }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -89,8 +89,6 @@ namespace NUnit.Engine.Services
             }
         }
 
-        #region IService Members
-
         public override void StartService()
         {
             try
@@ -110,7 +108,5 @@ namespace NUnit.Engine.Services
                 throw;
             }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -172,8 +172,6 @@ namespace NUnit.Engine.Services
             return result;
         }
 
-        #region Helper Methods
-
         /// <summary>
         /// Use Mono.Cecil to get information about all assemblies and
         /// apply it to the package using special internal keywords.
@@ -256,8 +254,6 @@ namespace NUnit.Engine.Services
 
             package.Settings[InternalEnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver] = requiresAssemblyResolver;
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Services/Service.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Service.cs
@@ -34,8 +34,6 @@ namespace NUnit.Engine.Services
     /// </summary>
     public abstract class Service : IService, IDisposable
     {
-        #region IService Default Implementation
-
         /// <summary>
         /// The ServiceContext
         /// </summary>
@@ -62,10 +60,6 @@ namespace NUnit.Engine.Services
             Status = ServiceStatus.Stopped;
         }
 
-        #endregion
-
-        #region IDisposable Default Implementation
-
         public void Dispose()
         {
             GC.SuppressFinalize(this);
@@ -75,7 +69,5 @@ namespace NUnit.Engine.Services
         protected bool _disposed = false;
 
         protected virtual void Dispose(bool disposing) { }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -43,8 +43,6 @@ namespace NUnit.Engine.Services
 
         public int ServiceCount { get { return _services.Count; } }
 
-        #region Public Methods
-
         public IService GetService( Type serviceType )
         {
             IService theService = null;
@@ -133,10 +131,6 @@ namespace NUnit.Engine.Services
             _services.Clear();
         }
 
-#endregion
-
-#region IDisposable
-
         private bool _disposed = false;
 
         public void Dispose()
@@ -162,7 +156,5 @@ namespace NUnit.Engine.Services
                 _disposed = true;
             }
         }
-
-#endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/SettingsService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/SettingsService.cs
@@ -37,8 +37,6 @@ namespace NUnit.Engine.Services
         public SettingsService(bool writeable)
             : base(Path.Combine(NUnitConfiguration.ApplicationDirectory, SETTINGS_FILE), writeable) { }
 
-        #region IService Implementation
-
         public IServiceLocator ServiceContext { get; set; }
 
         public ServiceStatus Status { get; private set; }
@@ -69,6 +67,5 @@ namespace NUnit.Engine.Services
                 Status = ServiceStatus.Stopped;
             }
         }
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -58,19 +58,12 @@ namespace NUnit.Engine.Services
     {
         private static readonly Logger log = InternalTrace.GetLogger(typeof(TestAgency));
 
-        #region Private Fields
-
         private readonly AgentDataBase _agentData = new AgentDataBase();
 
-        #endregion
-
-        #region Constructors
         public TestAgency() : this( "TestAgency", 0 ) { }
 
         public TestAgency( string uri, int port ) : base( uri, port ) { }
-        #endregion
 
-        #region ServerBase Overrides
         //public override void Stop()
         //{
         //    foreach( KeyValuePair<Guid,AgentRecord> pair in agentData )
@@ -94,9 +87,7 @@ namespace NUnit.Engine.Services
 
         //    base.Stop ();
         //}
-        #endregion
 
-        #region Public Methods - Called by Agents
         public void Register( ITestAgent agent )
         {
             AgentRecord r = _agentData[agent.Id];
@@ -106,10 +97,6 @@ namespace NUnit.Engine.Services
                     "agentId");
             r.Agent = agent;
         }
-
-        #endregion
-
-        #region Method Called by Clients
 
         public ITestAgent GetAgent(TestPackage package, int waitTime)
         {
@@ -152,9 +139,6 @@ namespace NUnit.Engine.Services
             return null;
         }
 
-        #endregion
-
-        #region Helper Methods
         private Guid LaunchAgentProcess(TestPackage package)
         {
             RuntimeFramework targetRuntime;
@@ -331,10 +315,6 @@ namespace NUnit.Engine.Services
             throw new NUnitEngineException(errorMsg);
         }
 
-        #endregion
-
-        #region IService Members
-
         public IServiceLocator ServiceContext { get; set; }
 
         public ServiceStatus Status { get; private set; }
@@ -364,8 +344,6 @@ namespace NUnit.Engine.Services
                 throw;
             }
         }
-
-        #endregion
     }
 }
 #endif

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -55,8 +55,6 @@ namespace NUnit.Engine
 
         public int Pos { get; set; }
 
-        #region Equality Overrides
-
         public override bool Equals(object obj)
         {
             return obj is Token && this == (Token)obj;
@@ -92,8 +90,6 @@ namespace NUnit.Engine
         {
             return !(t1 == t2);
         }
-
-        #endregion
     }
 
     /// <summary>

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -49,17 +49,11 @@ namespace NUnit.Engine
             InternalTraceLevel = InternalTraceLevel.Default;
         }
 
-        #region Public Properties
-
         public ServiceContext Services { get; private set; }
 
         public string WorkDirectory { get; set; }
 
         public InternalTraceLevel InternalTraceLevel { get; set; }
-
-        #endregion
-
-        #region ITestEngine Members
 
         /// <summary>
         /// Access the public IServiceLocator, first initializing
@@ -135,10 +129,6 @@ namespace NUnit.Engine
             return new Runners.MasterTestRunner(Services, package);
         }
 
-        #endregion
-
-        #region IDisposable Members
-
         private bool _disposed = false;
 
         public void Dispose()
@@ -158,7 +148,5 @@ namespace NUnit.Engine
                 _disposed = true;
             }
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/TestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngineResult.cs
@@ -59,8 +59,6 @@ namespace NUnit.Engine
 #endif
         private List<XmlNode> _xmlNodes = new List<XmlNode>();
 
-        #region Constructors
-
         /// <summary>
         /// Construct a TestResult from an XmlNode
         /// </summary>
@@ -86,10 +84,6 @@ namespace NUnit.Engine
         public TestEngineResult()
         {
         }
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         /// Gets a flag indicating whether this is a single result
@@ -150,7 +144,5 @@ namespace NUnit.Engine
             this._xmlText.Add(xml.OuterXml);
             this._xmlNodes.Add(xml);
         }
-
-        #endregion
     }
 }

--- a/src/NUnitEngine/nunit.engine/XmlHelper.cs
+++ b/src/NUnitEngine/nunit.engine/XmlHelper.cs
@@ -99,8 +99,6 @@ namespace NUnit
             return childNode;
         }
 
-        #region Safe Attribute Access
-
         /// <summary>
         /// Gets the value of the given attribute.
         /// </summary>
@@ -165,7 +163,5 @@ namespace NUnit
 
             return date;
         }
-
-        #endregion
     }
 }


### PR DESCRIPTION
Fixes #635 - remove all regions from the NUnit Console code base. 🎉 ReSharper did the edit, and I've reviewed by hand.

Note that in some cases, the region name was used for 'documentation' almost, however in all these cases the information seems to be duplicated in nearby comments. 🙂