### PR TITLE
Bump engine tests to run on .NET Core 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - sudo apt-get install apt-transport-https
         - sudo apt-get update
         - sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.2
-        - sudo apt-get install dotnet-runtime-2.0.6
+        - sudo apt-get install dotnet-runtime-2.1
 
 # macOS package restore currently taking >30 mins on Travis
 #    - os: osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,12 +31,12 @@ jobs:
       testRunTitle: netcoreapp1.1/Windows
     condition: succeededOrFailed()
   - task: PublishTestResults@2
-    displayName: Publish netcoreapp2.0 test results
+    displayName: Publish netcoreapp2.1 test results
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: test-results\netcoreapp2.0\*.xml
+      testResultsFiles: test-results\netcoreapp2.1\*.xml
       mergeTestResults: true
-      testRunTitle: netcoreapp2.0/Windows
+      testRunTitle: netcoreapp2.1/Windows
     condition: succeededOrFailed()
 
   - powershell: .\build.ps1 -Target Package --artifact-dir='$(Build.ArtifactStagingDirectory)'
@@ -80,12 +80,12 @@ jobs:
       testRunTitle: netcoreapp1.1/Linux
     condition: succeededOrFailed()
   - task: PublishTestResults@2
-    displayName: Publish netcoreapp2.0 test results
+    displayName: Publish netcoreapp2.1 test results
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: test-results/netcoreapp2.0/*.xml
+      testResultsFiles: test-results/netcoreapp2.1/*.xml
       mergeTestResults: true
-      testRunTitle: netcoreapp2.0/Linux
+      testRunTitle: netcoreapp2.1/Linux
     condition: succeededOrFailed()
 
 - job: macOS
@@ -114,10 +114,10 @@ jobs:
       testRunTitle: netcoreapp1.1/macOS
     condition: succeededOrFailed()
   - task: PublishTestResults@2
-    displayName: Publish netcoreapp2.0 test results
+    displayName: Publish netcoreapp2.1 test results
     inputs:
       testResultsFormat: NUnit
-      testResultsFiles: test-results/netcoreapp2.0/*.xml
+      testResultsFiles: test-results/netcoreapp2.1/*.xml
       mergeTestResults: true
-      testRunTitle: netcoreapp2.0/macOS
+      testRunTitle: netcoreapp2.1/macOS
     condition: succeededOrFailed()

--- a/build.cake
+++ b/build.cake
@@ -31,7 +31,7 @@ var PACKAGE_DIR = Argument("artifact-dir", PROJECT_DIR + "package") + "/";
 var BIN_DIR = PROJECT_DIR + "bin/" + configuration + "/";
 var NET35_BIN_DIR = BIN_DIR + "net35/";
 var NETCOREAPP11_BIN_DIR = BIN_DIR + "netcoreapp1.1/";
-var NETCOREAPP20_BIN_DIR = BIN_DIR + "netcoreapp2.0/";
+var NETCOREAPP21_BIN_DIR = BIN_DIR + "netcoreapp2.1/";
 var CHOCO_DIR = PROJECT_DIR + "choco/";
 var TOOLS_DIR = PROJECT_DIR + "tools/";
 var IMAGE_DIR = PROJECT_DIR + "images/";
@@ -48,7 +48,7 @@ var ENGINE_TESTS_CSPROJ = PROJECT_DIR + "src/NUnitEngine/nunit.engine.tests/nuni
 
 var NETFX_FRAMEWORKS = new [] { "net20", "net35" }; //Production code targets net20, tests target nets35
 var NETSTANDARD_FRAMEWORKS = new [] { "netstandard1.6", "netstandard2.0" };
-var NETCORE_FRAMEWORKS = new [] { "netcoreapp1.1", "netcoreapp2.0" };
+var NETCORE_FRAMEWORKS = new [] { "netcoreapp1.1", "netcoreapp2.1" };
 
 // Test Runner
 var NET20_CONSOLE = BIN_DIR + "net20/" + "nunit3-console.exe";
@@ -306,9 +306,9 @@ Task("TestNetStandard20Engine")
         if (IsDotNetCoreInstalled)
         {
             RunDotnetCoreTests(
-                NETCOREAPP20_BIN_DIR + ENGINE_TESTS,
-                NETCOREAPP20_BIN_DIR,
-                "netcoreapp2.0",
+                NETCOREAPP21_BIN_DIR + ENGINE_TESTS,
+                NETCOREAPP21_BIN_DIR,
+                "netcoreapp2.1",
                 ref ErrorDetail);
         }
         else

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET 2.0 Debug")]
 #elif NETSTANDARD1_6 || NETCOREAPP1_1
 [assembly: AssemblyConfiguration(".NET Standard 1.6 Debug")]
-#elif NETSTANDARD2_0 || NETCOREAPP2_0
+#elif NETSTANDARD2_0 || NETCOREAPP2_1
 [assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
 #else
 [assembly: AssemblyConfiguration("Debug")]
@@ -49,7 +49,7 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET 2.0")]
 #elif NETSTANDARD1_6 || NETCOREAPP1_1
 [assembly: AssemblyConfiguration(".NET Standard 1.6")]
-#elif NETSTANDARD2_0 || NETCOREAPP2_0
+#elif NETSTANDARD2_0 || NETCOREAPP2_1
 [assembly: AssemblyConfiguration(".NET Standard 2.0")]
 #else
 [assembly: AssemblyConfiguration("")]

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net20;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net20;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NUnitEngine/notest-assembly/notest-assembly.csproj
+++ b/src/NUnitEngine/notest-assembly/notest-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>notest_assembly</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 &&!NETCOREAPP2_0
+#if !NETCOREAPP1_1 &&!NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/NUnitEngine/nunit.engine.tests/DummyExtensions.cs
+++ b/src/NUnitEngine/nunit.engine.tests/DummyExtensions.cs
@@ -33,7 +33,7 @@ namespace NUnit.Engine.Tests
     [Extension]
     public class DummyFrameworkDriverExtension : IDriverFactory
     {
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
         public IFrameworkDriver GetDriver(AssemblyName reference)
 #else
         public IFrameworkDriver GetDriver(AppDomain domain, AssemblyName reference)

--- a/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionAssemblyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionAssemblyTests.cs
@@ -69,7 +69,7 @@ namespace NUnit.Engine.Tests.Extensibility
             Assert.That(_ea.AssemblyVersion, Is.EqualTo(THIS_ASSEMBLY_VERSION));
         }
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
         [Test]
         public void TargetFramework()
         {

--- a/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionSelectorTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionSelectorTests.cs
@@ -22,7 +22,7 @@
 // ***********************************************************************
 
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using NSubstitute;
 using NUnit.Engine.Extensibility;

--- a/src/NUnitEngine/nunit.engine.tests/Integration/RemoteAgentTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/RemoteAgentTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+﻿#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System.Diagnostics;
 using NUnit.Engine.Tests.Helpers;
 using NUnit.Framework;

--- a/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/PathUtilTests.cs
@@ -87,7 +87,7 @@ namespace NUnit.Engine.Internal.Tests
 		{
             bool windows = false;
 
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
             windows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #else
             var platform = Environment.OSVersion.Platform;

--- a/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
@@ -24,7 +24,7 @@
 using System;
 using System.ComponentModel;
 using NUnit.Framework;
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System.Drawing;
 #endif
 
@@ -101,7 +101,7 @@ namespace NUnit.Engine.Internal.Tests
             Assert.That(settings.GetSetting( "X", 42 ), Is.EqualTo(42));
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
         [Test]
         [SetCulture("da-DK")]
         public void SaveAndGetSettingShouldReturnTheOriginalValue()

--- a/src/NUnitEngine/nunit.engine.tests/Internal/TcpChannelUtilsTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/TcpChannelUtilsTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using System.Runtime.Remoting.Channels;
 using System.Runtime.Remoting.Channels.Tcp;

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -81,7 +81,7 @@ namespace NUnit.Engine.Runners.Tests
             //new TestRunData( "notest-assembly.dll", NoTestAssemblyData ),
             //new TestRunData( "notest-assembly.dll,notest-assembly.dll", NoTestAssemblyData, NoTestAssemblyData ),
             //new TestRunData( "mock-assembly.dll,notest-assembly.dll", MockAssemblyData, NoTestAssemblyData )
-#elif NETCOREAPP2_0
+#elif NETCOREAPP2_1
             new TestRunData( "mock-assembly.dll", MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", MockAssemblyData, MockAssemblyData ),
             //new TestRunData( "notest-assembly.dll", NoTestAssemblyData ),
@@ -122,7 +122,7 @@ namespace NUnit.Engine.Runners.Tests
             projectService.Add("project3.nunit", notestsPath);
             projectService.Add("project4.nunit", notestsPath, notestsPath);
             _services.Add(projectService);
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
             _services.Add(new DomainManager());
             _services.Add(new RuntimeFrameworkService());
 #endif

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using NUnit.Framework;
 

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Runners.Tests
     // intermittent errors, probably due to the test
     // fixture rather than the engine.
     [TestFixture(typeof(LocalTestRunner))]
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
     [TestFixture(typeof(TestDomainRunner))]
     //[TestFixture(typeof(ProcessRunner))]
     [TestFixture(typeof(MultipleTestDomainRunner), 1)]
@@ -70,7 +70,7 @@ namespace NUnit.Engine.Runners.Tests
 #if !NETCOREAPP1_1
             _services.Add(new Services.ExtensionService());
             _services.Add(new Services.ProjectService());
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
             _services.Add(new Services.DomainManager());
             _services.Add(new Services.RuntimeFrameworkService());
             _services.Add(new Services.TestAgency("ProcessRunnerTests", 0));
@@ -139,7 +139,7 @@ namespace NUnit.Engine.Runners.Tests
         [Test]
         public void RunAsync()
         {
-#if !NETCOREAPP2_0
+#if !NETCOREAPP2_1
             if (_runner is ProcessRunner || _runner is MultipleTestProcessRunner)
                 Assert.Ignore("RunAsync is not working for ProcessRunner");
 #endif

--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentDataBaseTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerStaticTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using System.IO;
 using NUnit.Framework;

--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -54,7 +54,7 @@ namespace NUnit.Engine.Services.Tests
         }
 
 
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
         [TestCase("mock-assembly.dll", false, typeof(NUnitNetStandardDriver))]
         [TestCase("mock-assembly.dll", true, typeof(NUnitNetStandardDriver))]
         [TestCase("notest-assembly.dll", false, typeof(NUnitNetStandardDriver))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -156,10 +156,10 @@ namespace NUnit.Engine.Services.Tests
             //May be null on mono
             Assume.That(Assembly.GetEntryAssembly(), Is.Not.Null, "Entry assembly is null, framework loading validation will be skipped.");
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             string other = "net35"; // Attempt to load the .NET 3.5 version of the extensions from the .NET Core 2.0 tests
 #elif NET35
-            string other = "netcoreapp2.0"; // Attempt to load the .NET Core 2.0 version of the extensions from the .NET 3.5 tests
+            string other = "netcoreapp2.1"; // Attempt to load the .NET Core 2.1 version of the extensions from the .NET 3.5 tests
 #endif
             var assemblyName = Path.Combine(GetSiblingDirectory(other), "nunit.engine.tests.dll");
             Assert.That(assemblyName, Does.Exist);
@@ -211,7 +211,7 @@ namespace NUnit.Engine.Services.Tests
 
         public static IEnumerable<TestCaseData> ValidCombos()
         {
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             Assembly netstandard = typeof(ExtensionService).Assembly;
             Assembly netcore = Assembly.GetExecutingAssembly();
 
@@ -233,7 +233,7 @@ namespace NUnit.Engine.Services.Tests
 
         public static IEnumerable<TestCaseData> InvalidTargetFrameworkCombos()
         {
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             Assembly netstandard = typeof(ExtensionService).Assembly;
             Assembly netcore = Assembly.GetExecutingAssembly();
 
@@ -246,7 +246,7 @@ namespace NUnit.Engine.Services.Tests
             Assembly netFramework = typeof(ExtensionService).Assembly;
 
             var extNetStandard = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("netstandard2.0"), "nunit.engine.dll"), false);
-            var extNetCore = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("netcoreapp2.0"), "nunit.engine.tests.dll"), false);
+            var extNetCore = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("netcoreapp2.1"), "nunit.engine.tests.dll"), false);
 
             yield return new TestCaseData(new FrameworkCombo(netFramework, extNetCore)).SetName("InvalidCombo(.NET Framework, .NET Core)");
 #endif
@@ -255,7 +255,7 @@ namespace NUnit.Engine.Services.Tests
 
         public static IEnumerable<TestCaseData> InvalidRunnerCombos()
         {
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
             Assembly netstandard = typeof(ExtensionService).Assembly;
             Assembly netcore = Assembly.GetExecutingAssembly();
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/InProcessTestRunnerFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/InProcessTestRunnerFactoryTests.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(_factory.Status, Is.EqualTo(ServiceStatus.Started), "Failed to start service");
         }
 
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
         [TestCase("x.dll", null, typeof(LocalTestRunner))]
         [TestCase("x.dll y.dll", null, typeof(LocalTestRunner))]
         [TestCase("x.dll y.dll z.dll", null, typeof(LocalTestRunner))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
@@ -72,7 +72,7 @@ namespace NUnit.Engine.Services.Tests
             return writer.GetType().Name;
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
         [Test]
         public void CanGetWriterUser()
         {

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1
 using NUnit.Framework;
 
 namespace NUnit.Engine.Services.Tests

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Services.Tests
     {
         private const string MOCK_ASSEMBLY = "mock-assembly.dll";
 
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
         private NUnitNetStandardDriver _driver;
 #else
         private NUnit3FrameworkDriver _driver;
@@ -45,7 +45,7 @@ namespace NUnit.Engine.Services.Tests
         public void LoadAssembly()
         {
             var mockAssemblyPath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
             _driver = new NUnitNetStandardDriver();
 #else
             var assemblyName = typeof(NUnit.Framework.TestAttribute).Assembly.GetName();

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -27,7 +27,7 @@ using NUnit.Framework;
 
 namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
 {
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP1_1 || NETCOREAPP2_1
     internal static class NetStandardTestCases
     {
         public class TestRunnerFactoryData : TestCaseData
@@ -68,7 +68,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                         }
                     });
 
-#if NETCOREAPP2_0
+#if NETCOREAPP2_1
                 yield return new TestRunnerFactoryData(
                     "SingleProject (list ctor)",
                     new TestPackage(new[] { "a.nunit" }),

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
     <OutputType Condition="'$(TargetFramework)'!='net35'">Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Fixes #693. Explanation in the issue