### PR TITLE
[CI] Test on .NET 5.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,6 +68,7 @@ jobs:
       sudo apt-get update
       sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.2
       sudo apt-get install dotnet-sdk-2.2
+      sudo apt-get install dotnet-runtime-5.0
       ./build.sh --target=Test --configuration=Release
     displayName: Build and test
 
@@ -101,6 +102,12 @@ jobs:
   pool:
     vmImage: macOS-latest
   steps:
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET 5.0'
+    inputs:
+      packageType: runtime
+      version: 5.x
 
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK'

--- a/build.cake
+++ b/build.cake
@@ -738,7 +738,7 @@ void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string argum
         var msg = $"No suitable runtime found to run tests under {framework}";
         if (BuildSystem.IsLocalBuild)
             Warning(msg);
-        else Error(msg);
+        else throw new Exception(msg);
     }
     else
     {

--- a/build.cake
+++ b/build.cake
@@ -13,7 +13,7 @@ var configuration = Argument("configuration", "Release");
 var productVersion = Argument("productVersion", "3.12.0-beta1");
 
 var ErrorDetail = new List<string>();
-bool IsDotNetCoreInstalled = false;
+var installedNetCoreRuntimes = GetInstalledNetCoreRuntimes();
 
 //////////////////////////////////////////////////////////////////////
 // SET PACKAGE VERSION
@@ -118,7 +118,6 @@ Setup(context =>
 
     // Executed BEFORE the first task.
     Information("Building {0} version {1} of NUnit Console/Engine.", configuration, productVersion);
-    IsDotNetCoreInstalled = CheckIfDotNetCoreInstalled();
 });
 
 Teardown(context =>
@@ -288,21 +287,18 @@ Task("TestNetCore31Console")
     .OnError(exception => { ErrorDetail.Add(exception.Message); })
     .Does(() =>
     {
-        if (IsDotNetCoreInstalled)
+        var runtimes = new[] { "3.1", "5.0" };
+
+        foreach (var runtime in runtimes)
         {
             RunDotnetCoreTests(
                 NETCORE31_CONSOLE,
                 NETCOREAPP31_BIN_DIR,
                 CONSOLE_TESTS,
-                "netcoreapp2.1",
+                runtime,
                 ref ErrorDetail);
         }
-        else
-        {
-            Warning("Skipping .NET Core Console tests because .NET Core is not installed");
-        }
     });
-
 
 //////////////////////////////////////////////////////////////////////
 // TEST NETSTANDARD 1.6 ENGINE
@@ -315,18 +311,11 @@ Task("TestNetStandard16Engine")
     .OnError(exception => { ErrorDetail.Add(exception.Message); })
     .Does(() =>
     {
-        if (IsDotNetCoreInstalled)
-        {
-            RunDotnetCoreTests(
-                NETCOREAPP11_BIN_DIR + ENGINE_TESTS,
-                NETCOREAPP11_BIN_DIR,
-                "netcoreapp1.1",
-                ref ErrorDetail);
-        }
-        else
-        {
-            Warning("Skipping .NET Standard tests because .NET Core is not installed");
-        }
+        RunDotnetCoreNUnitLiteTests(
+            NETCOREAPP11_BIN_DIR + ENGINE_TESTS,
+            NETCOREAPP11_BIN_DIR,
+            "netcoreapp1.1",
+            ref ErrorDetail);
     });
 
 //////////////////////////////////////////////////////////////////////
@@ -339,18 +328,11 @@ Task("TestNetStandard20Engine")
     .OnError(exception => { ErrorDetail.Add(exception.Message); })
     .Does(() =>
     {
-        if (IsDotNetCoreInstalled)
-        {
-            RunDotnetCoreTests(
-                NETCOREAPP21_BIN_DIR + ENGINE_TESTS,
-                NETCOREAPP21_BIN_DIR,
-                "netcoreapp2.1",
-                ref ErrorDetail);
-        }
-        else
-        {
-            Warning("Skipping .NET Standard tests because .NET Core is not installed");
-        }
+        RunDotnetCoreNUnitLiteTests(
+            NETCOREAPP21_BIN_DIR + ENGINE_TESTS,
+            NETCOREAPP21_BIN_DIR,
+            "netcoreapp2.1",
+            ref ErrorDetail);
     });
 
 
@@ -364,18 +346,16 @@ Task("TestNetCore31Engine")
     .OnError(exception => { ErrorDetail.Add(exception.Message); })
     .Does(() =>
     {
-        if (IsDotNetCoreInstalled)
+        var runtimes = new[] { "3.1", "5.0" };
+
+        foreach (var runtime in runtimes)
         {
             RunDotnetCoreTests(
                 NETCORE31_CONSOLE,
                 NETCOREAPP31_BIN_DIR,
                 ENGINE_TESTS,
-                "netcoreapp3.1",
+                runtime,
                 ref ErrorDetail);
-        }
-        else
-        {
-            Warning("Skipping .NET Core 3.1 engine tests because .NET Core is not installed");
         }
     });
 
@@ -660,6 +640,17 @@ Task("CheckPackages")
         CheckAllPackages();
     });
 
+Task("ListInstalledNetCoreRuntimes")
+    .Description("Lists all installed .NET Core Runtimes")
+    .Does(() => 
+    {
+        var runtimes = GetInstalledNetCoreRuntimes();
+        foreach (var runtime in runtimes)
+        {
+            Information(runtime);            
+        }
+    });
+
 //////////////////////////////////////////////////////////////////////
 // HELPER METHODS - GENERAL
 //////////////////////////////////////////////////////////////////////
