### PR TITLE
Labels: Add OnOutputOnly option, and deprecate On/All

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/TestEventHandlerTests.cs
@@ -76,21 +76,18 @@ namespace NUnit.ConsoleRunner.Tests
         {
             // Start Events
             new TestCaseData("<start-test fullname='SomeName'/>", "Off", ""),
-            new TestCaseData("<start-test fullname='SomeName'/>", "On", ""),
-            new TestCaseData("<start-test fullname='SomeName'/>", "All", "=> SomeName\r\n"),
+            new TestCaseData("<start-test fullname='SomeName'/>", "OnOutputOnly", ""),
             new TestCaseData("<start-test fullname='SomeName'/>", "Before", "=> SomeName\r\n"),
             new TestCaseData("<start-test fullname='SomeName'/>", "After", ""),
             new TestCaseData("<start-test fullname='SomeName'/>", "BeforeAndAfter", "=> SomeName\r\n"),
             new TestCaseData("<start-suite fullname='SomeName'/>", "Off", ""),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "On", ""),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "All", ""),
+            new TestCaseData("<start-suite fullname='SomeName'/>", "OnOutputOnly", ""),
             new TestCaseData("<start-suite fullname='SomeName'/>", "Before", ""),
             new TestCaseData("<start-suite fullname='SomeName'/>", "After", ""),
             new TestCaseData("<start-suite fullname='SomeName'/>", "BeforeAndAfter", ""),
             // Finish Events - No Output
             new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "Off", ""),
-            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "On", ""),
-            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "All", ""),
+            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "OnOutputOnly", ""),
             new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "Before", ""),
             new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "After", "Passed => SomeName\r\n"),
             new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "BeforeAndAfter", "Passed => SomeName\r\n"),
@@ -111,8 +108,7 @@ namespace NUnit.ConsoleRunner.Tests
             new TestCaseData("<test-case fullname='SomeName' result='Skipped' label='Ignored'/>", "After", "Ignored => SomeName\r\n"),
             new TestCaseData("<test-case fullname='SomeName' result='Skipped' label='Ignored'/>", "BeforeAndAfter", "Ignored => SomeName\r\n"),
             new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "Off", ""),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "On", ""),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "All", ""),
+            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "OnOutputOnly", ""),
             new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "Before", ""),
             new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "After", ""),
             new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "BeforeAndAfter", ""),
