### PR TITLE
Fix DirectTestRunner to not give all drivers the same ID.

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
@@ -148,7 +148,7 @@ namespace NUnit.Engine.Runners
 #else
                 IFrameworkDriver driver = driverService.GetDriver(testFile, skipNonTestAssemblies);
 #endif
-                driver.ID = TestPackage.ID;
+                driver.ID = subPackage.ID;
                 result.Add(LoadDriver(driver, testFile, subPackage));
                 _drivers.Add(driver);
             }

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -265,18 +265,31 @@ namespace NUnit.Engine.Runners.Tests
 
         private void CheckThatIdsAreUnique(XmlNode test)
         {
-            CheckThatIdsAreUnique(test, new Dictionary<string, bool>());
+            CheckTestIdsAreUnique(test, new HashSet<string>(), new HashSet<string>());
         }
 
-        private void CheckThatIdsAreUnique(XmlNode test, Dictionary<string, bool> dict)
+        /// Tests both that individual test IDs are unique, 
+        private void CheckTestIdsAreUnique(XmlNode test, HashSet<string> testIDs, HashSet<string> testAssemblyPrefixes)
         {
             foreach (XmlNode child in test.SelectNodes("test-suite"))
-                CheckThatIdsAreUnique(child, dict);
+                CheckTestIdsAreUnique(child, testIDs, testAssemblyPrefixes);
 
-            string id = test.GetAttribute("id");
-            Assert.That(dict, Does.Not.ContainKey(id));
+            var id = test.GetAttribute("id");
+            Assert.That(testIDs, Does.Not.Contain(id));
+            testIDs.Add(id);
 
-            dict.Add(id, true);
+            var testType = test.GetAttribute("type");
+            if (testType != null && testType.Equals("assembly", StringComparison.OrdinalIgnoreCase))
+            {
+                CheckTestAssemblyPrefixIsUnique(test, testAssemblyPrefixes);
+            }
+        }
+
+        private static void CheckTestAssemblyPrefixIsUnique(XmlNode test, HashSet<string> testAssemblyPrefixes)
+        {
+            var prefix = test.GetAttribute("id").Split('-')[0];
+            Assert.That(testAssemblyPrefixes, Does.Not.Contain(prefix));
+            testAssemblyPrefixes.Add(prefix);
         }
 
         private void CheckTestRunEvents()


### PR DESCRIPTION
This (I believe) is another separate bug which was exposed with the .NET Core work.

Each TestPackage (including sub-package) has a unique ID, and that unique ID should be passed on to each driver. There's currently a bug in the DirectTestRunner under which gives driver the ID from the Top-level test package, meaning all drivers end up with the same ID.

This was picked up by the MasterTestRunnerTests with the conversion to .NET Core. It was not visible previously as:
1) In the .NET 2.0 build, tests go through the same MultipleTestDomainRunner, which does not have the same bug.
2) In the .NET Standard builds, multiple test assemblies are currently loaded in the same AssemblyLoadContext, meaning that test ID's across multiple assemblies continued going up sequentially, and were not reset for each assembly.

In the second case, the MasterTestRunnerTests should be stronger, to assert that the ID prefix is different for each test assembly, rather than simply that all ID's are unique. That's the change I've made for the 'failing test' in this commit.