### PR TITLE
Use same current directory for agent as is being used by the runner

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Internal/ServerBase.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/ServerBase.cs
@@ -54,7 +54,7 @@ namespace NUnit.Engine.Internal
         }
         
         // Currently virtual to allow NSubstitute to mock it. In fact, it will
-        // probably be virtual or abstract at some point, if we implemment
+        // probably be virtual or abstract at some point, if we implement
         // alternate transports for different runtime targets
         public virtual string ServerUrl
         {

--- a/src/NUnitEngine/nunit.engine.core/Internal/ServerBase.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/ServerBase.cs
@@ -52,8 +52,11 @@ namespace NUnit.Engine.Internal
             this.uri = uri;
             this.port = port;
         }
-
-        public string ServerUrl
+        
+        // Currently virtual to allow NSubstitute to mock it. In fact, it will
+        // probably be virtual or abstract at some point, if we implemment
+        // alternate transports for different runtime targets
+        public virtual string ServerUrl
         {
             get { return string.Format("tcp://127.0.0.1:{0}/{1}", port, uri); }
         }

--- a/src/NUnitEngine/nunit.engine.tests/Integration/RemoteAgentTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/RemoteAgentTests.cs
@@ -7,7 +7,7 @@ namespace NUnit.Engine.Tests.Integration
 {
     public sealed class RemoteAgentTests : IntegrationTests
     {
-        [Test]
+        [Test, Ignore("No longer works with multiple agents")]
         public void Explore_does_not_throw_SocketException()
         {
             using (var runner = new RunnerInDirectoryWithoutFramework())

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
@@ -134,6 +134,12 @@ namespace NUnit.Engine.Services
             Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS + " --work=WORKDIRECTORY"));
         }
 
