### PR TITLE
Sign NuGet Packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ matrix:
 #        - sudo installer -pkg dotnet-runtime-2.0.6-osx-x64.pkg -target /
 
 script:
-  - ./build.sh --target "Travis" --configuration "Release"
+  - ./build.sh --target=Travis --configuration=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ matrix:
         - sudo dpkg -i packages-microsoft-prod.deb
         - sudo apt-get install apt-transport-https
         - sudo apt-get update
-        - sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.2
-        - sudo apt-get install dotnet-runtime-2.1
+        - sudo apt-get install dotnet-sdk-2.2
 
 # macOS package restore currently taking >30 mins on Travis
 #    - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 sudo: required
 
 dotnet: 2.1.401
-mono: 5.10.0 # Need 5.2+ for the included MSBuild.
+mono: 6.6.0
 
 matrix:
   include:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
       sudo apt-get install apt-transport-https
       sudo apt-get update
       sudo apt-get install dotnet-sdk-2.2
-      ./build.sh --target Test --configuration Release
+      ./build.sh --target=Test --configuration=Release
     displayName: Build and test
 
   # Workaround for https://github.com/nunit/nunit/issues/3012#issuecomment-441517922
@@ -93,7 +93,7 @@ jobs:
     vmImage: macOS-10.13
   steps:
 
-  - bash: ./build.sh --target Test --configuration Release
+  - bash: ./build.sh --target=Test --configuration=Release
     displayName: Build and test
 
   # Workaround for https://github.com/nunit/nunit/issues/3012#issuecomment-441517922

--- a/build.cake
+++ b/build.cake
@@ -551,7 +551,7 @@ Task("PackageZip")
 Task("InstallSigningTool")
     .Does(() =>
     {
-        var result = StartProcess("dotnet.exe", new ProcessSettings {  Arguments = "tool install SignClient -g" });
+        var result = StartProcess("dotnet.exe", new ProcessSettings {  Arguments = "tool install SignClient" });
     });
 
 Task("SignPackages")

--- a/build.cake
+++ b/build.cake
@@ -554,9 +554,9 @@ Task("InstallSigningTool")
         var result = StartProcess("dotnet.exe", new ProcessSettings {  Arguments = "tool install SignClient -g" });
     });
 
-Task("SignNuGet")
+Task("SignPackages")
     .IsDependentOn("InstallSigningTool")
