### PR TITLE
Initialize DriverService after ExtensionService

### DIFF
--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -102,7 +102,6 @@ namespace NUnit.Engine
                 // For example, ResultService uses ExtensionService, so ExtensionService is added
                 // later.
                 Services.Add(new SettingsService(true));
-                Services.Add(new DriverService());
                 Services.Add(new RecentFilesService());
                 Services.Add(new TestFilterService());
 #if !NETSTANDARD1_6
@@ -114,6 +113,7 @@ namespace NUnit.Engine
                 Services.Add(new TestAgency());
 #endif
 #endif
+                Services.Add(new DriverService());
                 Services.Add(new ResultService());
                 Services.Add(new DefaultTestRunnerFactory());
             }


### PR DESCRIPTION
Smallest possible fix for this. There are no tests and I didn't add any because we don't actually have code to test... that is, we add the tests in a certain order and initialize in the same order but without any knowledge of which services depend on other services.

A bigger fix, which I had once planned to make, would be for the ServiceManager to be able to get information from the services about their dependencies and to ensure that they are initialized in the right order and that there are no loops. That's a big (testable) change, however.

For now, since the current order is obviously wrong, I think we should merge this.

BTW it has been this way since the beginning AFAICS. We apparently could never run the V2 driver in process because of it.