### PR TITLE
Stop building engine assembly for .NET Standard 1.6

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -142,6 +142,17 @@ Task("Clean")
         CleanDirectory(PACKAGE_DIR);
     });
 
+// Not currently used in CI but useful for cleaning your local obj
+// directories, particularly after changing the target of a project.
+Task("CleanAll")
+    .Description("Cleans obj directories in additon to standard clean")
+    .IsDependentOn("Clean")
+    .Does(() =>
+    {
+        foreach (var dir in GetDirectories(PROJECT_DIR + "src/**/obj/"))
+            DeleteDirectory(dir, new DeleteDirectorySettings() { Recursive = true });
+    });
+
 //////////////////////////////////////////////////////////////////////
 // INITIALIZE FOR BUILD
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -200,12 +200,12 @@ Task("Build")
 
         Information("Publishing .NET Core & Standard projects so that dependencies are present...");
 
-        foreach(var framework in new [] { "netstandard1.6", "netstandard2.0", "netcoreapp3.1" })
+        foreach(var framework in new [] { "netstandard2.0", "netcoreapp3.1" })
              MSBuild(ENGINE_CSPROJ, CreateMSBuildSettings("Publish")
                 .WithProperty("TargetFramework", framework)
                 .WithProperty("PublishDir", BIN_DIR + framework));
 
-        foreach(var framework in new [] { "netstandard1.6", "netstandard2.0" })
+        foreach(var framework in new [] { "netstandard2.0" })
              MSBuild(ENGINE_API_CSPROJ, CreateMSBuildSettings("Publish")
                 .WithProperty("TargetFramework", framework)
                 .WithProperty("PublishDir", BIN_DIR + framework));
@@ -298,24 +298,6 @@ Task("TestNetCore31Console")
                 runtime,
                 ref ErrorDetail);
         }
-    });
-
-//////////////////////////////////////////////////////////////////////
-// TEST NETSTANDARD 1.6 ENGINE
-//////////////////////////////////////////////////////////////////////
-
-Task("TestNetStandard16Engine")
-    .Description("Tests the .NET Standard Engine")
-    .IsDependentOn("Build")
-    .WithCriteria(!BuildSystem.IsRunningOnAzurePipelines)   //Unable to find Azure build supporting both .NET Core 1.1 and .NET Core 3.1
-    .OnError(exception => { ErrorDetail.Add(exception.Message); })
-    .Does(() =>
-    {
-        RunDotnetCoreNUnitLiteTests(
-            NETCOREAPP11_BIN_DIR + ENGINE_TESTS,
-            NETCOREAPP11_BIN_DIR,
-            "netcoreapp1.1",
-            ref ErrorDetail);
     });
 
 //////////////////////////////////////////////////////////////////////

--- a/build.cake
+++ b/build.cake
@@ -48,6 +48,7 @@ var ZIP_IMG = PROJECT_DIR + "zip-image/";
 
 var SOLUTION_FILE = PROJECT_DIR + "NUnitConsole.sln";
 var ENGINE_CSPROJ = PROJECT_DIR + "src/NUnitEngine/nunit.engine/nunit.engine.csproj";
+var ENGINE_CORE_CSPROJ = PROJECT_DIR + "src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj";
 var ENGINE_API_CSPROJ = PROJECT_DIR + "src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj";
 var ENGINE_TESTS_CSPROJ = PROJECT_DIR + "src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj";
 var CONSOLE_CSPROJ = PROJECT_DIR + "src/NUnitConsole/nunit3-console/nunit3-console.csproj";
@@ -203,7 +204,7 @@ MSBuildSettings CreateMSBuildSettings(string target)
 }
 
 Task("Build")