-    .IsDependentOn("PackageNuGet")
+    .IsDependentOn("Package")
     .Does(() =>
     {
         // Get the secret.
@@ -573,10 +573,10 @@ Task("SignNuGet")
         var signClientPath = Context.Tools.Resolve("SignClient.exe") ?? Context.Tools.Resolve("SignClient") ?? throw new Exception("Failed to locate sign tool");
 
         var settings = File("./signclient.json");
-        //var filter = File("./signclient.filter");
 
         // Get the files to sign.
-        var files = GetFiles(string.Concat(PACKAGE_DIR, "*.nupkg"));
+        var files = GetFiles(string.Concat(PACKAGE_DIR, "*.nupkg")) +
+            GetFiles(string.Concat(PACKAGE_DIR, "*.msi"));
 
         foreach(var file in files)
         {
@@ -587,7 +587,6 @@ Task("SignNuGet")
                 .Append("sign")
                 .AppendSwitchQuoted("-c", MakeAbsolute(settings.Path).FullPath)
                 .AppendSwitchQuoted("-i", MakeAbsolute(file).FullPath)
-                //.AppendSwitchQuoted("-f", MakeAbsolute(filter).FullPath)
                 .AppendSwitchQuotedSecret("-s", secret)
                 .AppendSwitchQuotedSecret("-r", user)
                 .AppendSwitchQuoted("-n", "NUnit.org")

--- a/build.config
+++ b/build.config
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+CAKE_VERSION=0.35.0
+DOTNET_VERSION=3.0.100

--- a/build.config
+++ b/build.config
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-CAKE_VERSION=0.35.0
-DOTNET_VERSION=3.0.100

--- a/build.ps1
+++ b/build.ps1
@@ -21,39 +21,51 @@ The build script target to run.
 The build configuration to use.
 .PARAMETER Verbosity
 Specifies the amount of information to be displayed.
-.PARAMETER Experimental
-Tells Cake to use the latest Roslyn release.
-.PARAMETER WhatIf
-Performs a dry run of the build script.
-No tasks will be executed.
-.PARAMETER Mono
-Tells Cake to use the Mono scripting engine.
+.PARAMETER ShowDescription
+Shows description about tasks.
+.PARAMETER DryRun
+Performs a dry run.
 .PARAMETER SkipToolPackageRestore
 Skips restoring of packages.
 .PARAMETER ScriptArgs
 Remaining arguments are added here.
 
 .LINK
-http://cakebuild.net
+https://cakebuild.net
 
 #>
 
 [CmdletBinding()]
 Param(
     [string]$Script = "build.cake",
-    [string]$Target = "Default",
-    [ValidateSet("Release", "Debug")]
-    [string]$Configuration = "Release",
+    [string]$Target,
+    [string]$Configuration,
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-    [string]$Verbosity = "Verbose",
-    [switch]$Experimental,
-    [Alias("DryRun","Noop")]
-    [switch]$WhatIf,
-    [switch]$Mono,
+    [string]$Verbosity,
+    [switch]$ShowDescription,
+    [Alias("WhatIf", "Noop")]
+    [switch]$DryRun,
     [switch]$SkipToolPackageRestore,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
+
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+    # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
+    # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
+    # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
+    # installed (.NET 4.5 is an in-place upgrade).
+    # PowerShell Core already has support for TLS 1.2 so we can skip this if running in that.
+    if (-not $IsCoreCLR) {
+        [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+    }
+  } catch {
+    Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
+  }
 
 [Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
 function MD5HashFile([string] $filePath)
@@ -80,6 +92,15 @@ function MD5HashFile([string] $filePath)
     }
 }
 
+function GetProxyEnabledWebClient
+{
+    $wc = New-Object System.Net.WebClient
+    $proxy = [System.Net.WebRequest]::GetSystemWebProxy()
+    $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+    $wc.Proxy = $proxy
+    return $wc
+}
+
 Write-Host "Preparing to run build script..."
 
 if(!$PSScriptRoot){
@@ -87,42 +108,29 @@ if(!$PSScriptRoot){
 }
 
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
+$ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
+$MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
 $NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
 $CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
 $NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
 $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
-
-# Should we use mono?
-$UseMono = "";
-if($Mono.IsPresent) {
-    Write-Verbose -Message "Using the Mono based scripting engine."
-    $UseMono = "-mono"
-}
-
-# Should we use the new Roslyn?
-$UseExperimental = "";
-if($Experimental.IsPresent -and !($Mono.IsPresent)) {
-    Write-Verbose -Message "Using experimental version of Roslyn."
-    $UseExperimental = "-experimental"
-}
-
-# Is this a dry run?
-$UseDryRun = "";
-if($WhatIf.IsPresent) {
-    $UseDryRun = "-dryrun"
-}
+$ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
+$MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
     Write-Verbose -Message "Creating tools directory..."
-    New-Item -Path $TOOLS_DIR -Type directory | out-null
+    New-Item -Path $TOOLS_DIR -Type Directory | Out-Null
 }
 
 # Make sure that packages.config exist.
 if (!(Test-Path $PACKAGES_CONFIG)) {
     Write-Verbose -Message "Downloading packages.config..."
-    try { (New-Object System.Net.WebClient).DownloadFile("http://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
+    try {
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG)
+    } catch {
         Throw "Could not download packages.config."
     }
 }
@@ -130,7 +138,7 @@ if (!(Test-Path $PACKAGES_CONFIG)) {
 # Try find NuGet.exe in path if not exists
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Trying to find nuget.exe in PATH..."
-    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_) }
+    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
     $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
     if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
         Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
@@ -142,14 +150,20 @@ if (!(Test-Path $NUGET_EXE)) {
 if (!(Test-Path $NUGET_EXE)) {
     Write-Verbose -Message "Downloading NuGet.exe..."
     try {
-        (New-Object System.Net.WebClient).DownloadFile($NUGET_URL, $NUGET_EXE)
+        $wc = GetProxyEnabledWebClient
+        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
     } catch {
         Throw "Could not download NuGet.exe."
     }
 }
 
 # Save nuget.exe path to environment to be available to child processed
-$ENV:NUGET_EXE = $NUGET_EXE
+$env:NUGET_EXE = $NUGET_EXE
+$env:NUGET_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
+    "mono `"$NUGET_EXE`""
+} else {
+    "`"$NUGET_EXE`""
+}
 
 # Restore tools from NuGet?
 if(-Not $SkipToolPackageRestore.IsPresent) {
@@ -157,24 +171,61 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     Set-Location $TOOLS_DIR
 
     # Check for changes in packages.config and remove installed tools if true.
-    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    [string] $md5Hash = MD5HashFile $PACKAGES_CONFIG
     if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
-      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+    ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
         Write-Verbose -Message "Missing or changed package.config hash..."
-        Remove-Item * -Recurse -Exclude packages.config,nuget.exe
+        Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
+        Remove-Item -Recurse -Force
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+    
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
 
     if ($LASTEXITCODE -ne 0) {
-        Throw "An error occured while restoring NuGet tools."
+        Throw "An error occurred while restoring NuGet tools."
     }
     else
     {
         $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
     }
-    Write-Verbose -Message ($NuGetOutput | out-string)
+    Write-Verbose -Message ($NuGetOutput | Out-String)
+
+    Pop-Location
+}
+
+# Restore addins from NuGet
+if (Test-Path $ADDINS_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $ADDINS_DIR
+
+    Write-Verbose -Message "Restoring addins from NuGet..."
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet addins."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | Out-String)
+
+    Pop-Location
+}
+
+# Restore modules from NuGet
+if (Test-Path $MODULES_PACKAGES_CONFIG) {
+    Push-Location
+    Set-Location $MODULES_DIR
+
+    Write-Verbose -Message "Restoring modules from NuGet..."
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
+
+    if ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred while restoring NuGet modules."
+    }
+
+    Write-Verbose -Message ($NuGetOutput | Out-String)
+
     Pop-Location
 }
 
@@ -183,7 +234,23 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
+$CAKE_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
+    "mono `"$CAKE_EXE`""
+} else {
+    "`"$CAKE_EXE`""
+}
+
+ # Build an array (not a string) of Cake arguments to be joined later
+$cakeArguments = @()
+if ($Script) { $cakeArguments += "`"$Script`"" }
+if ($Target) { $cakeArguments += "-target=`"$Target`"" }
+if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
+if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
+if ($ShowDescription) { $cakeArguments += "-showdescription" }
+if ($DryRun) { $cakeArguments += "-dryrun" }
+$cakeArguments += $ScriptArgs
+
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& $CAKE_EXE_INVOCATION $($cakeArguments -join " ")"
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,14 @@
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
+ADDINS_DIR=$TOOLS_DIR/Addins
+MODULES_DIR=$TOOLS_DIR/Modules
 NUGET_EXE=$TOOLS_DIR/nuget.exe
 CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
 PACKAGES_CONFIG=$TOOLS_DIR/packages.config
 PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
+ADDINS_PACKAGES_CONFIG=$ADDINS_DIR/packages.config
+MODULES_PACKAGES_CONFIG=$MODULES_DIR/packages.config
 
 # Define md5sum or md5 depending on Linux/OSX
 MD5_EXE=
@@ -24,24 +28,14 @@ fi
 
 # Define default arguments.
 SCRIPT="build.cake"
-TARGET="Default"
-CONFIGURATION="Release"
-VERBOSITY="verbose"
-DRYRUN=
-SHOW_VERSION=false
-SCRIPT_ARGUMENTS=()
+CAKE_ARGUMENTS=()
 
 # Parse arguments.
 for i in "$@"; do
     case $1 in
         -s|--script) SCRIPT="$2"; shift ;;
-        -t|--target) TARGET="$2"; shift ;;
-        -c|--configuration) CONFIGURATION="$2"; shift ;;
-        -v|--verbosity) VERBOSITY="$2"; shift ;;
-        -d|--dryrun) DRYRUN="-dryrun" ;;
-        --version) SHOW_VERSION=true ;;
-        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
-        *) SCRIPT_ARGUMENTS+=("$1") ;;
+        --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
+        *) CAKE_ARGUMENTS+=("$1") ;;
     esac
     shift
 done
