### PR TITLE
[CI] Revert to running .NET Standard Engine Tests via NUnitLite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - sudo dpkg -i packages-microsoft-prod.deb
         - sudo apt-get install apt-transport-https
         - sudo apt-get update
+        - sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.2
         - sudo apt-get install dotnet-sdk-2.2
 
 # macOS package restore currently taking >30 mins on Travis

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		.travis.yml = .travis.yml
 		appveyor.yml = appveyor.yml
+		azure-pipelines.yml = azure-pipelines.yml
 		build.cake = build.cake
 		BUILDING.md = BUILDING.md
 		CHANGES.txt = CHANGES.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
       sudo dpkg -i packages-microsoft-prod.deb
       sudo apt-get install apt-transport-https
       sudo apt-get update
+      sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.2
       sudo apt-get install dotnet-sdk-2.2
       ./build.sh --target=Test --configuration=Release
     displayName: Build and test
@@ -103,6 +104,12 @@ jobs:
     inputs:
       packageType: runtime
       version: 2.1.x
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core runtime 1.1'
+    inputs:
+      packageType: runtime
+      version: 1.1.x
 
   - bash: |
      dotnet tool install --global Cake.Tool

--- a/build.cake
+++ b/build.cake
@@ -318,9 +318,8 @@ Task("TestNetStandard16Engine")
         if (IsDotNetCoreInstalled)
         {
             RunDotnetCoreTests(
-                NETCORE21_CONSOLE,
+                NETCOREAPP11_BIN_DIR + ENGINE_TESTS,
                 NETCOREAPP11_BIN_DIR,
-                ENGINE_TESTS,
                 "netcoreapp1.1",
                 ref ErrorDetail);
         }
@@ -343,9 +342,8 @@ Task("TestNetStandard20Engine")
         if (IsDotNetCoreInstalled)
         {
             RunDotnetCoreTests(
-                NETCORE21_CONSOLE,
+                NETCOREAPP21_BIN_DIR + ENGINE_TESTS,
                 NETCOREAPP21_BIN_DIR,
-                ENGINE_TESTS,
                 "netcoreapp2.1",
                 ref ErrorDetail);
         }
@@ -692,6 +690,11 @@ void RunTest(FilePath exePath, DirectoryPath workingDir, string testAssembly, st
         errorDetail.Add(string.Format("{0}: {1} tests failed", framework, rc));
     else if (rc < 0)
         errorDetail.Add(string.Format("{0} returned rc = {1}", exePath, rc));
+}
+
+void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string framework, ref List<string> errorDetail)
+{
+    RunDotnetCoreTests(exePath, workingDir, arguments: null, framework, ref errorDetail);
 }
 
 void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string arguments, string framework, ref List<string> errorDetail)


### PR DESCRIPTION
Unfortunately #710 seems to have also affected our own tests. Since https://github.com/nunit/nunit-console/pull/696, I don't think we've actually been running the .NET Standard 1.6 tests, as the console runner has instead been picking up the assembly of the same name in it's own directory - which is the .NET Standard 2.0 test suite. I only noticed as I was getting some weird results working on #710 - and then spotted the two test runs were reporting the same number of tests.

This reverts to running the .NET Standard tests under NUnitLite, as we previously did. (With some added CI changes to install a .NET Core 1.1 runtime, which have been lost along the way.)

It raises an interesting question about the resilience of our own tests. Perhaps we should instead start using the latest NuGet release of the NUnit Console to run the tests...