### PR TITLE
Issue-391:To provide useful error message when agent crashes with StackOverflow exception

### DIFF
--- a/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
+++ b/src/NUnitEngine/nunit-agent/AgentExitCodes.cs
@@ -32,5 +32,6 @@ namespace NUnit.Common
         public const int DEBUGGER_NOT_IMPLEMENTED = -4;
         public const int UNABLE_TO_LOCATE_AGENCY = -5;
         public const int UNEXPECTED_EXCEPTION = -100;
+        public const int STACK_OVERFLOW_EXCEPTION = -1073741571;
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -252,50 +252,23 @@ namespace NUnit.Engine.Services
                 case AgentExitCodes.UNABLE_TO_LOCATE_AGENCY:
                     errorMsg = "Remote test agent unable to locate agency process.";
                     break;
-                //case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
-                //    errorMsg = "Remote test agent was terminated due to a StackOverFlow exception in one of the tests.";
-                //    break;
+                case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
+                    if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                    {
+                        errorMsg = "Remote test agent was terminated due to a stack overflow.";
+                    }
+                    else
+                    {
+                        errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
+                    }
+                    break;
                 default:
-                    //errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
-                    errorMsg = GetDefaultError(process.ExitCode);
+                    errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
                     break;
             }
 
             throw new NUnitEngineException(errorMsg);
         }
-
-        private string GetDefaultError(int errorCode)
-        {
-            string defaultErrorMessage = $"Remote test agent exited with non-zero exit code {errorCode}";
-
-            switch (Environment.OSVersion.Platform)
-            {
-                case PlatformID.Win32NT:
-                    return GetWindowsError(errorCode);
-
-                case PlatformID.Unix:
-                    return defaultErrorMessage;
-
-                case PlatformID.MacOSX:
-                    return defaultErrorMessage;
-
-                default:
-                    return defaultErrorMessage;
-            }
-        }
-
-        private string GetWindowsError(int errorCode)
-        {
-            switch (errorCode)
-            {
-                case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
-                    return "Remote test agent was terminated due to a stack overflow.";
-
-                default:
-                    return $"Remote test agent exited with non-zero exit code {errorCode}";
-            }
-        }
-
 
         public IServiceLocator ServiceContext { get; set; }
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -252,6 +252,9 @@ namespace NUnit.Engine.Services
                 case AgentExitCodes.UNABLE_TO_LOCATE_AGENCY:
                     errorMsg = "Remote test agent unable to locate agency process.";
                     break;
+                case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
+                    errorMsg = "Remote test agent was terminated due to a StackOverFlow exception in one of the tests.";
+                    break;
                 default:
                     errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
                     break;

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -252,16 +252,50 @@ namespace NUnit.Engine.Services
                 case AgentExitCodes.UNABLE_TO_LOCATE_AGENCY:
                     errorMsg = "Remote test agent unable to locate agency process.";
                     break;
-                case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
-                    errorMsg = "Remote test agent was terminated due to a StackOverFlow exception in one of the tests.";
-                    break;
+                //case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
+                //    errorMsg = "Remote test agent was terminated due to a StackOverFlow exception in one of the tests.";
+                //    break;
                 default:
-                    errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
+                    //errorMsg = $"Remote test agent exited with non-zero exit code {process.ExitCode}";
+                    errorMsg = GetDefaultError(process.ExitCode);
                     break;
             }
 
             throw new NUnitEngineException(errorMsg);
         }
+
+        private string GetDefaultError(int errorCode)
+        {
+            string defaultErrorMessage = $"Remote test agent exited with non-zero exit code {errorCode}";
+
+            switch (Environment.OSVersion.Platform)
+            {
+                case PlatformID.Win32NT:
+                    return GetWindowsError(errorCode);
+
+                case PlatformID.Unix:
+                    return defaultErrorMessage;
+
+                case PlatformID.MacOSX:
+                    return defaultErrorMessage;
+
+                default:
+                    return defaultErrorMessage;
+            }
+        }
+
+        private string GetWindowsError(int errorCode)
+        {
+            switch (errorCode)
+            {
+                case AgentExitCodes.STACK_OVERFLOW_EXCEPTION:
+                    return "Remote test agent was terminated due to a stack overflow.";
+
+                default:
+                    return $"Remote test agent exited with non-zero exit code {errorCode}";
+            }
+        }
+
 
         public IServiceLocator ServiceContext { get; set; }
 


### PR DESCRIPTION
Added a case to handle exit code of `-1073741571` and provide meaningful message to user.