### PR TITLE
Enable legacyCorruptedStateExceptionsPolicy

### DIFF
--- a/src/NUnitConsole/nunit3-console/app.config
+++ b/src/NUnitConsole/nunit3-console/app.config
@@ -16,6 +16,14 @@
     <!-- Ensure that test exceptions don't crash NUnit -->
     <legacyUnhandledExceptionPolicy enabled="1" />
 
+    <!--
+     Since legacyUnhandledExceptionPolicy keeps the console from being killed even though an NUnit framework
+     test worker thread is killed, this is needed to prevent a hang. NUnit framework can only handle these
+     exceptions when this config element is present. (Or if future versions of NUnit framework drop support
+     for partial trust which would enable it to use [HandleProcessCorruptedStateExceptions].)
+    -->
+    <legacyCorruptedStateExceptionsPolicy enabled="true" />
+
     <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
     <loadFromRemoteSources enabled="true" />
 

--- a/src/NUnitEngine/nunit-agent/app.config
+++ b/src/NUnitEngine/nunit-agent/app.config
@@ -22,6 +22,14 @@
     <!-- Ensure that test exceptions don't crash NUnit -->
     <legacyUnhandledExceptionPolicy enabled="1" />
 
+    <!--
+     Since legacyUnhandledExceptionPolicy keeps the console from being killed even though an NUnit framework
+     test worker thread is killed, this is needed to prevent a hang. NUnit framework can only handle these
+     exceptions when this config element is present. (Or if future versions of NUnit framework drop support
+     for partial trust which would enable it to use [HandleProcessCorruptedStateExceptions].)
+    -->
+    <legacyCorruptedStateExceptionsPolicy enabled="true" />
+
     <!-- Run partial trust V2 assemblies in full trust under .NET 4.0 -->
     <loadFromRemoteSources enabled="true" />
 


### PR DESCRIPTION
Fixes #336.

Also, in order to fix the intermittent test run hangs investigated at https://github.com/nunit/nunit/issues/3295, at least one of the following things must happen:

- This PR gets merged (that was easy, let's go with this one for now 😅)

- Microsoft ports the .NET Core fix to .NET Framework 4.7 and 4.8 to fix the race condition that causes stack traces to throw AccessViolationException

- NUnit Framework drops support for partial trust (see comment in this PR and https://github.com/nunit/nunit/issues/3295)

- NUnit Framework implements a watchdog thread to notice the highly bizarre situation set up by the console's current app.config where the console process isn't killed but the NUnit framework test worker thread is killed (see comment in this PR and https://github.com/nunit/nunit/issues/3295)

