### PR TITLE
Split RuntimeFramework package setting into two: Requested and Target

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/MakeTestPackageTests.cs
@@ -71,7 +71,7 @@ namespace NUnit.ConsoleRunner.Tests
         [TestCase("--inprocess", "ProcessModel", "InProcess")]
         [TestCase("--domain=Multiple", "DomainUsage", "Multiple")]
         [TestCase("--domain=multiple", "DomainUsage", "Multiple")]
-        [TestCase("--framework=net-4.0", "RuntimeFramework", "net-4.0")]
+        [TestCase("--framework=net-4.0", "RequestedRuntimeFramework", "net-4.0")]
         [TestCase("--configfile=mytest.config", "ConfigurationFile", "mytest.config")]
         [TestCase("--agents=5", "MaxAgents", 5)]
         [TestCase("--debug", "DebugTests", true)]

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -396,7 +396,7 @@ namespace NUnit.ConsoleRunner
                 package.AddSetting(EnginePackageSettings.DomainUsage, options.DomainUsage);
 
             if (options.FrameworkSpecified)
-                package.AddSetting(EnginePackageSettings.RuntimeFramework, options.Framework);
+                package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, options.Framework);
 
             if (options.RunAsX86)
                 package.AddSetting(EnginePackageSettings.RunAsX86, true);

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -101,7 +101,13 @@ namespace NUnit
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
-        public const string RuntimeFramework = "RuntimeFramework";
+        public const string RequestedRuntimeFramework = "RequestedRuntimeFramework";
+
+        /// <summary>
+        /// Indicates the Target runtime selected for use by the engine,
+        /// based on the requested runtime and assembly metadata.
+        /// </summary>
+        public const string TargetRuntimeFramework = "TargetRuntimeFramework";
 
         /// <summary>
         /// Bool flag indicating that the test should be run in a 32-bit process 

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+
 namespace NUnit
 {
     /// <summary>
@@ -95,6 +97,14 @@ namespace NUnit
         /// for more than one assembly, "Separate" for a single assembly.
         /// </summary>
         public const string ProcessModel = "ProcessModel";
+
+        /// <summary>
+        /// Indicates the desired runtime to use for the tests. Values 
+        /// are strings like "net-4.5", "mono-4.0", etc. Default is to
+        /// use the target framework for which an assembly was built.
+        /// </summary>
+        [Obsolete("Use 'RuntimeFramework.RequestedRuntimeFramework' instead.")]
+        public const string RuntimeFramework = "RequestedRuntimeFramework";
 
         /// <summary>
         /// Indicates the desired runtime to use for the tests. Values 

--- a/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
+++ b/src/NUnitConsole/nunit3-console/EnginePackageSettings.cs
@@ -103,7 +103,7 @@ namespace NUnit
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
-        [Obsolete("Use 'RuntimeFramework.RequestedRuntimeFramework' instead.")]
+        [Obsolete("Use 'RequestedRuntimeFramework' instead.")]
         public const string RuntimeFramework = "RequestedRuntimeFramework";
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.core/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine.core/EnginePackageSettings.cs
@@ -106,7 +106,13 @@ namespace NUnit
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
-        public const string RuntimeFramework = "RuntimeFramework";
+        public const string RequestedRuntimeFramework = "RequestedRuntimeFramework";
+
+        /// <summary>
+        /// Indicates the Target runtime selected for use by the engine,
+        /// based on the requested runtime and assembly metadata.
+        /// </summary>
+        public const string TargetRuntimeFramework = "TargetRuntimeFramework";
 
         /// <summary>
         /// Bool flag indicating that the test should be run in a 32-bit process 

--- a/src/NUnitEngine/nunit.engine.core/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine.core/EnginePackageSettings.cs
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+using System;
+
 namespace NUnit
 {
     /// <summary>
@@ -100,6 +102,14 @@ namespace NUnit
         /// for more than one assembly, "Separate" for a single assembly.
         /// </summary>
         public const string ProcessModel = "ProcessModel";
+
+        /// <summary>
+        /// Indicates the desired runtime to use for the tests. Values 
+        /// are strings like "net-4.5", "mono-4.0", etc. Default is to
+        /// use the target framework for which an assembly was built.
+        /// </summary>
+        [Obsolete("Use 'RuntimeFramework.RequestedRuntimeFramework' instead.")]
+        public const string RuntimeFramework = "RequestedRuntimeFramework";
 
         /// <summary>
         /// Indicates the desired runtime to use for the tests. Values 

--- a/src/NUnitEngine/nunit.engine.core/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine.core/EnginePackageSettings.cs
@@ -108,7 +108,7 @@ namespace NUnit
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
-        [Obsolete("Use 'RuntimeFramework.RequestedRuntimeFramework' instead.")]
+        [Obsolete("Use 'RequestedRuntimeFramework' instead.")]
         public const string RuntimeFramework = "RequestedRuntimeFramework";
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
@@ -27,7 +27,7 @@ namespace NUnit.Engine.Services
             _agency.ServerUrl.ReturnsForAnyArgs(REMOTING_URL);
             _package = new TestPackage("junk.dll");
             // Only required setting, some tests may change this
-            _package.Settings[EnginePackageSettings.RuntimeFramework] = "net-4.5";
+            _package.Settings[EnginePackageSettings.TargetRuntimeFramework] = "net-4.5";
         }
 
         [TestCase("net-4.5", false, "../agents/net40/nunit-agent.exe")]
@@ -44,7 +44,7 @@ namespace NUnit.Engine.Services
         //[TestCase("netcore-1.1", true, "agents/netcoreapp1.1/testcentric-agent-x86.dll")]
         public void AgentSelection(string runtime, bool x86, string agentPath)
         {
-            _package.Settings[EnginePackageSettings.RuntimeFramework] = runtime;
+            _package.Settings[EnginePackageSettings.TargetRuntimeFramework] = runtime;
             _package.Settings[EnginePackageSettings.RunAsX86] = x86;
 
             var agentProcess = GetAgentProcess();
@@ -64,7 +64,7 @@ namespace NUnit.Engine.Services
         [TestCase("mono-2.0")]
         public void DefaultValues(string framework)
         {
-            _package.Settings[EnginePackageSettings.RuntimeFramework] = framework;
+            _package.Settings[EnginePackageSettings.TargetRuntimeFramework] = framework;
             var process = GetAgentProcess();
 
             Assert.That(process.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS));

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -65,7 +65,7 @@ namespace NUnit.Engine.Services.Tests
 
             var returnValue = _runtimeService.SelectRuntimeFramework(package);
 
-            Assert.That(package.GetSetting("RuntimeFramework", ""), Is.EqualTo(returnValue));
+            Assert.That(package.GetSetting("TargetRuntimeFramework", ""), Is.EqualTo(returnValue));
             Assert.That(package.GetSetting("RunAsX86", false), Is.EqualTo(runAsX86));
         }
 
@@ -87,10 +87,10 @@ namespace NUnit.Engine.Services.Tests
             var package = new TestPackage("test");
             package.AddSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, framework);
             package.AddSetting(InternalEnginePackageSettings.ImageRuntimeVersion, new Version(majorVersion, minorVersion));
