### PR TITLE
Manually updated .NET Core SDK on Linux build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,13 @@ jobs:
     vmImage: ubuntu-16.04
   steps:
 
-  - bash: ./build.sh --target Test --configuration Release
+  - bash: |
+      wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+      sudo dpkg -i packages-microsoft-prod.deb
+      sudo apt-get install apt-transport-https
+      sudo apt-get update
+      sudo apt-get install dotnet-sdk-2.2
+      ./build.sh --target Test --configuration Release
     displayName: Build and test
 
   # Workaround for https://github.com/nunit/nunit/issues/3012#issuecomment-441517922


### PR DESCRIPTION
Fix Linux build on Azure Dev Ops, by manually updating the .NET Core SDK.

I haven't looked in a lot of detail, but it appears type time of error can happen with certain incompatible version of the .NET Core SDK and NuGet. I assume the Azure image was updated for one of these which caused the failure, updating the image manually to the latest .NET Core SDK seems to fix the issue. 