### PR TITLE
Revert change to increment nunit.engine.api assembly version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -152,6 +152,7 @@ Task("UpdateAssemblyInfo")
     .Does(() =>
     {
         PatchAssemblyInfo("src/NUnitConsole/ConsoleVersion.cs", productVersion, version);
+        PatchAssemblyInfo("src/NUnitEngine/EngineApiVersion.cs", productVersion, assemblyVersion: null);
         PatchAssemblyInfo("src/NUnitEngine/EngineVersion.cs", productVersion, version);
     });
 

--- a/src/NUnitEngine/EngineApiVersion.cs
+++ b/src/NUnitEngine/EngineApiVersion.cs
@@ -1,0 +1,29 @@
+// ***********************************************************************
+// Copyright (c) 2014 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System.Reflection;
+
+[assembly: AssemblyProduct("NUnit Engine API")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyInformationalVersion("3.12.0")]
+[assembly: AssemblyFileVersion("3.12.0")]

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
+    <Compile Include="..\EngineApiVersion.cs" LinkBase="Properties" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts nunit/nunit-console#802.

This change had broken extension loading. See #826, which now covers the overall issue in more detail.

Fixes #807