### PR TITLE
Move ProjectDependencies section from sln -> csproj's 

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -31,12 +31,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.engine", "src\NUnitEngine\nunit.engine\nunit.engine.csproj", "{372A3447-D657-40FF-A089-77C19FEC30C8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.engine.tests", "src\NUnitEngine\nunit.engine.tests\nunit.engine.tests.csproj", "{D694CB69-6CFB-4762-86C2-EB27B808B282}"
-	ProjectSection(ProjectDependencies) = postProject
-		{B1D90742-39BD-429C-8E87-C5CD2991DF27} = {B1D90742-39BD-429C-8E87-C5CD2991DF27}
-		{C2A8FC7A-FA64-46EA-AF6D-73D6B371DBF8} = {C2A8FC7A-FA64-46EA-AF6D-73D6B371DBF8}
-		{28B605B2-E2E9-417E-8369-49E263F1F31B} = {28B605B2-E2E9-417E-8369-49E263F1F31B}
-		{0DE218CA-AFB8-423A-9CD2-E22DEAC55C46} = {0DE218CA-AFB8-423A-9CD2-E22DEAC55C46}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit-agent", "src\NUnitEngine\nunit-agent\nunit-agent.csproj", "{C2A8FC7A-FA64-46EA-AF6D-73D6B371DBF8}"
 EndProject
@@ -45,12 +39,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit3-console", "src\NUnitConsole\nunit3-console\nunit3-console.csproj", "{0DE218CA-AFB8-423A-9CD2-E22DEAC55C46}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit3-console.tests", "src\NUnitConsole\nunit3-console.tests\nunit3-console.tests.csproj", "{B310A760-8AE1-41CA-81F8-03B12E2FCE30}"
-	ProjectSection(ProjectDependencies) = postProject
-		{B1D90742-39BD-429C-8E87-C5CD2991DF27} = {B1D90742-39BD-429C-8E87-C5CD2991DF27}
-		{D694CB69-6CFB-4762-86C2-EB27B808B282} = {D694CB69-6CFB-4762-86C2-EB27B808B282}
-		{C2A8FC7A-FA64-46EA-AF6D-73D6B371DBF8} = {C2A8FC7A-FA64-46EA-AF6D-73D6B371DBF8}
-		{28B605B2-E2E9-417E-8369-49E263F1F31B} = {28B605B2-E2E9-417E-8369-49E263F1F31B}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit-agent-x86", "src\NUnitEngine\nunit-agent\nunit-agent-x86.csproj", "{28B605B2-E2E9-417E-8369-49E263F1F31B}"
 EndProject

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -32,6 +32,8 @@
     <ProjectReference Include="..\..\NUnitEngine\nunit.engine\nunit.engine.csproj" />
     <ProjectReference Include="..\nunit3-console\nunit3-console.csproj" />
     <ProjectReference Include="..\..\NUnitEngine\nunit.engine.api\nunit.engine.api.csproj" />
+    <ProjectReference Include="..\..\NUnitEngine\nunit-agent\nunit-agent.csproj" />
+    <ProjectReference Include="..\..\NUnitEngine\nunit-agent\nunit-agent-x86.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -29,6 +29,10 @@
     <ProjectReference Include="..\nunit.engine.api\nunit.engine.api.csproj" />
     <ProjectReference Include="..\nunit.engine\nunit.engine.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net35'">
+    <ProjectReference Include="..\nunit-agent\nunit-agent.csproj" />
+    <ProjectReference Include="..\nunit-agent\nunit-agent-x86.csproj" />
+  </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>


### PR DESCRIPTION
A workaround for https://github.com/dependabot/feedback/issues/520.

As I [understand from Stack Overflow](https://stackoverflow.com/q/5629981/1768779), the `ProjectDependencies` elements in the sln file can instead be specified in the csproj file. This is necessary in the NUnit Console's case, as the engine does not directly reference the agent, and as such, is not copied into the test dir by default. 

I also understand that `ProjectDependencies` is the older way of specifying such dependencies, and specifying them through the csproj instead hopefully follows the principle of least surprise!