### PR TITLE
nunit.console-runner-with-extensions.nuspec: Remove outdated release notes

### DIFF
--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -24,7 +24,7 @@
 
       Other extensions, if needed, must be installed separately.
     </description>
-    <releaseNotes>This release uses the latest version of the TeamCityEventListener extension.</releaseNotes>
+    <releaseNotes></releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2019 Charlie Poole, Rob Prouse</copyright>


### PR DESCRIPTION
It has been mentioning the teamcity event listener (as the only) change for
every version from 3.5.0 onwards. I am guessing that this is in fact not always a
change, nor the only change, so better to leave release notes empty if they are not updated.