### PR TITLE
Remove Microsoft.DotNet.InternalAbstractions dependency fully (Except .NET Standard 1.6)

### DIFF
--- a/nuget/runners/nunit.console-runner.netcore.nuspec
+++ b/nuget/runners/nunit.console-runner.netcore.nuspec
@@ -44,7 +44,6 @@
     <file src="bin/netcoreapp3.1/nunit.engine.api.dll" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/nunit.engine.api.pdb" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/nunit.engine.api.xml" target="tools/netcoreapp3.1/any" />
-    <file src="bin/netcoreapp3.1/Microsoft.DotNet.InternalAbstractions.dll" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/testcentric.engine.metadata.dll" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/System.Xml.XPath.XmlDocument.dll" target="tools/netcoreapp3.1/any" />
     <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools/netcoreapp3.1/any"/>

--- a/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
+++ b/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
@@ -9,8 +9,10 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -9,8 +9,10 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />


### PR DESCRIPTION
Fixes #837, and corrects an error I made in an earlier PR.

@CharliePoole - apologies, this will cause two small conflicts with your PR to remove the .NET Standard 1.6 builds. I just wanted to fix the errors for the 3.12 release, and then we can remove fully after.  