### PR TITLE
Fix extension loading for extensions which target multiple runtimes

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
@@ -410,7 +410,13 @@ namespace NUnit.Engine.Services
         /// </summary>
         internal void FindExtensionsInAssembly(ExtensionAssembly assembly)
         {
-            log.Info("Scanning {0} assembly for Extensions", assembly.FilePath);
+            log.Info($"Scanning {assembly.FilePath} for Extensions");
+
+            if (!CanLoadTargetFramework(Assembly.GetEntryAssembly(), assembly))
+            {
+                log.Info($"{assembly.FilePath} cannot be loaded on this runtime");
+                return;
+            }
 
             IRuntimeFramework assemblyTargetFramework = null;
 #if NETFRAMEWORK

--- a/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
@@ -1,4 +1,4 @@
-﻿// ***********************************************************************
+// ***********************************************************************
 // Copyright (c) 2015 Charlie Poole, Rob Prouse
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -360,7 +360,10 @@ namespace NUnit.Engine.Services
                 {
                     var candidate = new ExtensionAssembly(filePath, fromWildCard);
 
-                    for (int i = 0; i < _assemblies.Count; i++)
+                if (!CanLoadTargetFramework(Assembly.GetEntryAssembly(), candidate))
+                    return;
+
+                for (var i = 0; i < _assemblies.Count; i++)
                     {
                         var assembly = _assemblies[i];
 


### PR DESCRIPTION
Fixes #844. 

There was an error in the extension selection logic, where an extension of a higher version could replace an extension of a lower version, even if the higher version could not be loaded in the current runtime. This changes brings the check of where an extension is valid in the current runtime forward to prevent that.

The actual change is in the first commit, the second commit is subsequent reformatting and removal of the old check. Unfortunately this whole piece of logic currnently relies on 'real files' and is untested - something I think we'll need to refactor in future.