@@ -123,11 +119,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "OUTPUT"),
             new TestCaseData(
                 "<test-case fullname='SomeName' result='Passed'><output>OUTPUT</output></test-case>",
-                "On",
-                "=> SomeName\r\nOUTPUT"),
-            new TestCaseData(
-                "<test-case fullname='SomeName' result='Passed'><output>OUTPUT</output></test-case>",
-                "All",
+                "OnOutputOnly",
                 "=> SomeName\r\nOUTPUT"),
             new TestCaseData(
                 "<test-case fullname='SomeName' result='Passed'><output>OUTPUT</output></test-case>",
@@ -207,11 +199,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "OUTPUT"),
             new TestCaseData(
                 "<test-suite fullname='SomeName' result='Passed'><output>OUTPUT</output></test-suite>",
-                "On",
-                "=> SomeName\r\nOUTPUT"),
-            new TestCaseData(
-                "<test-suite fullname='SomeName' result='Passed'><output>OUTPUT</output></test-suite>",
-                "All",
+                "OnOutputOnly",
                 "=> SomeName\r\nOUTPUT"),
             new TestCaseData(
                 "<test-suite fullname='SomeName' result='Passed'><output>OUTPUT</output></test-suite>",
@@ -232,11 +220,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "OUTPUT"),
             new TestCaseData(
                 "<test-output testname='SomeName'>OUTPUT</test-output>",
-                "On",
-                "=> SomeName\r\nOUTPUT"),
-            new TestCaseData(
-                "<test-output testname='SomeName'>OUTPUT</test-output>",
-                "All",
+                "OnOutputOnly",
                 "=> SomeName\r\nOUTPUT"),
             new TestCaseData(
                 "<test-output testname='SomeName'>OUTPUT</test-output>",
@@ -308,11 +292,7 @@ namespace NUnit.ConsoleRunner.Tests
                 "OUTPUT"),
             new TestCaseData(
                 SingleTest_StartAndFinish,
-                "On",
-                "=> TestName\r\nOUTPUT"),
-            new TestCaseData(
-                SingleTest_StartAndFinish,
-                "All",
+                "OnOutputOnly",
                 "=> TestName\r\nOUTPUT"),
             new TestCaseData(
                 SingleTest_StartAndFinish,
@@ -335,15 +315,7 @@ from
 TEST1"),
             new TestCaseData(
                 SingleTest_ImmediateOutput,
-                "On",
-@"=> TEST1
-Immediate output from TEST1
-Output
-from
-TEST1"),
-            new TestCaseData(
-                SingleTest_ImmediateOutput,
-                "All",
+                "OnOutputOnly",
 @"=> TEST1
 Immediate output from TEST1
 Output
@@ -384,13 +356,7 @@ Passed => TEST1
 Output from Suite TEST1"),
             new TestCaseData(
                 SingleTest_SuiteFinish,
-                "On",
-@"=> TEST1
-Immediate output from TEST1
-Output from Suite TEST1"),
-            new TestCaseData(
-                SingleTest_SuiteFinish,
-                "All",
+                "OnOutputOnly",
 @"=> TEST1
 Immediate output from TEST1
 Output from Suite TEST1"),
@@ -419,14 +385,7 @@ Output from Suite TEST1"),
 Output from second test"),
             new TestCaseData(
                 TwoTests_SequentialExecution,
-                "On",
-@"=> TEST1
-Output from first test
-=> TEST2
-Output from second test"),
-            new TestCaseData(
-                TwoTests_SequentialExecution,
-                "All",
+                "OnOutputOnly",
 @"=> TEST1
 Output from first test
 => TEST2
@@ -467,23 +426,9 @@ Output from first test
 Output from second test"),
             new TestCaseData(
                 TwoTests_InterleavedExecution,
-                "On",
+                "OnOutputOnly",
 @"=> TEST1
 Immediate output from first testAnother immediate output from first test
-=> TEST2
-Immediate output from second test
-=> TEST1
-Output from first test
-=> TEST2
-Output from second test"),
-            new TestCaseData(
-                TwoTests_InterleavedExecution,
-                "All",
-@"=> TEST1
-Immediate output from first test
-=> TEST2
-=> TEST1
-Another immediate output from first test
 => TEST2
 Immediate output from second test
 => TEST1
@@ -544,17 +489,7 @@ Output from second test
 Output from first test"),
             new TestCaseData(
                 TwoTests_NestedExecution,
-                "On",
-@"=> TEST1
-Immediate output from first test
-=> TEST2
-Immediate output from second test
-Output from second test
-=> TEST1
-Output from first test"),
-            new TestCaseData(
-                TwoTests_NestedExecution,
-                "All",
+                "OnOutputOnly",
 @"=> TEST1
 Immediate output from first test
 => TEST2

--- a/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleOptions.cs
@@ -296,8 +296,26 @@ namespace NUnit.Common
             this.Add("noresult", "Don't save any test results.",
                 v => noresult = v != null);
 
-            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, On, Before, After, BeforeAndAfter, All",
-                v => DisplayTestLabels = parser.RequiredValue(v, "--labels", "Off", "On", "Before", "After", "BeforeAndAfter", "All"));
+            this.Add("labels=", "Specify whether to write test case names to the output. Values: Off, OnOutputOnly, Before, After, BeforeAndAfter",
+                v => {
+                        string deprecationWarning = null;
+
+                        if (v.Equals("On", StringComparison.OrdinalIgnoreCase))
+                        {
+                            deprecationWarning = "labels=On is deprecated and will be removed in a future release. Please use labels=OnOutputOnly instead.";
+                            v = "OnOutputOnly";
+                        }
+                        else if (v.Equals("All", StringComparison.OrdinalIgnoreCase))
+                        {
+                            deprecationWarning = "labels=All is deprecated and will be removed in a future release. Please use labels=Before instead.";
+                            v = "Before";
+                        } 
+
+                        if (deprecationWarning != null && !WarningMessages.Contains(deprecationWarning))
+                            WarningMessages.Add(deprecationWarning);
+
+                        DisplayTestLabels = parser.RequiredValue(v, "--labels", "Off", "OnOutputOnly", "Before", "After", "BeforeAndAfter");
+                });
 
             this.Add("test-name-format=", "Non-standard naming pattern to use in generating test names.",
                 v => DefaultTestNamePattern = parser.RequiredValue(v, "--test-name-format"));

--- a/src/NUnitConsole/nunit3-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit3-console/TestEventHandler.cs
@@ -51,9 +51,9 @@ namespace NUnit.ConsoleRunner
             _outWriter = outWriter;
 
             labelsOption = labelsOption.ToUpperInvariant();
-            _displayBeforeTest = labelsOption == "ALL" || labelsOption == "BEFORE" || labelsOption == "BEFOREANDAFTER";
+            _displayBeforeTest = labelsOption == "BEFORE" || labelsOption == "BEFOREANDAFTER";
             _displayAfterTest = labelsOption == "AFTER" || labelsOption == "BEFOREANDAFTER";
-            _displayBeforeOutput = _displayBeforeTest || _displayAfterTest || labelsOption == "ON";
+            _displayBeforeOutput = _displayBeforeTest || _displayAfterTest || labelsOption == "ONOUTPUTONLY";
         }
 
         public void OnTestEvent(string report)


### PR DESCRIPTION
Fixes #636, the changes as discussed in #630.

This adds `OnOutputOnly` as a more explicit name for `On`, and deprecates both `On` and `All` - which has been a duplicate of `Before` for a few releases now. Deprecation is done in the same way as the existing deprecated `--params` option.

The reasoning for this was to reduce ambiguity in the API. The original options were just `On` and `Off`. As new options have been added since version 3.0, `On` and `All` have become ambiguous in meaning. `On` currently represents the most limited option of label output available (only displaying labels for test output, and `All` displays less labels than the new `BeforeAndAfter` option. The deprecation message explains which alternative to switch to in each case, and looks like the below.

![image](https://user-images.githubusercontent.com/4837132/71644792-4e7a3500-2cc6-11ea-9a07-8ac7f98a20a1.png)

Not the only affect of this is an additional line in the console output - it does not change the exit code of the console, or the TestResults xml.

The old labels are converted to their new terms at the very top level of the console, and all lower functionality and tests removed, to make for easier removal in future. New tests have been added to cover the conversion, while the deprecated options remain. 🙂 