@@ -54,9 +48,9 @@ fi
 # Make sure that packages.config exist.
 if [ ! -f "$TOOLS_DIR/packages.config" ]; then
     echo "Downloading packages.config..."
-    curl -Lsfo "$TOOLS_DIR/packages.config" http://cakebuild.net/download/bootstrapper/packages
+    curl -Lsfo "$TOOLS_DIR/packages.config" https://cakebuild.net/download/bootstrapper/packages
     if [ $? -ne 0 ]; then
-        echo "An error occured while downloading packages.config."
+        echo "An error occurred while downloading packages.config."
         exit 1
     fi
 fi
@@ -66,26 +60,52 @@ if [ ! -f "$NUGET_EXE" ]; then
     echo "Downloading NuGet..."
     curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
     if [ $? -ne 0 ]; then
-        echo "An error occured while downloading nuget.exe."
+        echo "An error occurred while downloading nuget.exe."
         exit 1
     fi
 fi
 
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
-if [ ! -f $PACKAGES_CONFIG_MD5 ] || [ "$( cat $PACKAGES_CONFIG_MD5 | sed 's/\r$//' )" != "$( $MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' )" ]; then
-    find . -type d ! -name . | xargs rm -rf
+if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
+    find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
 fi
 
 mono "$NUGET_EXE" install -ExcludeVersion
 if [ $? -ne 0 ]; then
