### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,19 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ''
+labels: confirm, is:bug
+assignees: ''
+
+---
+
+<!--
+Thanks for filing a bug report with NUnit! NUnit is run entirely by volunteers from the community, so we welcome pull requests and contributions in all areas.
+
+To help the others diagnose and reproduce your issue, please include as many of the following as relevant:
+- The full command line being used
+- Method of installation (e.g. NuGet, zip, msi)
+- Log files (Run the console with `--trace=Debug` to produce these)
+- Version of the NUnit Engine/Console
+- All versions of the NUnit Framework in use
+-->

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -13,7 +13,8 @@ Thanks for filing a bug report with NUnit! NUnit is run entirely by volunteers f
 To help the others diagnose and reproduce your issue, please include as many of the following as relevant:
 - The full command line being used
 - Method of installation (e.g. NuGet, zip, msi)
-- Log files (Run the console with `--trace=Debug` to produce these)
+- Log files (Run the console with --trace=Debug to produce these)
 - Version of the NUnit Engine/Console
 - All versions of the NUnit Framework in use
+- Whether the behaviour is any different when the tests are run using the --inprocess flag
 -->

--- a/.github/ISSUE_TEMPLATE/feature-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature-suggestion.md
@@ -1,0 +1,14 @@
+---
+name: Feature Suggestion
+about: Suggest a feature to improve this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- 
+Thanks for suggesting a feature for the NUnit Console/Engine. NUnit is run entirely by volunteers from the community, so we welcome pull requests and contributions in all areas.
+
+Please describe what you're proposing, and let us know if you'd be willing to submit a pull request as well. It's best to wait for a response from the team before starting to write any code - we want to be sure any new features fit in with the overall vision for NUnit, and aren't going to cause any breaking changes.
+-->

--- a/.github/ISSUE_TEMPLATE/feature-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature-suggestion.md
@@ -10,5 +10,5 @@ assignees: ''
 <!-- 
 Thanks for suggesting a feature for the NUnit Console/Engine. NUnit is run entirely by volunteers from the community, so we welcome pull requests and contributions in all areas.
 
-Please describe what you're proposing, and let us know if you'd be willing to submit a pull request as well. It's best to wait for a response from the team before starting to write any code - we want to be sure any new features fit in with the overall vision for NUnit, and aren't going to cause any breaking changes.
+Please describe what you're proposing, and let us know if you'd be willing to submit a pull request as well. It's best to wait for a response from the team before starting to write any code. We want to be sure any new features fit in with the overall vision for NUnit and aren't going to cause any breaking changes.
 -->

--- a/.github/ISSUE_TEMPLATE/support-other.md
+++ b/.github/ISSUE_TEMPLATE/support-other.md
@@ -1,0 +1,19 @@
+---
+name: Support/Other
+about: All other issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Having problems? NUnit is run entirely by volunteers from the community, but we're keen to help!
+
+To help the others diagnose and reproduce your issue, please include as many of the following as relevant:
+- The full command line being used
+- Method of installation (e.g. NuGet, zip, msi)
+- Log files (Run the console with `--trace=Debug` to produce these)
+- Version of the NUnit Engine/Console
+- All versions of the NUnit Framework in use
+-->

--- a/.github/ISSUE_TEMPLATE/support-other.md
+++ b/.github/ISSUE_TEMPLATE/support-other.md
@@ -13,7 +13,8 @@ Having problems? NUnit is run entirely by volunteers from the community, but we'
 To help the others diagnose and reproduce your issue, please include as many of the following as relevant:
 - The full command line being used
 - Method of installation (e.g. NuGet, zip, msi)
-- Log files (Run the console with `--trace=Debug` to produce these)
+- Log files (Run the console with --trace=Debug to produce these)
 - Version of the NUnit Engine/Console
 - All versions of the NUnit Framework in use
+- Whether the behaviour is any different when the tests are run using the --inprocess flag
 -->


### PR DESCRIPTION
This is something I've wanted to do for a while. This adds issue templates - for anyone unfamiliar, see [here](https://help.github.com/en/articles/about-issue-and-pull-request-templates).

There's two problems I'm trying to solve:

1. We have lots of brilliant, enthusiastic bug reporters, but it often takes a bit of back and forth to get the information we required. That's frustrating for the reporter, and time consuming for the team.

1. I wanted to make it clear for first-timers that NUnit is a non-commercial, community-powered project, and promote a bit of 'help us to help you'.

Target audience is newcomers. I'm aware the wording and suggestions don't cover all options (e.g. getting debug logs if you're not using the console runner) - but my opinion is that this is to help the majority, and advanced users can continue to figure these things out themselves. 😄 

What do people think?