### PR TITLE
Add NUnit.Console-Runner.NetCore packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -440,6 +440,14 @@ Task("PackageNuGet")
             NoPackageAnalysis = true
         });
 
+        NuGetPack("nuget/runners/nunit.console-runner.netcore.nuspec", new NuGetPackSettings()
+        {
+            Version = productVersion,
+            BasePath = CURRENT_IMG_DIR,
+            OutputDirectory = PACKAGE_DIR,
+            NoPackageAnalysis = true
+        });
+
         NuGetPack("nuget/deprecated/nunit.runners.nuspec", new NuGetPackSettings()
         {
             Version = productVersion,

--- a/nuget/runners/nunit.console-runner.netcore.nuspec
+++ b/nuget/runners/nunit.console-runner.netcore.nuspec
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>NUnit.ConsoleRunner.NetCore</id>
+    <title>NUnit Console Runner (.NET Core)</title>
+    <version>$version$</version>
+    <authors>Charlie Poole, Rob Prouse</authors>
+    <owners>Charlie Poole, Rob Prouse</owners>
+    <license type="file">LICENSE.txt</license>
+    <projectUrl>https://nunit.org</projectUrl>
+    <repository type="git" url="https://github.com/nunit/nunit-console"/>
+    <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
+    <icon>images\nunit_256.png</icon>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>.NET Core build of the console runner for the NUnit unit-testing framework.</summary>
+    <description>
+      This package includes the .NET Core build of the NUnit console runner and test engine.
+
+      Any extensions, if needed, may be installed as separate packages.
+    </description>
+    <releaseNotes></releaseNotes>
+    <language>en-US</language>
+    <tags>nunit test testing tdd runner</tags>
+    <copyright>Copyright (c) 2020 Charlie Poole, Rob Prouse</copyright>
+  </metadata>
+  <files>
+    <file src="LICENSE.txt" />
+    <file src="NOTICES.txt" />
+    <file src="CHANGES.txt" />
+    <file src="bin/netcoreapp3.1/nunit3-console.exe" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit3-console.pdb" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit3-console.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit3-console.dll.config" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit3-console.deps.json" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit3-console.runtimeconfig.json" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.core.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.core.pdb" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.pdb" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.deps.json" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.api.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.api.pdb" target="tools" />
+    <file src="bin/netcoreapp3.1/nunit.engine.api.xml" target="tools" />
+    <file src="bin/netcoreapp3.1/Microsoft.DotNet.InternalAbstractions.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/Mono.Cecil.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/Mono.Cecil.Mdb.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/Mono.Cecil.Pdb.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/Mono.Cecil.Rocks.dll" target="tools" />
+    <file src="bin/netcoreapp3.1/System.Xml.XPath.XmlDocument.dll" target="tools" />
+    <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools"/>
+    <file src="../../nunit_256.png" target="images"/>
+  </files>
+</package>


### PR DESCRIPTION
Fixes #750 and #475 

This is the final part of the .NET Core Console Runner MVP.  🎉 Once this is merged, I aim to get a beta release out shortly, so people can trial the new console.

There is a new NuGet package added under the name nunit.console-runner.netcore. (word separators to try and keep convention with existing packages)

For the zip, I realised the .NET Standard engine was already included in the main zip, and didn't want to break backwards compatibility by separating that out. So I kept everything in a single zip file. The zip was 11MB before this change and is now 13MB - so it's no big change, but we probably want to look at breaking that up for v4.

Both packages have been tested manually. 