-    echo "Could not restore NuGet packages."
+    echo "Could not restore NuGet tools."
     exit 1
 fi
 
-$MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' >| $PACKAGES_CONFIG_MD5
+$MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' >| "$PACKAGES_CONFIG_MD5"
 
 popd >/dev/null
+
+# Restore addins from NuGet.
+if [ -f "$ADDINS_PACKAGES_CONFIG" ]; then
+    pushd "$ADDINS_DIR" >/dev/null
+
+    mono "$NUGET_EXE" install -ExcludeVersion
+    if [ $? -ne 0 ]; then
+        echo "Could not restore NuGet addins."
+        exit 1
+    fi
+
+    popd >/dev/null
+fi
+
+# Restore modules from NuGet.
+if [ -f "$MODULES_PACKAGES_CONFIG" ]; then
+    pushd "$MODULES_DIR" >/dev/null
+
+    mono "$NUGET_EXE" install -ExcludeVersion
+    if [ $? -ne 0 ]; then
+        echo "Could not restore NuGet modules."
+        exit 1
+    fi
+
+    popd >/dev/null
+fi
 
 # Make sure that Cake has been installed.
 if [ ! -f "$CAKE_EXE" ]; then
@@ -94,8 +114,4 @@ if [ ! -f "$CAKE_EXE" ]; then
 fi
 
 # Start Cake
-if $SHOW_VERSION; then
-    exec mono "$CAKE_EXE" -version
-else
-    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
-fi
+exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"

