### PR TITLE
Revert "Remove netstandard1.6 and netcoreapp1.1 builds"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,13 @@ jobs:
   
   steps:
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 1.1.2'
+    inputs:
+      packageType: runtime
+      version: 1.1.2
+      installationPath: C:/Program Files/dotnet
+
   - powershell: .\build.ps1 -Target Test -Configuration Release
     displayName: Build and test
 
@@ -22,6 +29,14 @@ jobs:
       testResultsFiles: test-results\net35\*.xml
       mergeTestResults: true
       testRunTitle: net35/Windows
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp1.1 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results\netcoreapp1.1\*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp1.1/Windows
     condition: succeededOrFailed()
   - task: PublishTestResults@2
     displayName: Publish netcoreapp2.1 test results
@@ -51,6 +66,7 @@ jobs:
       sudo dpkg -i packages-microsoft-prod.deb
       sudo apt-get install apt-transport-https
       sudo apt-get update
+      sudo apt-get install dotnet-sharedframework-microsoft.netcore.app-1.1.2
       sudo apt-get install dotnet-sdk-2.2
       sudo apt-get install dotnet-runtime-5.0
       ./build.sh --target=Test --configuration=Release
@@ -64,6 +80,14 @@ jobs:
       testResultsFiles: test-results/net35/*.xml
       mergeTestResults: true
       testRunTitle: net35/Linux
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp1.1 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/netcoreapp1.1/*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp1.1/Linux
     condition: succeededOrFailed()
   - task: PublishTestResults@2
     displayName: Publish netcoreapp2.1 test results
@@ -96,6 +120,12 @@ jobs:
       packageType: runtime
       version: 2.1.x
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core runtime 1.1'
+    inputs:
+      packageType: runtime
+      version: 1.1.x
+
   - bash: |
      dotnet tool install --global Cake.Tool
      dotnet cake --target=Test --configuration=Release
@@ -109,6 +139,14 @@ jobs:
       testResultsFiles: test-results/net35/*.xml
       mergeTestResults: true
       testRunTitle: net35/macOS
+    condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish netcoreapp1.1 test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: test-results/netcoreapp1.1/*.xml
+      mergeTestResults: true
+      testRunTitle: netcoreapp1.1/macOS
     condition: succeededOrFailed()
   - task: PublishTestResults@2
     displayName: Publish netcoreapp2.1 test results

--- a/nuget/engine/nunit.engine.api.nuspec
+++ b/nuget/engine/nunit.engine.api.nuspec
@@ -20,6 +20,11 @@
     <copyright>Copyright (c) 2020 Charlie Poole, Rob Prouse</copyright>
     <dependencies>
       <group targetFramework="net20" />
+      <group targetFramework="netstandard1.6">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="System.Runtime.Loader" version="4.3.0" exclude="compile" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" exclude="compile" />
+      </group>
       <group targetFramework="netstandard2.0">
         <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" exclude="compile" />
       </group>
@@ -28,6 +33,7 @@
   <files>
     <file src="LICENSE.txt" />
     <file src="bin/net20/nunit.engine.api.dll" target="lib/net20" />
+    <file src="bin/netstandard1.6/nunit.engine.api.dll" target="lib/netstandard1.6" />
     <file src="bin/netstandard2.0/nunit.engine.api.dll" target="lib/netstandard2.0" />
     <file src="..\..\nunit_256.png" target="images" />
   </files>

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -20,6 +20,14 @@
     <copyright>Copyright (c) 2020 Charlie Poole, Rob Prouse</copyright>
     <dependencies>
       <group targetFramework="net20" />
+      <group targetFramework="netstandard1.6">
+        <dependency id="NETStandard.Library" version="1.6.1" />
+        <dependency id="Microsoft.DotNet.InternalAbstractions" version="1.0.0" exclude="compile" />
+        <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" exclude="compile" />
+        <dependency id="System.Reflection" version="4.3.0" exclude="compile" />
+        <dependency id="System.Diagnostics.Process" version="4.3.0" exclude="compile" />
+        <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" exclude="compile" />
+      </group>
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.0" />
         <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" exclude="compile" />
@@ -64,6 +72,11 @@
     <file src="../../nuget/engine/nunit.engine.nuget.addins" target="contentFiles/any/lib/net20"/>
     <file src="../../nuget/engine/nunit.agent.addins" target="contentFiles/any/agents/net20"/>
     <file src="../../nuget/engine/nunit.agent.addins" target="contentFiles/any/agents/net40"/>
+    <file src="bin/netstandard1.6/nunit.engine.dll" target="lib/netstandard1.6" />
+    <file src="bin/netstandard1.6/nunit.engine.core.dll" target="lib/netstandard1.6" />
+    <file src="bin/netstandard1.6/nunit.engine.api.dll" target="lib/netstandard1.6" />
+    <file src="bin/netstandard1.6/testcentric.engine.metadata.dll" target="lib/netstandard1.6" />
+    <file src="../../nuget/engine/nunit.engine.nuget.addins" target="contentFiles/any/lib/netstandard1.6"/>
     <file src="bin/netstandard2.0/nunit.engine.dll" target="lib/netstandard2.0" />
     <file src="bin/netstandard2.0/nunit.engine.core.dll" target="lib/netstandard2.0" />
     <file src="bin/netstandard2.0/nunit.engine.api.dll" target="lib/netstandard2.0" />

--- a/package-checks.cake
+++ b/package-checks.cake
@@ -27,8 +27,10 @@ public void CheckAllPackages()
         CheckNuGetPackage("NUnit.Engine",
             HasFiles("LICENSE.txt", "NOTICES.txt", "CHANGES.txt"),
             HasDirectory("lib/net20").WithFiles(ENGINE_FILES),
+            HasDirectory("lib/netstandard1.6").WithFiles(ENGINE_FILES),
             HasDirectory("lib/netstandard2.0").WithFiles(ENGINE_FILES),
             HasDirectory("contentFiles/any/lib/net20").WithFile("nunit.engine.nuget.addins"),
+            HasDirectory("contentFiles/any/lib/netstandard1.6").WithFile("nunit.engine.nuget.addins"),
             HasDirectory("contentFiles/any/lib/netstandard2.0").WithFile("nunit.engine.nuget.addins"),
             HasDirectory("contentFiles/any/agents/net20").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins"),
             HasDirectory("contentFiles/any/agents/net40").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins")) &
@@ -36,6 +38,7 @@ public void CheckAllPackages()
             "NUnit.Engine.Api",
             HasFile("LICENSE.txt"),
             HasDirectory("lib/net20").WithFile("nunit.engine.api.dll"),
+            HasDirectory("lib/netstandard1.6").WithFile("nunit.engine.api.dll"),
             HasDirectory("lib/netstandard2.0").WithFile("nunit.engine.api.dll")) &
         CheckNuGetPackage(
             "NUnit.Runners",
@@ -53,8 +56,10 @@ public void CheckAllPackages()
             HasFiles("LICENSE.txt", "license.rtf", "NOTICES.txt", "CHANGES.txt"),
             HasDirectory("bin/net20").WithFiles("nunit3-console.exe", "nunit3-console.exe.config").AndFiles(ENGINE_FILES),
             HasDirectory("bin/net35").WithFiles("nunit3-console.exe", "nunit3-console.exe.config").AndFiles(ENGINE_FILES),
+            HasDirectory("bin/netstandard1.6").WithFiles(ENGINE_FILES),
             HasDirectory("bin/netstandard2.0").WithFiles(ENGINE_FILES),
-            HasDirectory("bin/netcoreapp2.1").WithFiles(ENGINE_FILES),
+            HasDirectory("bin/netcoreapp1.1").WithFiles(ENGINE_FILES),
+            HasDirectory("bin/netcoreapp1.1").WithFiles(ENGINE_FILES),
             HasDirectory("bin/agents/net20").WithFiles(AGENT_FILES),
             HasDirectory("bin/agents/net40").WithFiles(AGENT_FILES)) &
         CheckMsiPackage("NUnit.Console", 

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -35,6 +35,8 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET 3.5 Debug")]
 #elif NET20
 [assembly: AssemblyConfiguration(".NET 2.0 Debug")]
+#elif NETSTANDARD1_6 || NETCOREAPP1_1
+[assembly: AssemblyConfiguration(".NET Standard 1.6 Debug")]
 #elif NETSTANDARD2_0 || NETCOREAPP2_1
 [assembly: AssemblyConfiguration(".NET Standard 2.0 Debug")]
 #else
@@ -45,6 +47,8 @@ using System.Reflection;
 [assembly: AssemblyConfiguration(".NET 3.5")]
 #elif NET20
 [assembly: AssemblyConfiguration(".NET 2.0")]
+#elif NETSTANDARD1_6 || NETCOREAPP1_1
+[assembly: AssemblyConfiguration(".NET Standard 1.6")]
 #elif NETSTANDARD2_0 || NETCOREAPP2_1
 [assembly: AssemblyConfiguration(".NET Standard 2.0")]
 #else

--- a/src/NUnitEngine/EngineApiVersion.cs
+++ b/src/NUnitEngine/EngineApiVersion.cs
@@ -25,5 +25,5 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("NUnit Engine API")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyInformationalVersion("3.12.0-beta1")]
+[assembly: AssemblyInformationalVersion("3.12.0")]
 [assembly: AssemblyFileVersion("3.12.0")]

--- a/src/NUnitEngine/mock-assembly/MockAssembly.cs
+++ b/src/NUnitEngine/mock-assembly/MockAssembly.cs
@@ -112,7 +112,9 @@ namespace NUnit.Tests
 
             public const int Inconclusive = MockTestFixture.Inconclusive;
 
+#if !NETCOREAPP1_1
             public static readonly string AssemblyPath = AssemblyHelper.GetAssemblyPath(typeof(MockAssembly).Assembly);
+#endif
         }
 
         [TestFixture(Description="Fake Test Fixture")]

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp1.1'">
     <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitEngine/notest-assembly/notest-assembly.csproj
+++ b/src/NUnitEngine/notest-assembly/notest-assembly.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>notest_assembly</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="NUnit" Version="3.12.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp1.1'">
     <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
   </ItemGroup>
 </Project>

--- a/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineException.cs
+++ b/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineException.cs
@@ -22,7 +22,9 @@
 // ***********************************************************************
 
 using System;
+#if !NETSTANDARD1_6
 using System.Runtime.Serialization;
+#endif
 
 namespace NUnit.Engine
 {
@@ -31,7 +33,9 @@ namespace NUnit.Engine
     /// called with improper values or when a particular facility
     /// is not available.
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class NUnitEngineException : Exception
     {
         /// <summary>
@@ -48,9 +52,11 @@ namespace NUnit.Engine
         {
         }
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Serialization constructor
         /// </summary>
         public NUnitEngineException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineNotFoundException.cs
+++ b/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineNotFoundException.cs
@@ -28,7 +28,9 @@ namespace NUnit.Engine
     /// <summary>
     /// The exception that is thrown if a valid test engine is not found
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class NUnitEngineNotFoundException : Exception
     {
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineUnloadException.cs
+++ b/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineUnloadException.cs
@@ -23,7 +23,9 @@
 
 using System;
 using System.Collections.Generic;
+#if !NETSTANDARD1_6
 using System.Runtime.Serialization;
+#endif
 
 namespace NUnit.Engine
 {
@@ -33,7 +35,9 @@ namespace NUnit.Engine
     /// but one or more errors were encountered when attempting to unload
     /// and shut down the test run cleanly.
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class NUnitEngineUnloadException : NUnitEngineException  //Inherits from NUnitEngineException for backwards compatibility of calling runners
     {
         private const string AggregatedExceptionsMsg =
@@ -62,10 +66,12 @@ namespace NUnit.Engine
             AggregatedExceptions = aggregatedExceptions;
         }
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Serialization constructor.
         /// </summary>
         public NUnitEngineUnloadException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
 
         /// <summary>
         /// Gets the collection of exceptions .

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IDriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IDriverFactory.cs
@@ -40,7 +40,7 @@ namespace NUnit.Engine.Extensibility
         /// <param name="reference">An AssemblyName referring to the possible test framework.</param>
         bool IsSupportedTestFramework(AssemblyName reference);
 
-#if NETSTANDARD2_0
+#if NETSTANDARD1_6 || NETSTANDARD2_0
         /// <summary>
         /// Gets a driver for a given test assembly and a framework
         /// which the assembly is already known to reference.

--- a/src/NUnitEngine/nunit.engine.api/ITestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.api/ITestRunner.cs
@@ -77,6 +77,7 @@ namespace NUnit.Engine
         /// <returns>An XmlNode giving the result of the test execution</returns>
         XmlNode Run(ITestEventListener listener, TestFilter filter);
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage. The tests are run
         /// asynchronously and the listener interface is notified as it progresses.
@@ -85,6 +86,7 @@ namespace NUnit.Engine
         /// <param name="filter">A TestFilter used to select tests</param>
         /// <returns></returns>
         ITestRun RunAsync(ITestEventListener listener, TestFilter filter);
+#endif
 
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.

--- a/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
@@ -38,7 +38,22 @@ namespace NUnit.Engine
         private const string DefaultAssemblyName = "nunit.engine.dll";
         internal const string DefaultTypeName = "NUnit.Engine.TestEngine";
 
-#if NETSTANDARD2_0
+#if NETSTANDARD1_6
+        /// <summary>
+        /// Create an instance of the test engine.
+        /// </summary>
+        /// <returns>An <see cref="NUnit.Engine.ITestEngine"/></returns>
+        public static ITestEngine CreateInstance()
+        {
+            var apiLocation = typeof(TestEngineActivator).GetTypeInfo().Assembly.Location;
+            var directoryName = Path.GetDirectoryName(apiLocation);
+            var enginePath = directoryName == null ? DefaultAssemblyName : Path.Combine(directoryName, DefaultAssemblyName);
+            var assemblyName = System.Runtime.Loader.AssemblyLoadContext.GetAssemblyName(enginePath);
+            var assembly = Assembly.Load(assemblyName);
+            var engineType = assembly.GetType(DefaultTypeName);
+            return Activator.CreateInstance(engineType) as ITestEngine;
+        }
+#elif NETSTANDARD2_0
         /// <summary>
         /// Create an instance of the test engine.
         /// </summary>

--- a/src/NUnitEngine/nunit.engine.api/TestFilter.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestFilter.cs
@@ -32,7 +32,9 @@ namespace NUnit.Engine
     /// In the console runner, filters serve only to carry this
     /// XML representation, as all filtering is done by the engine.
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class TestFilter
     {
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -43,7 +43,9 @@ namespace NUnit.Engine
     /// package, changing settings as needed. This gives the best chance for the
     /// tests in the reloaded assembly to match those originally loaded.
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class TestPackage
     {
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.api/TestSelectionParserException.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestSelectionParserException.cs
@@ -22,7 +22,9 @@
 // ***********************************************************************
 
 using System;
+#if !NETSTANDARD1_6
 using System.Runtime.Serialization;
+#endif
 
 namespace NUnit.Engine
 {
@@ -30,7 +32,9 @@ namespace NUnit.Engine
     /// TestSelectionParserException is thrown when an error
     /// is found while parsing the selection expression.
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class TestSelectionParserException : Exception
     {
         /// <summary>
@@ -45,9 +49,11 @@ namespace NUnit.Engine
         /// <param name="innerException"></param>
         public TestSelectionParserException(string message, Exception innerException) : base(message, innerException) { }
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Serialization constructor
         /// </summary>
         public TestSelectionParserException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard1.6;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -9,7 +9,10 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
+    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NUnitEngine/nunit.engine.core/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine.core/Agents/TestAgent.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 
 namespace NUnit.Engine.Agents

--- a/src/NUnitEngine/nunit.engine.core/AsyncTestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine.core/AsyncTestEngineResult.cs
@@ -31,7 +31,9 @@ namespace NUnit.Engine
     /// <summary>
     /// The TestRun class encapsulates an ongoing test run.
     /// </summary>
+#if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class AsyncTestEngineResult : ITestRun
     {
         private volatile TestEngineResult _result;

--- a/src/NUnitEngine/nunit.engine.core/CoreEngine.cs
+++ b/src/NUnitEngine/nunit.engine.core/CoreEngine.cs
@@ -40,7 +40,11 @@ namespace NUnit.Engine
         public CoreEngine()
         {
             Services = new ServiceContext();
+#if NETSTANDARD1_6
+            WorkDirectory = NUnitConfiguration.ApplicationDirectory;
+#else
             WorkDirectory = Environment.CurrentDirectory;
+#endif
             InternalTraceLevel = InternalTraceLevel.Default;
         }
 
@@ -97,7 +101,9 @@ namespace NUnit.Engine
                 // For example, ResultService uses ExtensionService, so ExtensionService is added
                 // later.
                 Services.Add(new DriverService());
+#if !NETSTANDARD1_6
                 Services.Add(new ExtensionService());
+#endif
 #if NETFRAMEWORK
                 Services.Add(new DomainManager());
 #endif

--- a/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionAssembly.cs
+++ b/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionAssembly.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.IO;
 using Mono.Cecil;
@@ -74,3 +75,4 @@ namespace NUnit.Engine.Extensibility
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionNode.cs
+++ b/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionNode.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -171,3 +172,4 @@ namespace NUnit.Engine.Extensibility
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionPoint.cs
+++ b/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionPoint.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 
@@ -104,3 +105,4 @@ namespace NUnit.Engine.Extensibility
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionSelector.cs
+++ b/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionSelector.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using NUnit.Common;
 
@@ -76,3 +77,4 @@ namespace NUnit.Engine.Extensibility
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Extensibility/IExtensionAssembly.cs
+++ b/src/NUnitEngine/nunit.engine.core/Extensibility/IExtensionAssembly.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 
 namespace NUnit.Engine.Extensibility
@@ -35,3 +36,4 @@ namespace NUnit.Engine.Extensibility
 #endif
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/IDriverService.cs
+++ b/src/NUnitEngine/nunit.engine.core/IDriverService.cs
@@ -32,6 +32,15 @@ namespace NUnit.Engine
     /// </summary>
     public interface IDriverService
     {
+#if NETSTANDARD1_6
+        /// <summary>
+        /// Get a driver suitable for use with a particular test assembly.
+        /// </summary>
+        /// <param name="assemblyPath">The full path to the test assembly</param>
+        /// <param name="skipNonTestAssemblies">True if non-test assemblies should simply be skipped rather than reporting an error</param>
+        /// <returns></returns>
+        IFrameworkDriver GetDriver(string assemblyPath, bool skipNonTestAssemblies);
+#else
         /// <summary>
         /// Get a driver suitable for loading and running tests in the specified assembly.
         /// </summary>
@@ -41,5 +50,6 @@ namespace NUnit.Engine
         /// <param name="skipNonTestAssemblies">True if non-test assemblies should simply be skipped rather than reporting an error</param>
         /// <returns></returns>
         IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, string targetFramework, bool skipNonTestAssemblies);
+#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/ITestEngineRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/ITestEngineRunner.cs
@@ -68,6 +68,7 @@ namespace NUnit.Engine
         /// <returns>A TestEngineResult giving the result of the test execution</returns>
         TestEngineResult Run(ITestEventListener listener, TestFilter filter);
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage. The tests are run
         /// asynchronously and the listener interface is notified as it progresses.
@@ -76,6 +77,7 @@ namespace NUnit.Engine
         /// <param name="filter">A TestFilter used to select tests</param>
         /// <returns>An <see cref="AsyncTestEngineResult"/> that will provide the result of the test execution</returns>
         AsyncTestEngineResult RunAsync(ITestEventListener listener, TestFilter filter);
+#endif
 
         /// <summary>
         /// Cancel the current test run. If no test is running,

--- a/src/NUnitEngine/nunit.engine.core/Internal/AssemblyHelper.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/AssemblyHelper.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.IO;
 using System.Reflection;
@@ -92,3 +93,4 @@ namespace NUnit.Engine.Internal
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Internal/DomainDetailsBuilder.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/DomainDetailsBuilder.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/NUnitEngine/nunit.engine.core/Internal/DomainUsage.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/DomainUsage.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 namespace NUnit.Engine.Internal
 {
     /// <summary>

--- a/src/NUnitEngine/nunit.engine.core/Internal/NUnitConfiguration.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/NUnitConfiguration.cs
@@ -34,6 +34,8 @@ namespace NUnit.Engine.Internal
     /// </summary>
     public static class NUnitConfiguration
     {
+#if !NETSTANDARD1_6
+
         private static string _engineDirectory;
         public static string EngineDirectory
         {
@@ -47,6 +49,8 @@ namespace NUnit.Engine.Internal
             }
         }
 
+#endif
+
         private static string _applicationDirectory;
         public static string ApplicationDirectory
         {
@@ -55,7 +59,11 @@ namespace NUnit.Engine.Internal
                 if (_applicationDirectory == null)
                 {
                     _applicationDirectory = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+#if NETSTANDARD1_6
+                    Environment.GetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "LocalAppData" : "HOME"),
+#else
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+#endif
                         "NUnit");
                 }
 

--- a/src/NUnitEngine/nunit.engine.core/Internal/ProvidedPathsAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/ProvidedPathsAssemblyResolver.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -95,3 +96,4 @@ namespace NUnit.Engine.Internal
         List<string> _resolutionPaths;
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/nunit.engine.core/Properties/AssemblyInfo.cs
@@ -5,7 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
+#if NETSTANDARD1_6
+[assembly: AssemblyTitle("NUnit .NET Standard Engine Core")]
+#else
 [assembly: AssemblyTitle("NUnit Engine Core")]
+#endif
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/src/NUnitEngine/nunit.engine.core/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/AbstractTestRunner.cs
@@ -99,6 +99,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult giving the result of the test execution</returns>
         protected abstract TestEngineResult RunTests(ITestEventListener listener, TestFilter filter);
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage, returning immediately.
         /// The tests are run asynchronously and the listener interface is notified
@@ -123,6 +124,7 @@ namespace NUnit.Engine.Runners
 
             return testRun;
         }
+#endif
 
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
@@ -189,6 +191,7 @@ namespace NUnit.Engine.Runners
             return RunTests(listener, filter);
         }
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage. The tests are run
         /// asynchronously and the listener interface is notified as it progresses.
@@ -200,6 +203,7 @@ namespace NUnit.Engine.Runners
         {
             return RunTestsAsync(listener, filter);
         }
+#endif
 
         public void Dispose()
         {

--- a/src/NUnitEngine/nunit.engine.core/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/AggregatingTestRunner.cs
@@ -168,6 +168,9 @@ namespace NUnit.Engine.Runners
 
             bool disposeRunners = TestPackage.GetSetting(EnginePackageSettings.DisposeRunners, false);
 
+#if NETSTANDARD1_6
+            RunTestsSequentially(listener, filter, results, disposeRunners);
+#else
             if (LevelOfParallelism <= 1)
             {
                 RunTestsSequentially(listener, filter, results, disposeRunners);
@@ -176,7 +179,7 @@ namespace NUnit.Engine.Runners
             {
                 RunTestsInParallel(listener, filter, results, disposeRunners);
             }
-
+#endif
             if (disposeRunners) Runners.Clear();
 
             return ResultHelper.Merge(results);
@@ -192,6 +195,7 @@ namespace NUnit.Engine.Runners
             }
         }
 
+#if !NETSTANDARD1_6
         private void RunTestsInParallel(ITestEventListener listener, TestFilter filter, List<TestEngineResult> results, bool disposeRunners)
         {
             var workerPool = new ParallelTaskWorkerPool(LevelOfParallelism);
@@ -210,6 +214,7 @@ namespace NUnit.Engine.Runners
             foreach (var task in tasks)
                 LogResultsFromTask(task, results, _unloadExceptions);
         }
+#endif
 
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.

--- a/src/NUnitEngine/nunit.engine.core/Runners/LocalTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/LocalTestRunner.cs
@@ -32,7 +32,9 @@ namespace NUnit.Engine.Runners
     {
         public LocalTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
         {
-            TestDomain = AppDomain.CurrentDomain;
+#if !NETSTANDARD1_6
+            this.TestDomain = AppDomain.CurrentDomain;
+#endif
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/Runners/ParallelTaskWorkerPool.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/ParallelTaskWorkerPool.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -111,3 +112,4 @@ namespace NUnit.Engine.Runners
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
@@ -49,7 +49,11 @@ namespace NUnit.Engine.Services
         /// <param name="targetFramework">The value of any TargetFrameworkAttribute on the assembly, or null</param>
         /// <param name="skipNonTestAssemblies">True if non-test assemblies should simply be skipped rather than reporting an error</param>
         /// <returns></returns>
+#if NETSTANDARD1_6
+        public IFrameworkDriver GetDriver(string assemblyPath, bool skipNonTestAssemblies)
+#else
         public IFrameworkDriver GetDriver(AppDomain domain, string assemblyPath, string targetFramework, bool skipNonTestAssemblies)
+#endif
         {
             if (!File.Exists(assemblyPath))
                 return new InvalidAssemblyFrameworkDriver(assemblyPath, "File not found: " + assemblyPath);
@@ -117,6 +121,7 @@ namespace NUnit.Engine.Services
 
             try
             {
+#if !NETSTANDARD1_6
                 var extensionService = ServiceContext.GetService<ExtensionService>();
                 if (extensionService != null)
                 {
@@ -129,6 +134,7 @@ namespace NUnit.Engine.Services
                         _factories.Add(new NUnit2DriverFactory(node));
 #endif
                 }
+#endif
 
                 _factories.Add(new NUnit3DriverFactory());
 

--- a/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -539,3 +540,4 @@ namespace NUnit.Engine.Services
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.core/TestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine.core/TestEngineResult.cs
@@ -47,12 +47,16 @@ namespace NUnit.Engine
     /// for combining multiple TestEngineResults into one.
     /// 
     /// </summary>
+ #if !NETSTANDARD1_6
     [Serializable]
+#endif
     public class TestEngineResult
     {
         private List<string> _xmlText = new List<string>();
 
+#if !NETSTANDARD1_6
         [NonSerialized]
+#endif
         private List<XmlNode> _xmlNodes = new List<XmlNode>();
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
+++ b/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard1.6;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -9,7 +9,10 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnitNetStandardDriverTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnitNetStandardDriverTests.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if NETCOREAPP2_1
+#if NETCOREAPP1_1 || NETCOREAPP2_1
 
 using System;
 using System.Collections.Generic;

--- a/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionAssemblyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Extensibility/ExtensionAssemblyTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Reflection;
 using NUnit.Engine.Extensibility;
@@ -81,3 +82,4 @@ namespace NUnit.Engine.Tests.Extensibility
 #endif
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/ShadowCopyUtils.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/ShadowCopyUtils.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if !NETCOREAPP1_1
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,3 +36,4 @@ namespace NUnit.Engine.Tests.Helpers
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Integration/DirectoryWithNeededAssemblies.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/DirectoryWithNeededAssemblies.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETCOREAPP1_1
+using System;
 using System.IO;
 using NUnit.Engine.Tests.Helpers;
 
@@ -29,3 +30,4 @@ namespace NUnit.Engine.Tests.Integration
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Integration/MockAssemblyInDirectoryWithFramework.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/MockAssemblyInDirectoryWithFramework.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETCOREAPP1_1
+using System;
 using System.IO;
 using NUnit.Framework;
 
@@ -23,3 +24,4 @@ namespace NUnit.Engine.Tests.Integration
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Integration/RunnerInDirectoryWithoutFramework.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/RunnerInDirectoryWithoutFramework.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NETCOREAPP1_1
+using System;
 using System.IO;
 using System.Threading;
 using NUnit.Framework;
@@ -37,3 +38,4 @@ namespace NUnit.Engine.Tests.Integration
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Internal/AssemblyHelperTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/AssemblyHelperTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System.IO;
 using NUnit.Framework;
 
@@ -73,3 +74,4 @@ namespace NUnit.Engine.Internal.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Internal/SettingsStoreTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/SettingsStoreTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.IO;
 using System.Xml.Schema;
@@ -106,3 +107,4 @@ namespace NUnit.Engine.Internal.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Runners/DirectTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/DirectTestRunnerTests.cs
@@ -44,8 +44,10 @@ namespace NUnit.Engine.Tests.Runners
 
             var driverService = Substitute.For<IDriverService>();
             driverService.GetDriver(
+#if !NETCOREAPP1_1
                 AppDomain.CurrentDomain,
                 string.Empty,
+#endif 
                 string.Empty, 
                 false).ReturnsForAnyArgs(_driver);
 

--- a/src/NUnitEngine/nunit.engine.tests/Runners/Fakes/EmptyDirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/Fakes/EmptyDirectTestRunner.cs
@@ -9,7 +9,9 @@ namespace NUnit.Engine.Tests.Runners.Fakes
     {
         public EmptyDirectTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
         {
+#if !NETCOREAPP1_1
             TestDomain = AppDomain.CurrentDomain;
+#endif
         }
 
         public new void LoadPackage()

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -75,7 +75,13 @@ namespace NUnit.Engine.Runners.Tests
             // 1. These tests document current behavior. In some cases we may want to change that behavior.
             // 2. The .NET Standard builds don't seem to handle notest-assembly correctly, so those entries are commented out.
             // 3. The .NET Standard 1.6 build is not intended to handle projects.
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP1_1
+            new TestRunData( "mock-assembly.dll", MockAssemblyData ),
+            new TestRunData( "mock-assembly.dll,mock-assembly.dll", MockAssemblyData, MockAssemblyData ),
+            //new TestRunData( "notest-assembly.dll", NoTestAssemblyData ),
+            //new TestRunData( "notest-assembly.dll,notest-assembly.dll", NoTestAssemblyData, NoTestAssemblyData ),
+            //new TestRunData( "mock-assembly.dll,notest-assembly.dll", MockAssemblyData, NoTestAssemblyData )
+#elif NETCOREAPP2_1 || NETCOREAPP3_1
             new TestRunData( "mock-assembly.dll", MockAssemblyData ),
             new TestRunData( "mock-assembly.dll,mock-assembly.dll", MockAssemblyData, MockAssemblyData ),
             //new TestRunData( "notest-assembly.dll", NoTestAssemblyData ),
@@ -106,6 +112,7 @@ namespace NUnit.Engine.Runners.Tests
 
             // Add all services needed
             _services = new ServiceContext();
+#if !NETCOREAPP1_1
             _services.Add(new ExtensionService());
             var projectService = new FakeProjectService();
             var mockPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
@@ -115,6 +122,7 @@ namespace NUnit.Engine.Runners.Tests
             projectService.Add("project3.nunit", notestsPath);
             projectService.Add("project4.nunit", notestsPath, notestsPath);
             _services.Add(projectService);
+#endif
 #if NETFRAMEWORK
             _services.Add(new DomainManager());
             _services.Add(new RuntimeFrameworkService());
@@ -192,6 +200,7 @@ namespace NUnit.Engine.Runners.Tests
             CheckTestRunEvents();
         }
 
+#if !NETCOREAPP1_1
         [Test]
         public void RunAsync()
         {
@@ -206,6 +215,7 @@ namespace NUnit.Engine.Runners.Tests
 
             CheckTestRunEvents();
         }
+#endif
 
         private void CheckResult(XmlNode result, ResultData expected)
         {
@@ -290,7 +300,9 @@ namespace NUnit.Engine.Runners.Tests
             Assert.That(startRun.GetAttribute("clr-version"), Is.Not.Null, "Incorrect clr-version in start-run event");
             Assert.That(startRun.GetAttribute("start-time", DateTime.Now.AddDays(-2)), Is.GreaterThan(DateTime.Now.AddDays(-1)), "Incorrect start-time in start-run event");
             Assert.That(startRun.GetAttribute("count", -1), Is.EqualTo(_testRunData.Tests), "Incorrect count in start-run event");
+#if !NETSTANDARD1_6 && !NETCOREAPP1_1
             Assert.That(startRun.FirstChild.Name, Is.EqualTo("command-line"), "First child of start-run should be command-line");
+#endif
             Assert.That(_events[_events.Count - 1].Name, Is.EqualTo("test-run"), "Last event should be test-run");
 
             Assert.That(_events.Count(x => x.Name == "start-run"), Is.EqualTo(1), "More than one start-run event");

--- a/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Threading;
 using NUnit.Framework;
@@ -157,3 +158,4 @@ namespace NUnit.Engine.Runners.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -67,8 +67,10 @@ namespace NUnit.Engine.Runners.Tests
         {
             // Add all services needed by any of our TestEngineRunners
             _services = new ServiceContext();
+#if !NETCOREAPP1_1
             _services.Add(new Services.ExtensionService());
             _services.Add(new Services.ProjectService());
+#endif
 #if NETFRAMEWORK
             _services.Add(new Services.DomainManager());
             _services.Add(new Services.RuntimeFrameworkService());
@@ -133,6 +135,7 @@ namespace NUnit.Engine.Runners.Tests
             CheckPackageLoading();
         }
 
+#if !NETCOREAPP1_1
         [Test]
         public void RunAsync()
         {
@@ -148,6 +151,7 @@ namespace NUnit.Engine.Runners.Tests
             CheckRunResult(asyncResult.EngineResult);
             CheckPackageLoading();
         }
+#endif
 
         private void CheckPackageLoading()
         {

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
@@ -40,6 +40,8 @@ namespace NUnit.Engine.Services
         [TestCase("net-2.0", true, "../agents/net20/nunit-agent-x86.exe")]
         //[TestCase("netcore-2.1", false, "agents/netcoreapp2.1/testcentric-agent.dll")]
         //[TestCase("netcore-2.1", true, "agents/netcoreapp2.1/testcentric-agent-x86.dll")]
+        //[TestCase("netcore-1.1", false, "agents/netcoreapp1.1/testcentric-agent.dll")]
+        //[TestCase("netcore-1.1", true, "agents/netcoreapp1.1/testcentric-agent-x86.dll")]
         public void AgentSelection(string runtime, bool x86, string agentPath)
         {
             _package.Settings[EnginePackageSettings.TargetRuntimeFramework] = runtime;

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.DummyTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.DummyTestAgent.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETCOREAPP2_0
+#if !NETCOREAPP1_1 && !NETCOREAPP2_0
 using System;
 
 namespace NUnit.Engine.Services.Tests

--- a/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DriverServiceTests.cs
@@ -39,7 +39,9 @@ namespace NUnit.Engine.Services.Tests
         public void CreateDriverFactory()
         {
             var serviceContext = new ServiceContext();
+#if !NETCOREAPP1_1
             serviceContext.Add(new ExtensionService());
+#endif
             _driverService = new DriverService();
             serviceContext.Add(_driverService);
             serviceContext.ServiceManager.StartServices();
@@ -56,7 +58,7 @@ namespace NUnit.Engine.Services.Tests
         [TestCase("mock-assembly.dll", false, typeof(NUnitNetCore31Driver))]
         [TestCase("mock-assembly.dll", true, typeof(NUnitNetCore31Driver))]
         [TestCase("notest-assembly.dll", false, typeof(NUnitNetCore31Driver))]
-#elif NETCOREAPP2_1
+#elif NETCOREAPP1_1 || NETCOREAPP2_1
         [TestCase("mock-assembly.dll", false, typeof(NUnitNetStandardDriver))]
         [TestCase("mock-assembly.dll", true, typeof(NUnitNetStandardDriver))]
         [TestCase("notest-assembly.dll", false, typeof(NUnitNetStandardDriver))]
@@ -74,7 +76,11 @@ namespace NUnit.Engine.Services.Tests
         [TestCase("notest-assembly.dll", true, typeof(SkippedAssemblyFrameworkDriver))]
         public void CorrectDriverIsUsed(string fileName, bool skipNonTestAssemblies, Type expectedType)
         {
+#if NETCOREAPP1_1
+            var driver = _driverService.GetDriver(Path.Combine(TestContext.CurrentContext.TestDirectory, fileName), skipNonTestAssemblies);
+#else
             var driver = _driverService.GetDriver(AppDomain.CurrentDomain, Path.Combine(TestContext.CurrentContext.TestDirectory, fileName), null, skipNonTestAssemblies);
+#endif
             Assert.That(driver, Is.InstanceOf(expectedType));
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ExtensionServiceTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -288,3 +289,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/ProjectServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ProjectServiceTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -49,3 +50,4 @@ namespace NUnit.Engine.Services.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
@@ -36,7 +36,9 @@ namespace NUnit.Engine.Services.Tests
         public void CreateService()
         {
             var services = new ServiceContext();
+#if !NETCOREAPP1_1
             services.Add(new ExtensionService());
+#endif
             _resultService = new ResultService();
             services.Add(_resultService);
             services.ServiceManager.StartServices();
@@ -51,7 +53,11 @@ namespace NUnit.Engine.Services.Tests
         [Test]
         public void AvailableFormats()
         {
+#if NETCOREAPP1_1
+            Assert.That(_resultService.Formats, Is.EquivalentTo(new string[] { "nunit3", "cases" }));
+#else
             Assert.That(_resultService.Formats, Is.EquivalentTo(new string[] { "nunit3", "cases", "user" }));
+#endif
         }
 
         [TestCase("nunit3", null, ExpectedResult = "NUnit3XmlResultWriter")]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETCOREAPP1_1
 using System.IO;
 using System.Xml;
 using NUnit.Engine.Runners;
@@ -87,3 +88,4 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceDependencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceDependencyTests.cs
@@ -73,6 +73,7 @@ namespace NUnit.Engine.Services.Tests
             Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
         }
 
+#if !NETCOREAPP1_1
         [Test]
         public void DefaultTestRunnerFactory_ProjectServiceMissing()
         {
@@ -81,5 +82,6 @@ namespace NUnit.Engine.Services.Tests
             service.StartService();
             Assert.That(service.Status, Is.EqualTo(ServiceStatus.Error));
         }
+#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Services.Tests
     {
         private const string MOCK_ASSEMBLY = "mock-assembly.dll";
 
-#if NETCOREAPP2_1
+#if NETCOREAPP1_1 || NETCOREAPP2_1
         private NUnitNetStandardDriver _driver;
 #elif NETCOREAPP3_1
         private NUnitNetCore31Driver _driver;
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Services.Tests
         public void LoadAssembly()
         {
             var mockAssemblyPath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-#if NETCOREAPP2_1
+#if NETCOREAPP1_1 || NETCOREAPP2_1
             _driver = new NUnitNetStandardDriver();
 #elif NETCOREAPP3_1
             _driver = new NUnitNetCore31Driver();

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -45,12 +45,14 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
         public void SetUp()
         {
             _services = new ServiceContext();
+#if !NETCOREAPP1_1
             _services.Add(new ExtensionService());
             var projectService = new FakeProjectService();
             ((IService)projectService).StartService();
             projectService.Add(TestPackageFactory.FakeProject, "a.dll", "b.dll");
             _services.Add(projectService);
             Assert.That(((IService)projectService).Status, Is.EqualTo(ServiceStatus.Started));
+#endif
             _factory = new DefaultTestRunnerFactory();
             _services.Add(_factory);
             _factory.StartService();
@@ -90,4 +92,3 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
 #endif
     }
 }
-

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/TestCases/NetStandardTestCases.cs
@@ -68,6 +68,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                         }
                     });
 
+#if !NETCOREAPP1_1
                 yield return new TestRunnerFactoryData(
                     "SingleProject (list ctor)",
                     new TestPackage(new[] { "a.nunit" }),
@@ -220,6 +221,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests.TestCases
                         }
                     }
                 );
+#endif
             }
         }
     }

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType Condition="'$(TargetFramework)'!='net35'">Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
@@ -13,6 +13,12 @@
     <Reference Include="System.Web" />
     <PackageReference Include="NUnit" Version="3.13.0-dev-06899" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.1'">
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="NSubstitute" Version="2.0.3" />
+    <PackageReference Include="NUnitLite" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1' OR '$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/src/NUnitEngine/nunit.engine/Internal/ProcessModel.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/ProcessModel.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 
 namespace NUnit.Engine.Internal

--- a/src/NUnitEngine/nunit.engine/Internal/SettingsStore.cs
+++ b/src/NUnitEngine/nunit.engine/Internal/SettingsStore.cs
@@ -27,6 +27,9 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 using System.Xml;
+#if NETSTANDARD1_6
+using System.Xml.Linq;
+#endif
 
 namespace NUnit.Engine.Internal
 {
@@ -101,6 +104,29 @@ namespace NUnit.Engine.Internal
                 if (!Directory.Exists(dirPath))
                     Directory.CreateDirectory(dirPath);
 
+#if NETSTANDARD1_6
+                var settings = new XElement("Settings");
+
+                List<string> keys = new List<string>(_settings.Keys);
+                keys.Sort();
+
+                foreach (string name in keys)
+                {
+                    object val = GetSetting(name);
+                    if (val != null)
+                    {
+                        settings.Add(new XElement("Setting",
+                                                    new XAttribute("name", name),
+                                                    new XAttribute("value", TypeDescriptor.GetConverter(val.GetType()).ConvertToInvariantString(val))
+                                                    ));
+                    }
+                }
+                var doc = new XDocument(new XElement("NUnitSettings", settings));
+                using (var file = new FileStream(_settingsFile, FileMode.Create, FileAccess.Write))
+                {
+                    doc.Save(file);
+                }
+#else
                 var stream = new MemoryStream();
                 using (var writer = new XmlTextWriter(stream, Encoding.UTF8))
                 {
@@ -135,6 +161,7 @@ namespace NUnit.Engine.Internal
                     var contents = reader.ReadToEnd();
                     File.WriteAllText(_settingsFile, contents, Encoding.UTF8);
                 }
+#endif
             }
             catch (Exception)
             {

--- a/src/NUnitEngine/nunit.engine/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/nunit.engine/Properties/AssemblyInfo.cs
@@ -5,8 +5,13 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
+#if NETSTANDARD1_6
+[assembly: AssemblyTitle("NUnit .NET Standard Engine")]
+[assembly: AssemblyDescription("Provides a common interface for loading, exploring and running NUnit tests in .NET Core and .NET Standard")]
+#else
 [assembly: AssemblyTitle("NUnit Engine")]
 [assembly: AssemblyDescription("Provides a common interface for loading, exploring and running NUnit tests")]
+#endif
 [assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -55,7 +55,9 @@ namespace NUnit.Engine.Runners
 
         private ITestEngineRunner _engineRunner;
         private readonly IServiceLocator _services;
+#if !NETSTANDARD1_6
         private readonly ExtensionService _extensionService;
+#endif
 #if NETFRAMEWORK
         private readonly IRuntimeFrameworkService _runtimeService;
 #endif
@@ -78,7 +80,9 @@ namespace NUnit.Engine.Runners
 #if NETFRAMEWORK
             _runtimeService = _services.GetService<IRuntimeFrameworkService>();
 #endif
+#if !NETSTANDARD1_6
             _extensionService = _services.GetService<ExtensionService>();
+#endif
 
             // Last chance to catch invalid settings in package,
             // in case the client runner missed them.
@@ -167,6 +171,7 @@ namespace NUnit.Engine.Runners
         }
 
 
+#if !NETSTANDARD1_6
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage. The tests are run
         /// asynchronously and the listener interface is notified as it progresses.
@@ -178,6 +183,7 @@ namespace NUnit.Engine.Runners
         {
             return RunTestsAsync(listener, filter);
         }
+#endif
 
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
@@ -428,17 +434,23 @@ namespace NUnit.Engine.Runners
             var eventDispatcher = new TestEventDispatcher();
             if (listener != null)
                 eventDispatcher.Listeners.Add(listener);
-
+#if !NETSTANDARD1_6
             foreach (var extension in _extensionService.GetExtensions<ITestEventListener>())
                 eventDispatcher.Listeners.Add(extension);
+#endif
 
             IsTestRunning = true;
             
             string clrVersion;
             string engineVersion;
 
+#if !NETSTANDARD1_6
             clrVersion = Environment.Version.ToString();
             engineVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+#else
+            clrVersion =  Microsoft.DotNet.InternalAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+            engineVersion = typeof(MasterTestRunner).GetTypeInfo().Assembly.GetName().Version.ToString();
+#endif
 
             var startTime = DateTime.UtcNow;
             var startRunNode = XmlHelper.CreateTopLevelElement("start-run");
@@ -447,7 +459,9 @@ namespace NUnit.Engine.Runners
             startRunNode.AddAttribute("engine-version", engineVersion);
             startRunNode.AddAttribute("clr-version", clrVersion);
 
+#if !NETSTANDARD1_6
             InsertCommandLineElement(startRunNode);
+#endif
 
             eventDispatcher.OnTestEvent(startRunNode.OuterXml);
 
@@ -458,7 +472,9 @@ namespace NUnit.Engine.Runners
             // These are inserted in reverse order, since each is added as the first child.
             InsertFilterElement(result.Xml, filter);
 
+#if !NETSTANDARD1_6
             InsertCommandLineElement(result.Xml);
+#endif
 
             result.Xml.AddAttribute("engine-version", engineVersion);
             result.Xml.AddAttribute("clr-version", clrVersion);
@@ -474,6 +490,7 @@ namespace NUnit.Engine.Runners
             return result;
         }
 
+#if !NETSTANDARD1_6
         private AsyncTestEngineResult RunTestsAsync(ITestEventListener listener, TestFilter filter)
         {
             var testRun = new AsyncTestEngineResult();
@@ -507,6 +524,7 @@ namespace NUnit.Engine.Runners
             var cdata = doc.CreateCDataSection(Environment.CommandLine);
             cmd.AppendChild(cdata);
         }
+#endif
 
         private static void InsertFilterElement(XmlNode resultNode, TestFilter filter)
         {

--- a/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
@@ -29,7 +29,11 @@ namespace NUnit.Engine.Runners
     /// <summary>
     /// TestEventDispatcher is used to send test events to a number of listeners
     /// </summary>
-    public class TestEventDispatcher : MarshalByRefObject, ITestEventListener
+    public class TestEventDispatcher :
+#if !NETSTANDARD1_6
+        MarshalByRefObject, 
+#endif
+        ITestEventListener
     {
         private object _eventLock = new object();
 
@@ -49,9 +53,11 @@ namespace NUnit.Engine.Runners
             }
         }
 
+#if !NETSTANDARD1_6
         public override object InitializeLifetimeService()
         {
             return null;
         }
+#endif
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/AgentStatus.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStatus.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 namespace NUnit.Engine.Services
 {
     /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 using System.Diagnostics;
 

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
@@ -21,7 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
-#if !NETSTANDARD2_0
+#if !NETSTANDARD1_6 && !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -33,10 +33,13 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class DefaultTestRunnerFactory : InProcessTestRunnerFactory, ITestRunnerFactory
     {
+#if !NETSTANDARD1_6
         private IProjectService _projectService;
+#endif
 
         public override void StartService()
         {
+#if !NETSTANDARD1_6
             // TestRunnerFactory requires the ProjectService
             _projectService = ServiceContext.GetService<IProjectService>();
 
@@ -44,6 +47,9 @@ namespace NUnit.Engine.Services
             Status = _projectService != null && ((IService)_projectService).Status == ServiceStatus.Started
                 ? ServiceStatus.Started
                 : ServiceStatus.Error;
+#else
+            Status = ServiceStatus.Started;
+#endif
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Common;
@@ -166,3 +167,4 @@ namespace NUnit.Engine.Services
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -29,8 +29,14 @@ namespace NUnit.Engine.Services
 {
     public class ResultService : Service, IResultService
     {
+#if NETSTANDARD1_6
+        private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases" };
+#else
         private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases", "user" };
+#endif
+#if !NETSTANDARD1_6
         private IEnumerable<ExtensionNode> _extensionNodes;
+#endif
 
         private string[] _formats;
         public string[] Formats
@@ -41,9 +47,11 @@ namespace NUnit.Engine.Services
                 {
                     var formatList = new List<string>(BUILT_IN_FORMATS);
 
+#if !NETSTANDARD1_6
                     foreach (var node in _extensionNodes)
                         foreach (var format in node.GetValues("Format"))
                             formatList.Add(format);
+#endif
 
                     _formats = formatList.ToArray();
                 }
@@ -66,14 +74,17 @@ namespace NUnit.Engine.Services
                     return new NUnit3XmlResultWriter();
                 case "cases":
                     return new TestCaseResultWriter();
+#if !NETSTANDARD1_6
                 case "user":
                     return new XmlTransformResultWriter(args);
-
+#endif
                 default:
+#if !NETSTANDARD1_6
                     foreach (var node in _extensionNodes)
                         foreach (var supported in node.GetValues("Format"))
                             if (supported == format)
                                 return node.ExtensionObject as IResultWriter;
+#endif
                     return null;
             }
         }
@@ -82,11 +93,12 @@ namespace NUnit.Engine.Services
         {
             try
             {
+#if !NETSTANDARD1_6
                 var extensionService = ServiceContext.GetService<ExtensionService>();
 
                 if (extensionService != null && extensionService.Status == ServiceStatus.Started)
                     _extensionNodes = extensionService.GetExtensionNodes<IResultWriter>();
-
+#endif
                 // If there is no extension service, we start anyway using builtin writers
                 Status = ServiceStatus.Started;
             }

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -76,11 +76,12 @@ namespace NUnit.Engine.Services
             test.AddAttribute("start-time", DateTime.UtcNow.ToString("u"));
             doc.AppendChild(test);
 
+#if !NETSTANDARD1_6
             var cmd = doc.CreateElement("command-line");
             var cdata = doc.CreateCDataSection(Environment.CommandLine);
             cmd.AppendChild(cdata);
             test.AppendChild(cmd);
-
+#endif
             return doc;
         }
     }

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -21,6 +21,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ***********************************************************************
 
+#if !NETSTANDARD1_6
 using System;
 using System.IO;
 using System.Text;
@@ -95,3 +96,4 @@ namespace NUnit.Engine.Services
         }
     }
 }
+#endif

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -81,8 +81,10 @@ namespace NUnit.Engine
                 Services.Add(new SettingsService(true));
                 Services.Add(new RecentFilesService());
                 Services.Add(new TestFilterService());
+#if !NETSTANDARD1_6
                 Services.Add(new ExtensionService());
                 Services.Add(new ProjectService());
+#endif
 #if NETFRAMEWORK
                 Services.Add(new DomainManager());
                 Services.Add(new RuntimeFrameworkService());

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard1.6;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -9,7 +9,10 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6'">
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.6' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />


### PR DESCRIPTION
Reverts nunit/nunit-console#854 - postponing merge until after the 3.12 release.