### PR TITLE
Clean extension dir before running FetchExtensions task

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -447,6 +447,8 @@ Task("PackageChocolatey")
 Task("FetchExtensions")
 .Does(() =>
 {
+    CleanDirectory(EXTENSION_PACKAGES_DIR);
+
     foreach(var package in EXTENSION_PACKAGES)
     {
         NuGetInstall(package, new NuGetInstallSettings {


### PR DESCRIPTION
Fixes #595 

This issue was caused by incorrect versioning in the teamcity extension. However there is a very tenuous edge-case under which previous versions of extensions may end up in the combined packages...so I added and extra `CleanDirectory` just in case.