--- a/signclient.json
+++ b/signclient.json
@@ -1,0 +1,13 @@
+{
+  "SignClient": {
+    "AzureAd": {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "ClientId": "c248d68a-ba6f-4aa9-8a68-71fe872063f8",
+      "TenantId": "16076fdc-fcc1-4a15-b1ca-32c9a255900e"
+    },
+    "Service": {
+      "Url": "https://codesign.dotnetfoundation.org/",
+      "ResourceId": "https://SignService/3c30251f-36f3-490b-a955-520addb85001"
+    }
+  }
+}

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.32.1" />
+    <package id="Cake" version="0.35.0" />
 </packages>


### PR DESCRIPTION
Fixes #691 

This is the first pass at signing the NuGet packages. We could also sign the WiX installer, the Choco packages and the ZIP file if we want, but we'll need to make sure everything is installed on the build servers if we want to do the signing there. Right now, it just signs the NuGet packages, but I can easily extend it.

As I see it, we currently have a couple of options.

1. If we want to continue to build and release on the developer machines, I can extend this to sign everything. I can share the environment variables that need to be set with @ChrisMaddock so he can do a release.
2. If we want to build, sign and release from Azure DevOps, I need to do the following;
    - Extend the Cake script to sign everything
    - Figure out how to install WiX on the build machines
    - Setup the Azure DevOps build to build and sign the release branch?

Either way, I should probably extend the script to sign everything so I'll do that. I just wanted to get this out for review. 

@ChrisMaddock if you want to do a release soon, the first option is probably easiest then we can work on the second option as a second PR. What do you think?

At the moment, I am running the command `.\build.ps1 -Target SignNuGet` (may change the target to Sign) and the target outputs the following;

```
========================================
SignNuGet
========================================
Signing C:/Src/nunit/nunit-console/package/NUnit.Console.3.11.0.nupkg...
Submitting 'C:\Src\nunit\nunit-console\package\NUnit.Console.3.11.0.nupkg' for signing.
Successfully signed 'C:\Src\nunit\nunit-console\package\NUnit.Console.3.11.0.nupkg' in 3551 ms
Signing C:/Src/nunit/nunit-console/package/NUnit.ConsoleRunner.3.11.0.nupkg...
Submitting 'C:\Src\nunit\nunit-console\package\NUnit.ConsoleRunner.3.11.0.nupkg' for signing.
Successfully signed 'C:\Src\nunit\nunit-console\package\NUnit.ConsoleRunner.3.11.0.nupkg' in 3895 ms
Signing C:/Src/nunit/nunit-console/package/NUnit.Engine.3.11.0.nupkg...
Submitting 'C:\Src\nunit\nunit-console\package\NUnit.Engine.3.11.0.nupkg' for signing.
Successfully signed 'C:\Src\nunit\nunit-console\package\NUnit.Engine.3.11.0.nupkg' in 3962 ms
Signing C:/Src/nunit/nunit-console/package/NUnit.Engine.Api.3.11.0.nupkg...
Submitting 'C:\Src\nunit\nunit-console\package\NUnit.Engine.Api.3.11.0.nupkg' for signing.
Successfully signed 'C:\Src\nunit\nunit-console\package\NUnit.Engine.Api.3.11.0.nupkg' in 2317 ms
Signing C:/Src/nunit/nunit-console/package/nunit.engine.netstandard.3.11.0.nupkg...
Submitting 'C:\Src\nunit\nunit-console\package\nunit.engine.netstandard.3.11.0.nupkg' for signing.
Successfully signed 'C:\Src\nunit\nunit-console\package\nunit.engine.netstandard.3.11.0.nupkg' in 2096 ms
Signing C:/Src/nunit/nunit-console/package/NUnit.Runners.3.11.0.nupkg...
Submitting 'C:\Src\nunit\nunit-console\package\NUnit.Runners.3.11.0.nupkg' for signing.
Successfully signed 'C:\Src\nunit\nunit-console\package\NUnit.Runners.3.11.0.nupkg' in 1965 ms
```