### PR TITLE
Fix for running multiple test packages targetting different frameworks on the correct platform

### DIFF
--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
@@ -45,6 +45,11 @@ namespace NUnit.Engine
         /// the settings in the package and the assemblies themselves.
         /// The package RuntimeFramework setting may be updated as a 
         /// result and the selected runtime is returned.
+        ///
+        /// Note that if a package has subpackages, the subpackages may run on a different
+        /// framework to the top-level package. In future, this method should
+        /// probably not return a simple string, and instead require runners
+        /// to inspect the test package structure, to find all desired frameworks.
         /// </summary>
         /// <param name="package">A TestPackage</param>
         /// <returns>The selected RuntimeFramework</returns>

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -96,6 +96,10 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public void RuntimeFrameworkIsSetForSubpackages()
         {
+            //Runtime Service verifies that requested frameworks are available, therefore this test can only currently be run on platforms with both CLR v2 and v4 available
+            Assume.That(new RuntimeFramework(RuntimeType.Net, new Version("2.0.50727")), Has.Property(nameof(RuntimeFramework.IsAvailable)).True);
+            Assume.That(new RuntimeFramework(RuntimeType.Net, new Version("4.0.30319")), Has.Property(nameof(RuntimeFramework.IsAvailable)).True);
+
             var topLevelPackage = new TestPackage(new [] {"a.dll", "b.dll"});
 
             var net20Package = topLevelPackage.SubPackages[0];

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -91,6 +91,26 @@ namespace NUnit.Engine.Services.Tests
 
             _runtimeService.SelectRuntimeFramework(package);
             Assert.That(package.GetSetting<string>(EnginePackageSettings.RuntimeFramework, null), Is.EqualTo(requested));
+        }
+
+        [Test]
+        public void RuntimeFrameworkIsSetForSubpackages()
+        {
+            var topLevelPackage = new TestPackage(new [] {"a.dll", "b.dll"});
+
+            var net20Package = topLevelPackage.SubPackages[0];
+            net20Package.Settings.Add(InternalEnginePackageSettings.ImageRuntimeVersion, new Version("2.0.50727"));
+            var net40Package = topLevelPackage.SubPackages[1];
+            net40Package.Settings.Add(InternalEnginePackageSettings.ImageRuntimeVersion, new Version("4.0.30319"));
+
+            _runtimeService.SelectRuntimeFramework(topLevelPackage);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(net20Package.Settings[EnginePackageSettings.RuntimeFramework], Is.EqualTo("net-2.0"));
+                Assert.That(net40Package.Settings[EnginePackageSettings.RuntimeFramework], Is.EqualTo("net-4.0"));
+                Assert.That(topLevelPackage.Settings[EnginePackageSettings.RuntimeFramework], Is.EqualTo("net-4.0"));
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit/issues/3338.

Previously, the chosen framework for a TestPackage was only set on the top level package. This meant that when subpackages got passed into the ProcessRunner, the information wasn't available, and they defaulted to run on the current framework. I think this is probably a long-standing bug, it just to a niche scenario like in #3338 for it to actually be noticed.

The fix calculates and sets the best framework on every package in the tree, so that sub runners can access the information. It's done on the basis of 'minimum change', as this area of code is a little messy already, and I'd _love_ to refactor it all one day. (And possibly one day soon, with the introduction of .NET Core targets.)

Note the ADO Linux build is currently failing here, as Mikkel reported on the framework: https://github.com/nunit/nunit/issues/3338. I'm hoping ADO may apply a fix here...