-            package.AddSetting(EnginePackageSettings.RuntimeFramework, requested);
+            package.AddSetting(EnginePackageSettings.RequestedRuntimeFramework, requested);
 
             _runtimeService.SelectRuntimeFramework(package);
-            Assert.That(package.GetSetting<string>(EnginePackageSettings.RuntimeFramework, null), Is.EqualTo(requested));
+            Assert.That(package.GetSetting<string>(EnginePackageSettings.RequestedRuntimeFramework, null), Is.EqualTo(requested));
         }
 
         [Test]
@@ -111,9 +111,9 @@ namespace NUnit.Engine.Services.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.That(net20Package.Settings[EnginePackageSettings.RuntimeFramework], Is.EqualTo("net-2.0"));
-                Assert.That(net40Package.Settings[EnginePackageSettings.RuntimeFramework], Is.EqualTo("net-4.0"));
-                Assert.That(topLevelPackage.Settings[EnginePackageSettings.RuntimeFramework], Is.EqualTo("net-4.0"));
+                Assert.That(net20Package.Settings[EnginePackageSettings.TargetRuntimeFramework], Is.EqualTo("net-2.0"));
+                Assert.That(net40Package.Settings[EnginePackageSettings.TargetRuntimeFramework], Is.EqualTo("net-4.0"));
+                Assert.That(topLevelPackage.Settings[EnginePackageSettings.TargetRuntimeFramework], Is.EqualTo("net-4.0"));
             });
         }
     }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -342,6 +342,17 @@ namespace NUnit.Engine.Runners
                 && _projectService.CanLoadFrom(package.FullName);
         }
 
