### PR TITLE
Fix agent debug logging

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -67,7 +67,7 @@ namespace NUnit.Agent
                 {
                     debugArgPassed = true;
                 }
-                else if (arg.StartsWith("--trace:"))
+                else if (arg.StartsWith("--trace="))
                 {
                     traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), arg.Substring(8));
                 }


### PR DESCRIPTION
The argument to set the debug log level was not being read by the agent.

Now standardised as an equals sign, same as all other arguments.