-    .Description("Builds the engine and console")
+    .Description("Builds the engine and console") 
     .IsDependentOn("UpdateAssemblyInfo")
     .Does(() =>
     {
@@ -212,11 +213,15 @@ Task("Build")
         Information("Publishing .NET Core & Standard projects so that dependencies are present...");
 
         foreach(var framework in new [] { "netstandard2.0", "netcoreapp3.1" })
-             MSBuild(ENGINE_CSPROJ, CreateMSBuildSettings("Publish")
-                .WithProperty("TargetFramework", framework)
-                .WithProperty("PublishDir", BIN_DIR + framework));
+            MSBuild(ENGINE_CSPROJ, CreateMSBuildSettings("Publish")
+               .WithProperty("TargetFramework", framework)
+               .WithProperty("PublishDir", BIN_DIR + framework));
 
-        foreach(var framework in new [] { "netstandard2.0" })
+        MSBuild(ENGINE_CORE_CSPROJ, CreateMSBuildSettings("Publish")
+           .WithProperty("TargetFramework", "netstandard1.6")
+           .WithProperty("PublishDir", BIN_DIR + "netstandard1.6"));
+
+        foreach (var framework in new [] { "netstandard1.6", "netstandard2.0" })
              MSBuild(ENGINE_API_CSPROJ, CreateMSBuildSettings("Publish")
                 .WithProperty("TargetFramework", framework)
                 .WithProperty("PublishDir", BIN_DIR + framework));

--- a/build.cake
+++ b/build.cake
@@ -806,7 +806,6 @@ Task("TestConsole")
 Task("TestEngine")
     .Description("Builds and tests the engine")
     .IsDependentOn("TestNet20Engine")
-    .IsDependentOn("TestNetStandard16Engine")
     .IsDependentOn("TestNetStandard20Engine")
     .IsDependentOn("TestNetCore31Engine");
 

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -72,7 +72,6 @@
     <file src="../../nuget/engine/nunit.engine.nuget.addins" target="contentFiles/any/lib/net20"/>
     <file src="../../nuget/engine/nunit.agent.addins" target="contentFiles/any/agents/net20"/>
     <file src="../../nuget/engine/nunit.agent.addins" target="contentFiles/any/agents/net40"/>
-    <file src="bin/netstandard1.6/nunit.engine.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard1.6/nunit.engine.core.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard1.6/nunit.engine.api.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard1.6/testcentric.engine.metadata.dll" target="lib/netstandard1.6" />

--- a/package-checks.cake
+++ b/package-checks.cake
@@ -56,10 +56,10 @@ public void CheckAllPackages()
             HasFiles("LICENSE.txt", "license.rtf", "NOTICES.txt", "CHANGES.txt"),
             HasDirectory("bin/net20").WithFiles("nunit3-console.exe", "nunit3-console.exe.config").AndFiles(ENGINE_FILES),
             HasDirectory("bin/net35").WithFiles("nunit3-console.exe", "nunit3-console.exe.config").AndFiles(ENGINE_FILES),
-            HasDirectory("bin/netstandard1.6").WithFiles(ENGINE_FILES),
+            HasDirectory("bin/netstandard1.6").WithFiles("nunit.engine.core.dll", "nunit.engine.api.dll", "testcentric.engine.metadata.dll"),
             HasDirectory("bin/netstandard2.0").WithFiles(ENGINE_FILES),
-            HasDirectory("bin/netcoreapp1.1").WithFiles(ENGINE_FILES),
-            HasDirectory("bin/netcoreapp1.1").WithFiles(ENGINE_FILES),
+            HasDirectory("bin/netcoreapp1.1").WithFiles("nunit.engine.core.dll", "nunit.engine.api.dll", "testcentric.engine.metadata.dll"),
+            HasDirectory("bin/netcoreapp2.1").WithFiles(ENGINE_FILES),
             HasDirectory("bin/agents/net20").WithFiles(AGENT_FILES),
             HasDirectory("bin/agents/net40").WithFiles(AGENT_FILES)) &
         CheckMsiPackage("NUnit.Console", 

--- a/package-checks.cake
+++ b/package-checks.cake
@@ -27,7 +27,7 @@ public void CheckAllPackages()
         CheckNuGetPackage("NUnit.Engine",
             HasFiles("LICENSE.txt", "NOTICES.txt", "CHANGES.txt"),
             HasDirectory("lib/net20").WithFiles(ENGINE_FILES),
-            HasDirectory("lib/netstandard1.6").WithFiles(ENGINE_FILES),
+            HasDirectory("lib/netstandard1.6").WithFiles("nunit.engine.core.dll", "nunit.engine.api.dll", "testcentric.engine.metadata.dll"),
             HasDirectory("lib/netstandard2.0").WithFiles(ENGINE_FILES),
             HasDirectory("contentFiles/any/lib/net20").WithFile("nunit.engine.nuget.addins"),
             HasDirectory("contentFiles/any/lib/netstandard1.6").WithFile("nunit.engine.nuget.addins"),

--- a/src/NUnitEngine/EngineApiVersion.cs
+++ b/src/NUnitEngine/EngineApiVersion.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("NUnit Engine API")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyInformationalVersion("3.12.0")]
+[assembly: AssemblyInformationalVersion("3.12.0-beta1")]
 [assembly: AssemblyFileVersion("3.12.0")]

--- a/src/NUnitEngine/nunit.engine.tests/Api/ServiceLocatorTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/ServiceLocatorTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -50,3 +51,4 @@ namespace NUnit.Engine.Api.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/SettingsGroupTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.ComponentModel;
 using NUnit.Framework;
@@ -118,3 +119,4 @@ namespace NUnit.Engine.Internal.Tests
 #endif
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -75,13 +76,7 @@ namespace NUnit.Engine.Runners.Tests
             // 1. These tests document current behavior. In some cases we may want to change that behavior.
             // 2. The .NET Standard builds don't seem to handle notest-assembly correctly, so those entries are commented out.
             // 3. The .NET Standard 1.6 build is not intended to handle projects.
-#if NETCOREAPP1_1
-            new TestRunData( "mock-assembly.dll", MockAssemblyData ),
-            new TestRunData( "mock-assembly.dll,mock-assembly.dll", MockAssemblyData, MockAssemblyData ),
-            //new TestRunData( "notest-assembly.dll", NoTestAssemblyData ),
-            //new TestRunData( "notest-assembly.dll,notest-assembly.dll", NoTestAssemblyData, NoTestAssemblyData ),
-            //new TestRunData( "mock-assembly.dll,notest-assembly.dll", MockAssemblyData, NoTestAssemblyData )
-#elif NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP2_1 || NETCOREAPP3_1
             new TestRunData( "mock-assembly.dll", MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", MockAssemblyData, MockAssemblyData ),
             //new TestRunData( "notest-assembly.dll", NoTestAssemblyData ),
@@ -112,7 +107,6 @@ namespace NUnit.Engine.Runners.Tests
 
             // Add all services needed
             _services = new ServiceContext();
-#if !NETCOREAPP1_1
             _services.Add(new ExtensionService());
             var projectService = new FakeProjectService();
             var mockPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
@@ -122,7 +116,6 @@ namespace NUnit.Engine.Runners.Tests
             projectService.Add("project3.nunit", notestsPath);
             projectService.Add("project4.nunit", notestsPath, notestsPath);
             _services.Add(projectService);
-#endif
 #if NETFRAMEWORK
             _services.Add(new DomainManager());
             _services.Add(new RuntimeFrameworkService());
@@ -200,7 +193,6 @@ namespace NUnit.Engine.Runners.Tests
             CheckTestRunEvents();
         }
 
-#if !NETCOREAPP1_1
         [Test]
         public void RunAsync()
         {
@@ -215,7 +207,6 @@ namespace NUnit.Engine.Runners.Tests
 
             CheckTestRunEvents();
         }
-#endif
 
         private void CheckResult(XmlNode result, ResultData expected)
         {
@@ -300,9 +291,7 @@ namespace NUnit.Engine.Runners.Tests
             Assert.That(startRun.GetAttribute("clr-version"), Is.Not.Null, "Incorrect clr-version in start-run event");
             Assert.That(startRun.GetAttribute("start-time", DateTime.Now.AddDays(-2)), Is.GreaterThan(DateTime.Now.AddDays(-1)), "Incorrect start-time in start-run event");
             Assert.That(startRun.GetAttribute("count", -1), Is.EqualTo(_testRunData.Tests), "Incorrect count in start-run event");
-#if !NETCOREAPP1_1
             Assert.That(startRun.FirstChild.Name, Is.EqualTo("command-line"), "First child of start-run should be command-line");
-#endif
             Assert.That(_events[_events.Count - 1].Name, Is.EqualTo("test-run"), "Last event should be test-run");
 
             Assert.That(_events.Count(x => x.Name == "start-run"), Is.EqualTo(1), "More than one start-run event");
@@ -386,3 +375,4 @@ namespace NUnit.Engine.Runners.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -300,7 +300,7 @@ namespace NUnit.Engine.Runners.Tests
             Assert.That(startRun.GetAttribute("clr-version"), Is.Not.Null, "Incorrect clr-version in start-run event");
             Assert.That(startRun.GetAttribute("start-time", DateTime.Now.AddDays(-2)), Is.GreaterThan(DateTime.Now.AddDays(-1)), "Incorrect start-time in start-run event");
             Assert.That(startRun.GetAttribute("count", -1), Is.EqualTo(_testRunData.Tests), "Incorrect count in start-run event");
-#if !NETSTANDARD1_6 && !NETCOREAPP1_1
+#if !NETCOREAPP1_1
             Assert.That(startRun.FirstChild.Name, Is.EqualTo("command-line"), "First child of start-run should be command-line");
 #endif
             Assert.That(_events[_events.Count - 1].Name, Is.EqualTo("test-run"), "Last event should be test-run");

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -67,10 +68,8 @@ namespace NUnit.Engine.Runners.Tests
         {
             // Add all services needed by any of our TestEngineRunners
             _services = new ServiceContext();
-#if !NETCOREAPP1_1
             _services.Add(new Services.ExtensionService());
             _services.Add(new Services.ProjectService());
-#endif
 #if NETFRAMEWORK
             _services.Add(new Services.DomainManager());
             _services.Add(new Services.RuntimeFrameworkService());
@@ -135,7 +134,6 @@ namespace NUnit.Engine.Runners.Tests
             CheckPackageLoading();
         }
 
-#if !NETCOREAPP1_1
         [Test]
         public void RunAsync()
         {
@@ -151,7 +149,6 @@ namespace NUnit.Engine.Runners.Tests
             CheckRunResult(asyncResult.EngineResult);
             CheckPackageLoading();
         }
-#endif
 
         private void CheckPackageLoading()
         {
@@ -193,3 +190,4 @@ namespace NUnit.Engine.Runners.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -58,3 +59,4 @@ namespace NUnit.Engine.Services.Tests.Fakes
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeSettingsService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeSettingsService.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using NUnit.Engine.Internal;
 
@@ -55,3 +56,4 @@ namespace NUnit.Engine.Services.Tests.Fakes
         public bool FailedToStop { get; set; }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RecentFilesTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using NUnit.Framework;
 
@@ -203,3 +204,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.IO;
 using System.Reflection;
@@ -36,9 +37,7 @@ namespace NUnit.Engine.Services.Tests
         public void CreateService()
         {
             var services = new ServiceContext();
-#if !NETCOREAPP1_1
             services.Add(new ExtensionService());
-#endif
             _resultService = new ResultService();
             services.Add(_resultService);
             services.ServiceManager.StartServices();
@@ -53,11 +52,7 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public void AvailableFormats()
         {
-#if NETCOREAPP1_1
-            Assert.That(_resultService.Formats, Is.EquivalentTo(new string[] { "nunit3", "cases" }));
-#else
             Assert.That(_resultService.Formats, Is.EquivalentTo(new string[] { "nunit3", "cases", "user" }));
-#endif
         }
 
         [TestCase("nunit3", null, ExpectedResult = "NUnit3XmlResultWriter")]
@@ -98,3 +93,4 @@ namespace NUnit.Engine.Services.Tests
 #endif
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceDependencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceDependencyTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using NUnit.Framework;
 
@@ -73,7 +74,6 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
         }
 
-#if !NETCOREAPP1_1
         [Test]
         public void DefaultTestRunnerFactory_ProjectServiceMissing()
         {
@@ -82,6 +82,6 @@ namespace NUnit.Engine.Services.Tests
             service.StartService();
             Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
         }
-#endif
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using NUnit.Framework;
 
@@ -90,3 +91,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/SettingsServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/SettingsServiceTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -48,3 +49,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilterBuilderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilterBuilderTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Xml;
 using NUnit.Engine;
@@ -108,3 +109,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -35,7 +36,7 @@ namespace NUnit.Engine.Services.Tests
     {
         private const string MOCK_ASSEMBLY = "mock-assembly.dll";
 
-#if NETCOREAPP1_1 || NETCOREAPP2_1
+#if NETCOREAPP2_1
         private NUnitNetStandardDriver _driver;
 #elif NETCOREAPP3_1
         private NUnitNetCore31Driver _driver;
@@ -47,7 +48,7 @@ namespace NUnit.Engine.Services.Tests
         public void LoadAssembly()
         {
             var mockAssemblyPath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-#if NETCOREAPP1_1 || NETCOREAPP2_1
+#if NETCOREAPP2_1
             _driver = new NUnitNetStandardDriver();
 #elif NETCOREAPP3_1
             _driver = new NUnitNetCore31Driver();
@@ -103,3 +104,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Engine.Runners;
@@ -45,14 +46,12 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
         public void SetUp()
         {
             _services = new ServiceContext();
-#if !NETCOREAPP1_1
             _services.Add(new ExtensionService());
             var projectService = new FakeProjectService();
             ((IService)projectService).StartService();
             projectService.Add(TestPackageFactory.FakeProject, "a.dll", "b.dll");
             _services.Add(projectService);
             Assert.That(((IService)projectService).Status, Is.EqualTo(ServiceStatus.Started));
-#endif
             _factory = new DefaultTestRunnerFactory();
             _services.Add(_factory);
             _factory.StartService();
@@ -92,3 +91,4 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
 #endif
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -89,3 +90,4 @@ namespace NUnit.Engine.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -163,3 +164,4 @@ namespace NUnit.Engine.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType Condition="'$(TargetFramework)'!='net35'">Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
@@ -33,6 +33,8 @@
     <ProjectReference Include="..\mock-assembly\mock-assembly.csproj" />
     <ProjectReference Include="..\nunit.engine.api\nunit.engine.api.csproj" />
     <ProjectReference Include="..\nunit.engine.core\nunit.engine.core.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp1.1'">
     <ProjectReference Include="..\nunit.engine\nunit.engine.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType Condition="'$(TargetFramework)'!='net35'">Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitEngine/nunit.engine/Internal/ProcessModel.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ProcessModel.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 
 namespace NUnit.Engine.Internal

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsStore.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsStore.cs
@@ -27,9 +27,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 using System.Xml;
-#if NETSTANDARD1_6
-using System.Xml.Linq;
-#endif
 
 namespace NUnit.Engine.Internal
 {
@@ -104,29 +101,6 @@ namespace NUnit.Engine.Internal
                 if (!Directory.Exists(dirPath))
                     Directory.CreateDirectory(dirPath);
 
-#if NETSTANDARD1_6
-                var settings = new XElement("Settings");
-
-                List<string> keys = new List<string>(_settings.Keys);
-                keys.Sort();
-
-                foreach (string name in keys)
-                {
-                    object val = GetSetting(name);
-                    if (val != null)
-                    {
-                        settings.Add(new XElement("Setting",
-                                                    new XAttribute("name", name),
-                                                    new XAttribute("value", TypeDescriptor.GetConverter(val.GetType()).ConvertToInvariantString(val))
-                                                    ));
-                    }
-                }
-                var doc = new XDocument(new XElement("NUnitSettings", settings));
-                using (var file = new FileStream(_settingsFile, FileMode.Create, FileAccess.Write))
-                {
-                    doc.Save(file);
-                }
-#else
                 var stream = new MemoryStream();
                 using (var writer = new XmlTextWriter(stream, Encoding.UTF8))
                 {
@@ -161,7 +135,6 @@ namespace NUnit.Engine.Internal
                     var contents = reader.ReadToEnd();
                     File.WriteAllText(_settingsFile, contents, Encoding.UTF8);
                 }
-#endif
             }
             catch (Exception)
             {

--- a/src/NUnitEngine/nunit.engine/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/nunit.engine/Properties/AssemblyInfo.cs
@@ -5,13 +5,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-#if NETSTANDARD1_6
-[assembly: AssemblyTitle("NUnit .NET Standard Engine")]
-[assembly: AssemblyDescription("Provides a common interface for loading, exploring and running NUnit tests in .NET Core and .NET Standard")]
-#else
 [assembly: AssemblyTitle("NUnit Engine")]
 [assembly: AssemblyDescription("Provides a common interface for loading, exploring and running NUnit tests")]
-#endif
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -55,9 +55,7 @@ namespace NUnit.Engine.Runners
 
         private ITestEngineRunner _engineRunner;
         private readonly IServiceLocator _services;
-#if !NETSTANDARD1_6
         private readonly ExtensionService _extensionService;
-#endif
 #if NETFRAMEWORK
         private readonly IRuntimeFrameworkService _runtimeService;
 #endif
@@ -80,9 +78,7 @@ namespace NUnit.Engine.Runners
 #if NETFRAMEWORK
             _runtimeService = _services.GetService<IRuntimeFrameworkService>();
 #endif
-#if !NETSTANDARD1_6
             _extensionService = _services.GetService<ExtensionService>();
-#endif
 
             // Last chance to catch invalid settings in package,
             // in case the client runner missed them.
@@ -171,7 +167,6 @@ namespace NUnit.Engine.Runners
         }
 
 
-#if !NETSTANDARD1_6
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage. The tests are run
         /// asynchronously and the listener interface is notified as it progresses.
@@ -183,7 +178,6 @@ namespace NUnit.Engine.Runners
         {
             return RunTestsAsync(listener, filter);
         }
-#endif
 
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
@@ -434,23 +428,17 @@ namespace NUnit.Engine.Runners
             var eventDispatcher = new TestEventDispatcher();
             if (listener != null)
                 eventDispatcher.Listeners.Add(listener);
-#if !NETSTANDARD1_6
+
             foreach (var extension in _extensionService.GetExtensions<ITestEventListener>())
                 eventDispatcher.Listeners.Add(extension);
-#endif
 
             IsTestRunning = true;
             
             string clrVersion;
             string engineVersion;
 
-#if !NETSTANDARD1_6
             clrVersion = Environment.Version.ToString();
             engineVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-#else
-            clrVersion =  Microsoft.DotNet.InternalAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
-            engineVersion = typeof(MasterTestRunner).GetTypeInfo().Assembly.GetName().Version.ToString();
-#endif
 
             var startTime = DateTime.UtcNow;
             var startRunNode = XmlHelper.CreateTopLevelElement("start-run");
@@ -459,9 +447,7 @@ namespace NUnit.Engine.Runners
             startRunNode.AddAttribute("engine-version", engineVersion);
             startRunNode.AddAttribute("clr-version", clrVersion);
 
-#if !NETSTANDARD1_6
             InsertCommandLineElement(startRunNode);
-#endif
 
             eventDispatcher.OnTestEvent(startRunNode.OuterXml);
 
@@ -472,9 +458,7 @@ namespace NUnit.Engine.Runners
             // These are inserted in reverse order, since each is added as the first child.
             InsertFilterElement(result.Xml, filter);
 
-#if !NETSTANDARD1_6
             InsertCommandLineElement(result.Xml);
-#endif
 
             result.Xml.AddAttribute("engine-version", engineVersion);
             result.Xml.AddAttribute("clr-version", clrVersion);
@@ -490,7 +474,6 @@ namespace NUnit.Engine.Runners
             return result;
         }
 
-#if !NETSTANDARD1_6
         private AsyncTestEngineResult RunTestsAsync(ITestEventListener listener, TestFilter filter)
         {
             var testRun = new AsyncTestEngineResult();
@@ -524,7 +507,6 @@ namespace NUnit.Engine.Runners
             var cdata = doc.CreateCDataSection(Environment.CommandLine);
             cmd.AppendChild(cdata);
         }
-#endif
 
         private static void InsertFilterElement(XmlNode resultNode, TestFilter filter)
         {

--- a/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
@@ -29,11 +29,7 @@ namespace NUnit.Engine.Runners
     /// <summary>
     /// TestEventDispatcher is used to send test events to a number of listeners
     /// </summary>
-    public class TestEventDispatcher :
-#if !NETSTANDARD1_6
-        MarshalByRefObject, 
-#endif
-        ITestEventListener
+    public class TestEventDispatcher : MarshalByRefObject, ITestEventListener
     {
         private object _eventLock = new object();
 
@@ -53,11 +49,9 @@ namespace NUnit.Engine.Runners
             }
         }
 
-#if !NETSTANDARD1_6
         public override object InitializeLifetimeService()
         {
             return null;
         }
-#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/AgentStatus.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStatus.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 namespace NUnit.Engine.Services
 {
     /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Diagnostics;
 

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6 && !NETSTANDARD2_0
+#if !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -33,13 +33,10 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class DefaultTestRunnerFactory : InProcessTestRunnerFactory, ITestRunnerFactory
     {
-#if !NETSTANDARD1_6
         private IProjectService _projectService;
-#endif
 
         public override void StartService()
         {
-#if !NETSTANDARD1_6
             // TestRunnerFactory requires the ProjectService
             _projectService = ServiceContext.GetService<IProjectService>();
 
@@ -47,9 +44,6 @@ namespace NUnit.Engine.Services
             Status = _projectService != null && ((IService)_projectService).Status == ServiceStatus.Started
                 ? ServiceStatus.Started
                 : ServiceStatus.Error;
-#else
-            Status = ServiceStatus.Started;
-#endif
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Common;
@@ -167,4 +166,3 @@ namespace NUnit.Engine.Services
         }
     }
 }
-#endif

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -29,14 +29,8 @@ namespace NUnit.Engine.Services
 {
     public class ResultService : Service, IResultService
     {
-#if NETSTANDARD1_6
-        private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases" };
-#else
         private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases", "user" };
-#endif
-#if !NETSTANDARD1_6
         private IEnumerable<ExtensionNode> _extensionNodes;
-#endif
 
         private string[] _formats;
         public string[] Formats
@@ -47,11 +41,9 @@ namespace NUnit.Engine.Services
                 {
                     var formatList = new List<string>(BUILT_IN_FORMATS);
 
-#if !NETSTANDARD1_6
                     foreach (var node in _extensionNodes)
                         foreach (var format in node.GetValues("Format"))
                             formatList.Add(format);
-#endif
 
                     _formats = formatList.ToArray();
                 }
@@ -74,17 +66,14 @@ namespace NUnit.Engine.Services
                     return new NUnit3XmlResultWriter();
                 case "cases":
                     return new TestCaseResultWriter();
-#if !NETSTANDARD1_6
                 case "user":
                     return new XmlTransformResultWriter(args);
-#endif
+
                 default:
-#if !NETSTANDARD1_6
                     foreach (var node in _extensionNodes)
                         foreach (var supported in node.GetValues("Format"))
                             if (supported == format)
                                 return node.ExtensionObject as IResultWriter;
-#endif
                     return null;
             }
         }
@@ -93,12 +82,11 @@ namespace NUnit.Engine.Services
         {
             try
             {
-#if !NETSTANDARD1_6
                 var extensionService = ServiceContext.GetService<ExtensionService>();
 
                 if (extensionService != null && extensionService.Status == ServiceStatus.Started)
                     _extensionNodes = extensionService.GetExtensionNodes<IResultWriter>();
-#endif
+
                 // If there is no extension service, we start anyway using builtin writers
                 Status = ServiceStatus.Started;
             }

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -76,12 +76,11 @@ namespace NUnit.Engine.Services
             test.AddAttribute("start-time", DateTime.UtcNow.ToString("u"));
             doc.AppendChild(test);
 
-#if !NETSTANDARD1_6
             var cmd = doc.CreateElement("command-line");
             var cdata = doc.CreateCDataSection(Environment.CommandLine);
             cmd.AppendChild(cdata);
             test.AppendChild(cmd);
-#endif
+
             return doc;
         }
     }

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -21,7 +21,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD1_6
 using System;
 using System.IO;
 using System.Text;
@@ -96,4 +95,3 @@ namespace NUnit.Engine.Services
         }
     }
 }
-#endif

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -81,10 +81,8 @@ namespace NUnit.Engine
                 Services.Add(new SettingsService(true));
                 Services.Add(new RecentFilesService());
                 Services.Add(new TestFilterService());
-#if !NETSTANDARD1_6
                 Services.Add(new ExtensionService());
                 Services.Add(new ProjectService());
-#endif
 #if NETFRAMEWORK
                 Services.Add(new DomainManager());
                 Services.Add(new RuntimeFrameworkService());

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard1.6;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -9,7 +9,7 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />


### PR DESCRIPTION
Fixes #849

PR #854 should be reviewed before this one, because it removes .NET Standard 1.6 completely. If that's approved, we can drop this one, which only removes the 1.6 build for the primary engine.