+        private struct ObsoletePackageSetting
+        {
+            public string OldKey;
+            public string NewKey;
+        }
+
+        private static ObsoletePackageSetting[] ObsoleteSettings = new ObsoletePackageSetting[]
+        {
+            new ObsoletePackageSetting() { OldKey = "RuntimeFramework", NewKey = "RequestedRuntimeFramework"}
+        };
+
         // Any Errors thrown from this method indicate that the client
         // runner is putting invalid values into the package.
         private void ValidatePackageSettings()
@@ -376,6 +387,14 @@ namespace NUnit.Engine.Runners
 
             if (runningInProcess && runAsX86 && IntPtr.Size == 8)
                 throw new NUnitEngineException("Cannot run tests in process - a 32 bit process is required.");
+
+            foreach (var entry in ObsoleteSettings)
+            {
+                var oldKey = entry.OldKey;
+                var newKey = entry.NewKey;
+                if (TestPackage.Settings.ContainsKey(oldKey) && !TestPackage.Settings.ContainsKey(newKey))
+                    TestPackage.Settings[newKey] = TestPackage.Settings[oldKey];
+            }
 #endif
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -349,7 +349,7 @@ namespace NUnit.Engine.Runners
 #if NETFRAMEWORK  // TODO: How do we validate runtime framework for .NET Standard 2.0?
             var processModel = TestPackage.GetSetting(EnginePackageSettings.ProcessModel, "Default").ToLower();
             var runningInProcess = processModel == "single" || processModel == "inprocess";
-            var frameworkSetting = TestPackage.GetSetting(EnginePackageSettings.RuntimeFramework, "");
+            var frameworkSetting = TestPackage.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
             var runAsX86 = TestPackage.GetSetting(EnginePackageSettings.RunAsX86, false);
 
             if (frameworkSetting.Length > 0)

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -20,7 +20,7 @@ namespace NUnit.Engine.Services
         public AgentProcess(TestAgency agency, TestPackage package, Guid agentId)
         {
             // Get target runtime
-            string runtimeSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");
+            string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");
             TargetRuntime = RuntimeFramework.Parse(runtimeSetting);
 
             // Access other package settings

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -121,7 +121,7 @@ namespace NUnit.Engine.Services
             RuntimeFramework currentFramework = RuntimeFramework.CurrentFramework;
             log.Debug("Current framework is " + currentFramework);
 
-            string frameworkSetting = package.GetSetting(EnginePackageSettings.RuntimeFramework, "");
+            string frameworkSetting = package.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
 
             RuntimeFramework requestedFramework;
             if (frameworkSetting.Length > 0)
@@ -154,7 +154,7 @@ namespace NUnit.Engine.Services
             }
 
             RuntimeFramework targetFramework = new RuntimeFramework(targetRuntime, targetVersion);
-            package.Settings[EnginePackageSettings.RuntimeFramework] = targetFramework.ToString();
+            package.Settings[EnginePackageSettings.TargetRuntimeFramework] = targetFramework.ToString();
 
             log.Debug($"Test will use {targetFramework} for {package.Name}");
             return targetFramework;

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -87,7 +87,6 @@ namespace NUnit.Engine.Services
         private IAgentLease CreateRemoteAgent(TestPackage package, int waitTime)
         {
             var agentId = Guid.NewGuid();
-            //var process = LaunchAgentProcess(package, agentId);
             var process = new AgentProcess(this, package, agentId);
 
             process.Exited += (sender, e) => OnAgentExit((Process)sender, agentId);


### PR DESCRIPTION
As discussed in PR #759, we are using the setting "RuntimeFramework" to mean two things: the framework the user requested and the framework selected as best by the RuntimeFrameworkService. This works in some places, but in others we have to check whether the framework indicated is valid and is actually available. These checks are only needed for a pending user request, so having two names is more useful.