### PR TITLE
Fix paths in addins files for global nuget package location

### DIFF
--- a/nuget/engine/nunit.engine.nuget.addins
+++ b/nuget/engine/nunit.engine.nuget.addins
@@ -1,2 +1,4 @@
 ../../../NUnit.Extension.*/**/tools/     # nuget v2 layout
 ../../../../NUnit.Extension.*/**/tools/  # nuget v3 layout
+../../../nunit.extension.*/**/tools/     # nuget v2 layout
+../../../../nunit.extension.*/**/tools/  # nuget v3 layout

--- a/nuget/runners/nunit.console.nuget.addins
+++ b/nuget/runners/nunit.console.nuget.addins
@@ -1,2 +1,4 @@
 ../../NUnit.Extension.*/**/tools/        # nuget v2 layout
 ../../../NUnit.Extension.*/**/tools/     # nuget v3 layout
+../../nunit.extension.*/**/tools/        # nuget v2 layout
+../../../nunit.extension.*/**/tools/     # nuget v3 layout


### PR DESCRIPTION
Paths on Linux are case-sensitive and nuget converts the paths
to lowercase when installing them in the global package location.
However, when installing the packages in a local directory the
paths don't get changed.

This change adds the lowercase paths in addition to the camel case
ones so that we find extensions that are installed parallel to
the NUnit.ConsoleRunner nuget package regardless of whether it is
installed in a local directory or in the global package location.

This fixes #775.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nunit/nunit-console/776)
<!-- Reviewable:end -->
