### PR TITLE
Display path and version of extension assemblies

### DIFF
--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -332,6 +332,13 @@ namespace NUnit.ConsoleRunner
                     if(node.TargetFramework != null)
                         _outWriter.Write(ColorStyle.Value, $"(.NET {node.TargetFramework?.FrameworkVersion})");
                     _outWriter.WriteLine(node.Enabled ? "" : " (Disabled)");
+
+                    _outWriter.Write("      Version: ");
+                    _outWriter.Write(ColorStyle.Value, node.AssemblyVersion.ToString());
+
+                    _outWriter.Write("      Path: ");
+                    _outWriter.Write(ColorStyle.Value, node.AssemblyPath);
+
                     foreach (var prop in node.PropertyNames)
                     {
                         _outWriter.Write("      " + prop + ":");

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -334,10 +334,10 @@ namespace NUnit.ConsoleRunner
                     _outWriter.WriteLine(node.Enabled ? "" : " (Disabled)");
 
                     _outWriter.Write("      Version: ");
-                    _outWriter.Write(ColorStyle.Value, node.AssemblyVersion.ToString());
+                    _outWriter.WriteLine(ColorStyle.Value, node.AssemblyVersion.ToString());
 
                     _outWriter.Write("      Path: ");
-                    _outWriter.Write(ColorStyle.Value, node.AssemblyPath);
+                    _outWriter.WriteLine(ColorStyle.Value, node.AssemblyPath);
 
                     foreach (var prop in node.PropertyNames)
                     {

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionNode.cs
@@ -72,5 +72,15 @@ namespace NUnit.Engine.Extensibility
         /// <param name="name">The property name</param>
         /// <returns>A collection of values</returns>
         IEnumerable<string> GetValues(string name);
+
+        /// <summary>
+        /// The path to the assembly implementing this extension.
+        /// </summary>
+        string AssemblyPath { get; }
+
+        /// <summary>
+        /// The Version of the assembly implementing this extension.
+        /// </summary>
+        Version AssemblyVersion { get; }
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IExtensionNode.cs
@@ -79,7 +79,7 @@ namespace NUnit.Engine.Extensibility
         string AssemblyPath { get; }
 
         /// <summary>
-        /// The Version of the assembly implementing this extension.
+        /// The version of the assembly implementing this extension.
         /// </summary>
         Version AssemblyVersion { get; }
     }

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -47,11 +47,13 @@ namespace NUnit.Engine.Extensibility
         /// Construct an ExtensionNode supplying the assembly path and type name.
         /// </summary>
         /// <param name="assemblyPath">The path to the assembly where this extension is found.</param>
+        /// <param name="assemblyVersion">The version of the assembly whee this extension is found.</param>
         /// <param name="typeName">The full name of the Type of the extension object.</param>
         /// <param name="targetFramework">The target framework of the extension assembly.</param>
-        public ExtensionNode(string assemblyPath, string typeName, IRuntimeFramework targetFramework)
+        public ExtensionNode(string assemblyPath, Version assemblyVersion, string typeName, IRuntimeFramework targetFramework)
         {
             AssemblyPath = assemblyPath;
+            AssemblyVersion = assemblyVersion;
             TypeName = typeName;
             TargetFramework = targetFramework;
             Enabled = true; // By default
@@ -111,6 +113,11 @@ namespace NUnit.Engine.Extensibility
         /// Gets the path to the assembly where the extension is defined.
         /// </summary>
         public string AssemblyPath { get; private set; }
+
+        /// <summary>
+        /// Gets the version of the assembly where the extension is defined
+        /// </summary>
+        public Version AssemblyVersion { get; private set; }
 
         /// <summary>
         /// Gets an object of the specified extension type, loading the Assembly

--- a/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine/Extensibility/ExtensionNode.cs
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Extensibility
         /// Construct an ExtensionNode supplying the assembly path and type name.
         /// </summary>
         /// <param name="assemblyPath">The path to the assembly where this extension is found.</param>
-        /// <param name="assemblyVersion">The version of the assembly whee this extension is found.</param>
+        /// <param name="assemblyVersion">The version of the extension assembly.</param>
         /// <param name="typeName">The full name of the Type of the extension object.</param>
         /// <param name="targetFramework">The target framework of the extension assembly.</param>
         public ExtensionNode(string assemblyPath, Version assemblyVersion, string typeName, IRuntimeFramework targetFramework)
@@ -115,7 +115,7 @@ namespace NUnit.Engine.Extensibility
         public string AssemblyPath { get; private set; }
 
         /// <summary>
-        /// Gets the version of the assembly where the extension is defined
+        /// Gets the version of the extension assembly.
         /// </summary>
         public Version AssemblyVersion { get; private set; }
 

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -463,7 +463,7 @@ namespace NUnit.Engine.Services
                     if (versionArg != null && new Version((string)versionArg) > ENGINE_VERSION)
                         continue;
 
-                    var node = new ExtensionNode(assembly.FilePath, type.FullName, assemblyTargetFramework);
+                    var node = new ExtensionNode(assembly.FilePath, assembly.AssemblyVersion, type.FullName, assemblyTargetFramework);
                     node.Path = extensionAttr.GetNamedArgument("Path") as string;
                     node.Description = extensionAttr.GetNamedArgument("Description") as string;
 


### PR DESCRIPTION
This PR is intended to resolve the problem discussed in TestCentric/testcentric-gui#395 for the engine and console.

The engine fixes are already in use in the private build that's part of the TestCentric GUI. The console changes are intended to display output as suggested by @Sharken03 in that issue.