+        [Test]
+        public void WorkingDirectory()
+        {
+            Assert.That(GetAgentProcess().StartInfo.WorkingDirectory, Is.EqualTo(Environment.CurrentDirectory));
+        }
+
         private AgentProcess GetAgentProcess()
         {
             return new AgentProcess(_agency, _package, AGENT_ID);

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
@@ -1,0 +1,143 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric Engine contributors.
+// Licensed under the MIT License. See LICENSE.txt in root directory.
+// ***********************************************************************
+
+#if NETFRAMEWORK
+using System;
+using System.IO;
+using System.Diagnostics;
+using NUnit.Framework;
+using NSubstitute;
+
+namespace NUnit.Engine.Services
+{
+    public class AgentProcessTests
+    {
+        private TestAgency _agency;
+        private TestPackage _package;
+        private readonly static Guid AGENT_ID = Guid.NewGuid();
+        private const string REMOTING_URL = "tcp://127.0.0.1:1234/TestAgency";
+        private readonly string REQUIRED_ARGS = $"{AGENT_ID} {REMOTING_URL} --pid={Process.GetCurrentProcess().Id}";
+
+        [SetUp]
+        public void SetUp()
+        {
+            _agency = Substitute.For<TestAgency>();
+            _agency.ServerUrl.ReturnsForAnyArgs(REMOTING_URL);
+            _package = new TestPackage("junk.dll");
+            // Only required setting, some tests may change this
+            _package.Settings[EnginePackageSettings.RuntimeFramework] = "net-4.5";
+        }
+
+        [TestCase("net-4.5", false, "../agents/net40/nunit-agent.exe")]
+        [TestCase("net-4.5", true, "../agents/net40/nunit-agent-x86.exe")]
+        [TestCase("net-4.0", false, "../agents/net40/nunit-agent.exe")]
+        [TestCase("net-4.0", true, "../agents/net40/nunit-agent-x86.exe")]
+        [TestCase("net-3.5", false, "../agents/net20/nunit-agent.exe")]
+        [TestCase("net-3.5", true, "../agents/net20/nunit-agent-x86.exe")]
+        [TestCase("net-2.0", false, "../agents/net20/nunit-agent.exe")]
+        [TestCase("net-2.0", true, "../agents/net20/nunit-agent-x86.exe")]
+        //[TestCase("netcore-2.1", false, "agents/netcoreapp2.1/testcentric-agent.dll")]
+        //[TestCase("netcore-2.1", true, "agents/netcoreapp2.1/testcentric-agent-x86.dll")]
+        //[TestCase("netcore-1.1", false, "agents/netcoreapp1.1/testcentric-agent.dll")]
+        //[TestCase("netcore-1.1", true, "agents/netcoreapp1.1/testcentric-agent-x86.dll")]
+        public void AgentSelection(string runtime, bool x86, string agentPath)
+        {
+            _package.Settings[EnginePackageSettings.RuntimeFramework] = runtime;
+            _package.Settings[EnginePackageSettings.RunAsX86] = x86;
+
+            var agentProcess = GetAgentProcess();
+            agentPath = Path.Combine(TestContext.CurrentContext.TestDirectory, agentPath);
+
+            // NOTE: the file doesn't actually exist at this location during unit
+            // testing, but it's where it will be found once the app is installed.
+            Assert.That(agentProcess.AgentExePath, Is.SamePath(agentPath));
+        }
+
+        [TestCase("net-4.5")]
+        [TestCase("net-4.0")]
+        [TestCase("net-3.5")]
+        [TestCase("net-2.0")]
+        [TestCase("mono-4.5")]
+        [TestCase("mono-4.0")]
+        [TestCase("mono-2.0")]
+        public void DefaultValues(string framework)
+        {
+            _package.Settings[EnginePackageSettings.RuntimeFramework] = framework;
+            var process = GetAgentProcess();
+
+            Assert.That(process.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS));
+
+            Assert.True(process.EnableRaisingEvents, "EnableRaisingEvents");
+
+            var startInfo = process.StartInfo;
+            Assert.False(startInfo.UseShellExecute, "UseShellExecute");
+            Assert.True(startInfo.CreateNoWindow, "CreateNoWindow");
+            Assert.False(startInfo.LoadUserProfile, "LoadUserProfile");
+
+            var targetRuntime = RuntimeFramework.Parse(framework);
+            if (targetRuntime.Runtime == RuntimeType.Mono)
+            {
+                string monoOptions = "--runtime=v" + targetRuntime.ClrVersion.ToString(3);
+                Assert.That(startInfo.FileName, Is.EqualTo(RuntimeFramework.MonoExePath));
+                Assert.That(startInfo.Arguments, Is.EqualTo(
+                    $"{monoOptions} \"{process.AgentExePath}\" {process.AgentArgs}"));
+            }
+            else
+            {
+                Assert.That(startInfo.FileName, Is.EqualTo(process.AgentExePath));
+                Assert.That(startInfo.Arguments, Is.EqualTo(process.AgentArgs.ToString()));
+            }
+        }
+
+        [Test]
+        public void DebugTests()
+        {
+            _package.Settings[EnginePackageSettings.DebugTests] = true;
+            var agentProcess = GetAgentProcess();
+
+            // Not reflected in args because framework handles it
+            Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS));
+        }
+
+        [Test]
+        public void DebugAgent()
+        {
+            _package.Settings[EnginePackageSettings.DebugAgent] = true;
+            var agentProcess = GetAgentProcess();
+            Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS + " --debug-agent"));
+        }
+
+
+        [Test]
+        public void LoadUserProfile()
+        {
+            _package.Settings[EnginePackageSettings.LoadUserProfile] = true;
+            var agentProcess = GetAgentProcess();
+            Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS));
+        }
+
+        [Test]
+        public void TraceLevel()
+        {
+            _package.Settings[EnginePackageSettings.InternalTraceLevel] = "Debug";
+            var agentProcess = GetAgentProcess();
+            Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS + " --trace=Debug"));
+        }
+
+        [Test]
+        public void WorkDirectory()
+        {
+            _package.Settings[EnginePackageSettings.WorkDirectory] = "WORKDIRECTORY";
+            var agentProcess = GetAgentProcess();
+            Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS + " --work=WORKDIRECTORY"));
+        }
+
+        private AgentProcess GetAgentProcess()
+        {
+            return new AgentProcess(_agency, _package, AGENT_ID);
+        }
+    }
+}
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.cs
@@ -40,14 +40,14 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
-            Assert.That(() => database.Start(DummyAgent.Id, DummyProcess), Throws.ArgumentException.With.Property("ParamName").EqualTo("agentId"));
+            database.AddAgent(DummyAgent.Id, DummyProcess);
+            Assert.That(() => database.AddAgent(DummyAgent.Id, DummyProcess), Throws.ArgumentException.With.Property("ParamName").EqualTo("agentId"));
 
             database.Register(DummyAgent);