@@ -727,22 +718,47 @@ void RunTest(FilePath exePath, DirectoryPath workingDir, string testAssembly, st
         errorDetail.Add(string.Format("{0} returned rc = {1}", exePath, rc));
 }
 
-void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string framework, ref List<string> errorDetail)
+void RunDotnetCoreNUnitLiteTests(FilePath exePath, DirectoryPath workingDir, string framework, ref List<string> errorDetail)
 {
     RunDotnetCoreTests(exePath, workingDir, arguments: null, framework, ref errorDetail);
 }
 
 void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string arguments, string framework, ref List<string> errorDetail)
 {
+    //Filename is first arg if running on NUnit Console of exePath if running NUnitLite tests
+    var fileName = arguments ?? exePath.GetFilename();
+
+    //Find most suitable runtime
+    var fxVersion = new string(framework.SkipWhile(c => !char.IsDigit(c)).ToArray());
+    //Select latest runtime matching requested major/minor version
+    var selectedFramework = installedNetCoreRuntimes.Where(v => v.StartsWith(fxVersion)).OrderByDescending(Version.Parse).FirstOrDefault();
+
+    if (selectedFramework == null)
+    {
+        var msg = $"No suitable runtime found to run tests under {framework}";
+        if (BuildSystem.IsLocalBuild)
+            Warning(msg);
+        else Error(msg);
+    }
+    else
+    {
+        Information($"Runtime framework version {selectedFramework} selected to run {fileName} for {framework}.");
+    }
+
+    //Run Tests
+
+    var args = new ProcessArgumentBuilder()
+                .AppendSwitch("--fx-version", " ", selectedFramework)
+                .AppendQuoted(exePath.FullPath)
+                .Append(arguments)
+                .AppendSwitchQuoted("--result", ":", GetResultXmlPath(exePath.FullPath, framework).FullPath)
+                .Render();
+
     int rc = StartProcess(
         "dotnet",
         new ProcessSettings
         {
-            Arguments = new ProcessArgumentBuilder()
-                .AppendQuoted(exePath.FullPath)
-                .Append(arguments)
-                .AppendSwitchQuoted("--result", ":", GetResultXmlPath(exePath.FullPath, framework).FullPath)
-                .Render(),
+            Arguments = args,
             WorkingDirectory = workingDir
         });
 
@@ -751,6 +767,30 @@ void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string argum
     else if (rc < 0)
         errorDetail.Add(string.Format("{0} returned rc = {1}", exePath, rc));
 }
+
+public List<string> GetInstalledNetCoreRuntimes()
+{
+    var list = new List<string>();
+
+    var process = StartProcess("dotnet", 
+            new ProcessSettings 
+            { 
+                Arguments = "--list-runtimes",
+                RedirectStandardOutput = true,
+                RedirectedStandardOutputHandler = 
+                s => {
+                    if (s == null || !s.StartsWith("Microsoft.NETCore.App"))
+                        return s;
+
+                    var version = s.Split(' ')[1];                    
+
+                    list.Add(version);
+                    return s;
+                }
+            });
+    return list;
+}
+
 
 //////////////////////////////////////////////////////////////////////
 // HELPER METHODS - PACKAGE

--- a/build.cake
+++ b/build.cake
@@ -725,7 +725,7 @@ void RunDotnetCoreNUnitLiteTests(FilePath exePath, DirectoryPath workingDir, str
 
 void RunDotnetCoreTests(FilePath exePath, DirectoryPath workingDir, string arguments, string framework, ref List<string> errorDetail)
 {
-    //Filename is first arg if running on NUnit Console of exePath if running NUnitLite tests
+    //Filename is first arg if running on NUnit Console, or exePath if running NUnitLite tests
     var fileName = arguments ?? exePath.GetFilename();
 
     //Find most suitable runtime

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'!='net35'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -1,12 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net20;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp1.1'">
+    <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />

--- a/src/NUnitEngine/notest-assembly/notest-assembly.csproj
+++ b/src/NUnitEngine/notest-assembly/notest-assembly.csproj
@@ -3,7 +3,10 @@
     <RootNamespace>notest_assembly</RootNamespace>
     <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp1.1'">
+    <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
   </ItemGroup>
 </Project>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -11,14 +11,21 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='net35'">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="NUnitLite" Version="3.11.0" />
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="NUnitLite" Version="3.13.0-dev-06899" />
+    <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1' OR '$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="NUnitLite" Version="3.13.0-dev-06899" />
+    <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -11,7 +11,6 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
-    <PackageReference Include="NUnitLite" Version="3.13.0-dev-06899" />
     <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #830 and also fixes #511 

This runs the tests on .NET 5.0, where available. I thought this was important to at least test on .NET 5.0, as it's a platform I suspect a large number of our users will shortly be running on. I haven't yet seen any reason to add a .NET 5.0 build though - so this instead runs tests for the .NET Core 3.1 Engine/Console on .NET 5.0. I also didn't see a need to add a requirement for users to have .NET 5.0 installed to contribute, so if unavailable, the default is to provide a warning - assuming the tests will be run on all platforms in CI instead.

It also improves the CI's handling of .NET Core platforms, as per #511. The new behaviour: 
- The Cake script will now locate the most appropriate runtime for the request - that being the highest major/minor version installed for the runtime requested. e.g. on my machine, the 3.1 tests will chose to run on 3.1.5 over 3.1.2.
- If a runtime isn't available, e.g. .NET 5.0:
     - When building locally through the Cake scripts, if a certain runtime isn't available the script will provide a warning.
     - When building in CI and a certain runtime isn't available, the script will error. This is with various known exceptions built in, such as the .NET Core 1.1 test running on Azure.

One day I hope the Engine itself will do all this boilerplate stuff for us...we'll get there! 😄 