### PR TITLE
[WIP] Workaround to load assemblies not located in same dir as engine under .NET Core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - sudo apt-get install apt-transport-https
         - sudo apt-get update
         - sudo apt-get install dotnet-sdk-2.2
+        - sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.0.16
 
 # macOS package restore currently taking >30 mins on Travis
 #    - os: osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,8 @@ jobs:
       sudo dpkg -i packages-microsoft-prod.deb
       sudo apt-get install apt-transport-https
       sudo apt-get update
-      sudo apt-get install dotnet-sdk-2.2
+      sudo apt-get install dotnet-sdk-1.2
+      sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.0.16
       ./build.sh --target=Test --configuration=Release
     displayName: Build and test
 

--- a/build.cake
+++ b/build.cake
@@ -317,9 +317,9 @@ Task("TestNetStandard16Engine")
         if (IsDotNetCoreInstalled)
         {
             RunDotnetCoreTests(
-                NETCORE21_CONSOLE,
-                NETCOREAPP11_BIN_DIR,
                 ENGINE_TESTS,
+                NETCOREAPP11_BIN_DIR,
+                "",
                 "netcoreapp1.1",
                 ref ErrorDetail);
         }

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -17,4 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\NUnitEngine\nunit.engine.api\nunit.engine.api.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+    <PackageReference Include="Mono.Cecil" Version="0.10.0" developmentDependency="true" />
+  </ItemGroup>
 </Project>

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+
+using System.IO;
 #if NETSTANDARD
 using System;
 using System.Linq;
@@ -76,15 +78,24 @@ namespace NUnit.Engine.Drivers
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
 
             var assemblyRef = AssemblyDefinition.ReadAssembly(testAssembly);
+#if NETSTANDARD1_6
             _testAssembly = Assembly.Load(new AssemblyName(assemblyRef.FullName));
+#else
+            _testAssembly = Assembly.LoadFrom(testAssembly);
+#endif
             if(_testAssembly == null)
                 throw new NUnitEngineException(string.Format(FAILED_TO_LOAD_TEST_ASSEMBLY, assemblyRef.FullName));
 
+#if NETSTANDARD1_6
             var nunitRef = assemblyRef.MainModule.AssemblyReferences.Where(reference => reference.Name.Equals("nunit.framework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
             if (nunitRef == null)
                 throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 
             var nunit = Assembly.Load(new AssemblyName(nunitRef.FullName));
+#else
+            var nunit = Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(testAssembly), "nunit.framework.dll"));
+#endif
+
             if (nunit == null)
                 throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 


### PR DESCRIPTION
Fixes #710. This is a hack for 3.11, rather than the proper solution.

This uses `Assembly.LoadFrom` in place of `Assembly.Load` to allow the engine to load assemblies which are not located in the same directory as itself. (I expect this is why we haven't seen this issue before, as the engine is always located in the same dir as the test assembly when used with the adapter.) It uses a bit of a hack to assume the framework also sits in the same dir.

The proper solution, I believe, would be to use `AssemblyLoadContext`. This is only available in .NET Core, and not .NET Standard - meaning we'd need to either convert the engine to .NET Core, or create a .NET Core agent. The latter is in our pipeline anyway - but there's a few bigger items in the way first (Replacing .NET remoting being the key one.)

Note this is only possible for the .NET Standard 2.0 build - .NET Standard 1.6 is stuck with the restriction that the test assembly and engine must be copied to the same directory. Given .NET Standard 1.6 is no longer supported by the framework (and it's already been mentioned before) - I'm hoping we can support from the next engine release.