-            Assert.That(() => database.Start(DummyAgent.Id, DummyProcess), Throws.ArgumentException.With.Property("ParamName").EqualTo("agentId"));
+            Assert.That(() => database.AddAgent(DummyAgent.Id, DummyProcess), Throws.ArgumentException.With.Property("ParamName").EqualTo("agentId"));
 
             database.MarkTerminated(DummyAgent.Id);
-            Assert.That(() => database.Start(DummyAgent.Id, DummyProcess), Throws.ArgumentException.With.Property("ParamName").EqualTo("agentId"));
+            Assert.That(() => database.AddAgent(DummyAgent.Id, DummyProcess), Throws.ArgumentException.With.Property("ParamName").EqualTo("agentId"));
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             database.Register(DummyAgent);
             Assert.That(() => database.Register(DummyAgent), Throws.ArgumentException.With.Property("ParamName").EqualTo("agent"));
         }
@@ -73,7 +73,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             database.MarkTerminated(DummyAgent.Id);
             Assert.That(() => database.Register(DummyAgent), Throws.ArgumentException.With.Property("ParamName").EqualTo("agent"));
         }
@@ -99,7 +99,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             Assert.That(database.IsReady(DummyAgent.Id, out _), Is.False);
         }
 
@@ -108,7 +108,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             database.Register(DummyAgent);
             Assert.That(database.IsReady(DummyAgent.Id, out var registeredAgent), Is.True);
             Assert.That(registeredAgent, Is.SameAs(DummyAgent));
@@ -119,7 +119,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             database.Register(DummyAgent);
             database.MarkTerminated(DummyAgent.Id);
             Assert.That(database.IsReady(DummyAgent.Id, out _), Is.False);
@@ -138,7 +138,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             Assert.That(database.IsAgentProcessActive(DummyAgent.Id, out var process), Is.True);
             Assert.That(process, Is.SameAs(DummyProcess));
         }
@@ -148,7 +148,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             database.Register(DummyAgent);
             Assert.That(database.IsAgentProcessActive(DummyAgent.Id, out var process), Is.True);
             Assert.That(process, Is.SameAs(DummyProcess));
@@ -159,7 +159,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var database = new AgentStore();
 
-            database.Start(DummyAgent.Id, DummyProcess);
+            database.AddAgent(DummyAgent.Id, DummyProcess);
             database.Register(DummyAgent);
             database.MarkTerminated(DummyAgent.Id);
             Assert.That(database.IsAgentProcessActive(DummyAgent.Id, out _), Is.False);
@@ -179,7 +179,7 @@ namespace NUnit.Engine.Services.Tests
                     Assert.That(database.IsAgentProcessActive(id, out _), Is.False);
                     Assert.That(database.IsReady(id, out _), Is.False);
 
-                    database.Start(id, DummyProcess);
+                    database.AddAgent(id, DummyProcess);
                     Assert.That(database.IsAgentProcessActive(id, out _), Is.True);
                     Assert.That(database.IsReady(id, out _), Is.False);
 

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -48,6 +48,7 @@ namespace NUnit.Engine.Services
 
             StartInfo.UseShellExecute = false;
             StartInfo.CreateNoWindow = true;
