### PR TITLE
Sticking plaster to prevent crash with .NET 2.0 agent encountering .NET 4.0 extension

### DIFF
--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -67,7 +67,7 @@ namespace NUnit.Agent
                 {
                     debugArgPassed = true;
                 }
-                else if (arg.StartsWith("--trace:"))
+                else if (arg.StartsWith("--trace="))
                 {
                     traceLevel = (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), arg.Substring(8));
                 }
@@ -103,7 +103,7 @@ namespace NUnit.Agent
             };
 
             // Custom Service Initialization
-            engine.Services.Add(new ExtensionService());
+            engine.Services.Add(new ExtensionService(isRunningOnAgent: true));
             engine.Services.Add(new DomainManager());
             engine.Services.Add(new InProcessTestRunnerFactory());
             engine.Services.Add(new DriverService());


### PR DESCRIPTION
Fixes #757 

This is a quick-hack fix, for the next release. When the extension service is run under the agent, it silently skips extensions which target a framework that the agent cannot load.

The "proper fix" here in my mind, is to locate all extensions within the main engine, and just pass any required driver extensions to the relevant agent. This removes all the assembly loading logic from the agents, further slimming down the agents. That's a bigger refactor, and I wanted to get a quick fix in for the 3.12 release.

The only downside, is that this quick-fix will give a crash to any users who are genuinely mistakenly trying to use a .NET 4.0+ driver to run .NET 2.0 tests. I believe this is 'safe-enough' as:

1. Driver extensions are very low usage - the only one I'm aware of is the NUnit 2 driver, which targets .NET 2.0
1. Trying to run a test assembly with no valid driver is something I would expect to fail quite loudly.
1. Trying to run a .NET 2.0 test assembly with a .NET 4.0 driver is already something which would have errored - this change just  means the error message is slightly less-nice!