### PR TITLE
Use AssemblyLoadContext to correctly load .NET Core assemblies 

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
@@ -61,14 +61,16 @@ namespace NUnit.Engine.Drivers
         /// Gets a driver for a given test assembly and a framework
         /// which the assembly is already known to reference.
         /// </summary>
-        /// <param name="domain">The domain in which the assembly will be loaded</param>
         /// <param name="reference">An AssemblyName referring to the test framework.</param>
         /// <returns></returns>
         public IFrameworkDriver GetDriver(AssemblyName reference)
         {
             Guard.ArgumentValid(IsSupportedTestFramework(reference), "Invalid framework", "reference");
-
+#if NETSTANDARD
             return new NUnitNetStandardDriver();
+#elif NETCOREAPP3_1
+            return new NUnitNetCore31Driver();
+#endif
         }
 #endif
     }

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -28,9 +28,7 @@ using System.Collections.Generic;
 using System.IO;
 using NUnit.Engine.Internal;
 using System.Reflection;
-using System.Runtime.Loader;
 using NUnit.Engine.Extensibility;
-using Mono.Cecil;
 
 namespace NUnit.Engine.Drivers
 {
@@ -55,7 +53,7 @@ namespace NUnit.Engine.Drivers
         static readonly string RUN_ASYNC_METHOD = "RunTests";
         static readonly string STOP_RUN_METHOD = "StopRun";
 
-        static ILogger log = InternalTrace.GetLogger(nameof(NUnitNetStandardDriver));
+        static ILogger log = InternalTrace.GetLogger(nameof(NUnitNetCore31Driver));
 
         Assembly _testAssembly;
         Assembly _frameworkAssembly;

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -1,5 +1,5 @@
 ﻿// ***********************************************************************
-// Copyright (c) 2016 Charlie Poole, Rob Prouse
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -21,28 +21,26 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NETSTANDARD || NETCOREAPP3_1
+#if NETCOREAPP3_1
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using System.IO;
 using NUnit.Engine.Internal;
 using System.Reflection;
+using System.Runtime.Loader;
 using NUnit.Engine.Extensibility;
 using Mono.Cecil;
 
 namespace NUnit.Engine.Drivers
 {
     /// <summary>
-    /// NUnitNetStandardDriver is used by the test-runner to load and run
-    /// tests using the NUnit framework assembly.
-    ///
-    /// NUnitNetStandardDriver was the original driver for the .NET Standard builds
-    /// of the engine, however has an issue with loading .NET Core assemblies
-    /// (https://github.com/nunit/nunit-console/issues/710)
-    /// <see cref="NUnitNetCore31Driver" /> is the replacement driver for running .NET Core tests,
-    /// and should be preferred for use with .NET Core 3.1 and later.
+    /// NUnitNetCore31Driver is used by the test-runner to load and run
+    /// tests using the NUnit framework assembly. It contains functionality to
+    /// correctly load assemblies from other directories, using APIs first available in
+    /// .NET Core 3.1.
     /// </summary>
-    public class NUnitNetStandardDriver : IFrameworkDriver
+    public class NUnitNetCore31Driver : IFrameworkDriver
     {
         const string LOAD_MESSAGE = "Method called without calling Load first";
         const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
@@ -73,28 +71,33 @@ namespace NUnit.Engine.Drivers
         /// <summary>
         /// Loads the tests in an assembly.
         /// </summary>
-        /// <param name="frameworkAssembly">The NUnit Framework that the tests reference</param>
-        /// <param name="testAssembly">The test assembly</param>
+        /// <param name="assemblyPath">The path to the test assembly</param>
         /// <param name="settings">The test settings</param>
-        /// <returns>An Xml string representing the loaded test</returns>
-        public string Load(string testAssembly, IDictionary<string, object> settings)
+        /// <returns>An XML string representing the loaded test</returns>
+        public string Load(string assemblyPath, IDictionary<string, object> settings)
         {
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
 
-            var assemblyRef = AssemblyDefinition.ReadAssembly(testAssembly);
-            _testAssembly = Assembly.Load(new AssemblyName(assemblyRef.FullName));
-            if(_testAssembly == null)
-                throw new NUnitEngineException(string.Format(FAILED_TO_LOAD_TEST_ASSEMBLY, assemblyRef.FullName));
+            assemblyPath = Path.GetFullPath(assemblyPath);  //AssemblyLoadContext requires an absolute path
+            var assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
 
-            var nunitRef = assemblyRef.MainModule.AssemblyReferences.Where(reference => reference.Name.Equals("nunit.framework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            try
+            {
+                _testAssembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
+            }
+            catch (Exception e)
+            {
+                throw new NUnitEngineException(string.Format(FAILED_TO_LOAD_TEST_ASSEMBLY, assemblyPath), e);
+            }
+
+            var nunitRef = _testAssembly.GetReferencedAssemblies().FirstOrDefault(reference => reference.Name.Equals("nunit.framework", StringComparison.OrdinalIgnoreCase));
+            
             if (nunitRef == null)
                 throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 
-            var nunit = Assembly.Load(new AssemblyName(nunitRef.FullName));
-            if (nunit == null)
+            _frameworkAssembly = assemblyLoadContext.LoadFromAssemblyName(nunitRef);
+            if (_frameworkAssembly == null)
                 throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
-
-            _frameworkAssembly = nunit;
 
             _frameworkController = CreateObject(CONTROLLER_TYPE, _testAssembly, idPrefix, settings);
             if (_frameworkController == null)

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NETSTANDARD || NETCOREAPP3_1
+#if NETSTANDARD
 using System;
 using System.Linq;
 using System.Collections.Generic;

--- a/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
@@ -1,0 +1,48 @@
+﻿// ***********************************************************************
+// Copyright (c) 2020 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN METHOD
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+#if NETCOREAPP3_1
+
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace NUnit.Engine.Internal
+{
+    internal class CustomAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly AssemblyDependencyResolver _resolver;
+
+        public CustomAssemblyLoadContext(string mainAssemblyToLoadPath)
+        {
+            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+        }
+
+        protected override Assembly Load(AssemblyName name)
+        {
+            var assemblyPath = _resolver.ResolveAssemblyToPath(name);
+            return assemblyPath != null ? LoadFromAssemblyPath(assemblyPath) : null;
+        }
+    }
+}
+
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnitNetStandardDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnitNetStandardDriverTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NETCOREAPP
+#if NETCOREAPP1_1 || NETCOREAPP2_1
 
 using System;
 using System.Collections.Generic;

--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -54,7 +54,11 @@ namespace NUnit.Engine.Services.Tests
         }
 
 
-#if NETCOREAPP
+#if NETCOREAPP3_1
+        [TestCase("mock-assembly.dll", false, typeof(NUnitNetCore31Driver))]
+        [TestCase("mock-assembly.dll", true, typeof(NUnitNetCore31Driver))]
+        [TestCase("notest-assembly.dll", false, typeof(NUnitNetCore31Driver))]
+#elif NETCOREAPP1_1 || NETCOREAPP2_1
         [TestCase("mock-assembly.dll", false, typeof(NUnitNetStandardDriver))]
         [TestCase("mock-assembly.dll", true, typeof(NUnitNetStandardDriver))]
         [TestCase("notest-assembly.dll", false, typeof(NUnitNetStandardDriver))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -35,8 +35,10 @@ namespace NUnit.Engine.Services.Tests
     {
         private const string MOCK_ASSEMBLY = "mock-assembly.dll";
 
-#if NETCOREAPP
+#if NETCOREAPP1_1 || NETCOREAPP2_1
         private NUnitNetStandardDriver _driver;
+#elif NETCOREAPP3_1
+        private NUnitNetCore31Driver _driver;
 #else
         private NUnit3FrameworkDriver _driver;
 #endif
@@ -45,8 +47,10 @@ namespace NUnit.Engine.Services.Tests
         public void LoadAssembly()
         {
             var mockAssemblyPath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-#if NETCOREAPP
+#if NETCOREAPP1_1 || NETCOREAPP2_1
             _driver = new NUnitNetStandardDriver();
+#elif NETCOREAPP3_1
+            _driver = new NUnitNetCore31Driver();
 #else
             var assemblyName = typeof(NUnit.Framework.TestAttribute).Assembly.GetName();
             _driver = new NUnit3FrameworkDriver(AppDomain.CurrentDomain, assemblyName);


### PR DESCRIPTION
I believe this fixes #710. It uses .NET Core's AssemblyLoadContext API's to ensure .NET Core dependencies are loaded in the intended way. (It also means that we no longer need to publish as test assembly, to be able to run tests on it.)

~~This is based on top of #778, so only the last commit is actually new here: https://github.com/nunit/nunit-console/commit/45769e2630d4ab2aae196f250a6d94e47e1b9081~~

~~Note this will currently fail CI due to #779. (I believe this is actually running the tests correctly now, and exposing test errors which need to be fixed!)~~

~~@beloquintana @CharliePoole @schrufygroovy - once we've got CI fixed up, would you be able to test this package with your respective runners, and check it solves the problems you were seeing? I'll shout when it's ready. 🙂~~