+            StartInfo.WorkingDirectory = Environment.CurrentDirectory;
             EnableRaisingEvents = true;
 
             if (TargetRuntime.Runtime == RuntimeType.Mono)

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -1,0 +1,108 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric Engine contributors.
+// Licensed under the MIT License. See LICENSE.txt in root directory.
+// ***********************************************************************
+
+#if NETFRAMEWORK
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using NUnit.Engine;
+using NUnit.Engine.Internal;
+
+namespace NUnit.Engine.Services
+{
+    public class AgentProcess : Process
+    {
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(AgentProcess));
+
+        public AgentProcess(TestAgency agency, TestPackage package, Guid agentId)
+        {
+            // Get target runtime
+            string runtimeSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");
+            TargetRuntime = RuntimeFramework.Parse(runtimeSetting);
+
+            // Access other package settings
+            bool runAsX86 = package.GetSetting(EnginePackageSettings.RunAsX86, false);
+            bool debugTests = package.GetSetting(EnginePackageSettings.DebugTests, false);
+            bool debugAgent = package.GetSetting(EnginePackageSettings.DebugAgent, false);
+            string traceLevel = package.GetSetting(EnginePackageSettings.InternalTraceLevel, "Off");
+            bool loadUserProfile = package.GetSetting(EnginePackageSettings.LoadUserProfile, false);
+            string workDirectory = package.GetSetting(EnginePackageSettings.WorkDirectory, string.Empty);
+
+            AgentArgs = new StringBuilder($"{agentId} {agency.ServerUrl} --pid={Process.GetCurrentProcess().Id}");
+
+            // Set options that need to be in effect before the package
+            // is loaded by using the command line.
+            if (traceLevel != "Off")
+                AgentArgs.Append(" --trace=").EscapeProcessArgument(traceLevel);
+            if (debugAgent)
+                AgentArgs.Append(" --debug-agent");
+            if (workDirectory != string.Empty)
+                AgentArgs.Append(" --work=").EscapeProcessArgument(workDirectory);
+
+            AgentExePath = GetTestAgentExePath(TargetRuntime, runAsX86);
+
+            log.Debug("Using nunit-agent at " + AgentExePath);
+
+            StartInfo.UseShellExecute = false;
+            StartInfo.CreateNoWindow = true;
+            EnableRaisingEvents = true;
+
+            if (TargetRuntime.Runtime == RuntimeType.Mono)
+            {
+                StartInfo.FileName = RuntimeFramework.MonoExePath;
+                string monoOptions = "--runtime=v" + TargetRuntime.ClrVersion.ToString(3);
+                if (debugTests || debugAgent) monoOptions += " --debug";
+                StartInfo.Arguments = string.Format("{0} \"{1}\" {2}", monoOptions, AgentExePath, AgentArgs);
+            }
+            else if (TargetRuntime.Runtime == RuntimeType.Net)
+            {
+                StartInfo.FileName = AgentExePath;
+                StartInfo.Arguments = AgentArgs.ToString();
+                StartInfo.LoadUserProfile = loadUserProfile;
+            }
+            else
+            {
+                StartInfo.FileName = AgentExePath;
+                StartInfo.Arguments = AgentArgs.ToString();
+            }
+        }
+
+        // Internal properties exposed for testing
+
+        internal RuntimeFramework TargetRuntime { get; }
+        internal string AgentExePath { get; }
+        internal StringBuilder AgentArgs { get; }
+
+        public static string GetTestAgentExePath(RuntimeFramework targetRuntime, bool requires32Bit)
+        {
+            string engineDir = NUnitConfiguration.EngineDirectory;
+            if (engineDir == null) return null;
+
+            // If running out of a package "agents" is a subdirectory
+            string agentsDir = Path.Combine(engineDir, "agents");
+            log.Debug($"Checking for agents at {agentsDir}");
+
+            if (!Directory.Exists(agentsDir))
+            {
+                // When developing and running in the output directory, "agents" is a 
+                // sibling directory the one holding the agent (e.g. net20). This is a
+                // bit of a kluge, but it's necessary unless we change the binary 
+                // output directory to match the distribution structure.
+                agentsDir = Path.Combine(Path.GetDirectoryName(engineDir), "agents");
+                log.Debug($"Directory not found! Using {agentsDir}");
+            }
+
+            string runtimeDir = targetRuntime.FrameworkVersion.Major >= 4 ? "net40" : "net20";
+
+            string agentName = requires32Bit
+                ? "nunit-agent-x86.exe"
+                : "nunit-agent.exe";
+
+            return Path.Combine(Path.Combine(agentsDir, runtimeDir), agentName);
+        }
+    }
+}
+#endif

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Services
     {
         private readonly Dictionary<Guid, AgentRecord> _agentsById = new Dictionary<Guid, AgentRecord>();
 
-        public void Start(Guid agentId, Process process)
+        public void AddAgent(Guid agentId, Process process)
         {
             lock (_agentsById)
             {


### PR DESCRIPTION
Fixes #758 

The first commit refactors the private method `TestCentric.LaunchAgentProcess` to a class, `AgentProcess`, in order to enable testing. Tests of existing function are added.

The second commit sets one integration test to Ignore. See subsequent comment about this.

The third commit actually makes the desired change.