### PR TITLE
Separate addins files for nuget packages

### DIFF
--- a/nuget/engine/nunit.engine.nuget.addins
+++ b/nuget/engine/nunit.engine.nuget.addins
@@ -1,0 +1,2 @@
+../../../NUnit.Extension.*/**/tools/     # nuget v2 layout
+../../../../NUnit.Extension.*/**/tools/  # nuget v3 layout

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -48,14 +48,14 @@
     <file src="bin/net20/nunit-agent.exe.config" target="lib/net20" />
     <file src="bin/net20/nunit-agent-x86.exe" target="lib/net20" />
     <file src="bin/net20/nunit-agent-x86.exe.config" target="lib/net20" />
-    <file src="../../nuget/engine/nunit.nuget.addins" target="lib/net20"/>
+    <file src="../../nuget/engine/nunit.engine.nuget.addins" target="lib/net20"/>
     <file src="bin/netstandard1.6/nunit.engine.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard1.6/nunit.engine.api.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard1.6/Mono.Cecil.dll" target="lib/netstandard1.6" />
-    <file src="../../nuget/engine/nunit.nuget.addins" target="lib/netstandard1.6"/>
+    <file src="../../nuget/engine/nunit.engine.nuget.addins" target="lib/netstandard1.6"/>
     <file src="bin/netstandard2.0/nunit.engine.dll" target="lib/netstandard2.0" />
     <file src="bin/netstandard2.0/nunit.engine.api.dll" target="lib/netstandard2.0" />
     <file src="bin/netstandard2.0/Mono.Cecil.dll" target="lib/netstandard2.0" />
-    <file src="../../nuget/engine/nunit.nuget.addins" target="lib/netstandard2.0"/>
+    <file src="../../nuget/engine/nunit.engine.nuget.addins" target="lib/netstandard2.0"/>
   </files>
 </package>

--- a/nuget/engine/nunit.nuget.addins
+++ b/nuget/engine/nunit.nuget.addins
@@ -1,3 +1,0 @@
-../../NUnit.Extension.*/**/tools/        # nuget v2 layout
-../../../NUnit.Extension.*/**/tools/     
-../../../../NUnit.Extension.*/**/tools/  # nuget v3 layout

--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -36,6 +36,6 @@
     <file src="bin/net20/nunit.engine.api.xml" target="tools" />
     <file src="bin/net20/nunit.engine.dll" target="tools" />
     <file src="bin/net20/Mono.Cecil.dll" target="tools" />
-    <file src="..\..\nuget\engine\nunit.nuget.addins" target="tools"/>
+    <file src="..\..\nuget\runners\nunit.console.nuget.addins" target="tools"/>
   </files>
 </package>

--- a/nuget/runners/nunit.console.nuget.addins
+++ b/nuget/runners/nunit.console.nuget.addins
@@ -1,0 +1,2 @@
+../../NUnit.Extension.*/**/tools/        # nuget v2 layout
+../../../NUnit.Extension.*/**/tools/     # nuget v3 layout


### PR DESCRIPTION
Fixes #586.

For the last release, we made a quick fix with the addins files for the NuGet packages, to correct a path bug that had been brought in when combining the netfx and .NET Standard engines into the same solution. This removes that quick fix, and creates two separate files for each nuget package.

I've tested the install of each package by hand, and extensions appear to be loaded correctly.