### PR TITLE
Propagate settings up from single sub package

### DIFF
--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -158,6 +158,8 @@ namespace NUnit.Engine
         /// <returns></returns>
         public T GetSetting<T>(string name, T defaultSetting)
         {
+            if (SubPackages != null && SubPackages.Count == 1 && SubPackages[0].Settings != null)
+                return SubPackages[0].GetSetting<T>(name, defaultSetting);
             return Settings.ContainsKey(name)
                 ? (T)Settings[name]
                 : defaultSetting;


### PR DESCRIPTION
For instance, this makes settings from nunit project files available at top level. This fixes a regression since 3.10.

I guard both SubPackages and Settings against null, since there is a constructor that doesn't always initialize them.