### PR TITLE
Link to release notes on docs and Review uses of CHANGES.TXT

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Issues that need confirmation will have the **confirm** label or be unlabeled. Y
 
 Great documentation is essential for any open source project and NUnit is no exception. [Our documentation](https://github.com/nunit/docs/wiki/NUnit-Documentation) often lags behind the features that have been implemented or would benefit from better examples.
 
-A great place to start is by going through the [release notes](https://github.com/nunit/nunit-console/blob/master/CHANGES.txt) and ensuring that the documentation for new features is up to date.
+A great place to start is by going through the [release notes](https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html) and ensuring that the documentation for new features is up to date.
 
 ## Fixing Bugs and Adding Features 
 

--- a/build.cake
+++ b/build.cake
@@ -459,7 +459,6 @@ Task("PackageChocolatey")
                 Files = new [] {
                     new ChocolateyNuSpecContent { Source = CURRENT_IMG_DIR + "LICENSE.txt", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = CURRENT_IMG_DIR + "NOTICES.txt", Target = "tools" },
-                    new ChocolateyNuSpecContent { Source = CURRENT_IMG_DIR + "CHANGES.txt", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = CHOCO_DIR + "VERIFICATION.txt", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = CHOCO_DIR + "nunit.choco.addins", Target = "tools" },
                     new ChocolateyNuSpecContent { Source = CHOCO_DIR + "nunit.agent.addins", Target = "tools/agents/net20" },

--- a/choco/nunit-console-runner.nuspec
+++ b/choco/nunit-console-runner.nuspec
@@ -15,7 +15,7 @@
     <bugTrackerUrl>https://github.com/nunit/nunit-console/issues</bugTrackerUrl>
     <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
     <packageSourceUrl>https://github.com/nunit/nunit-console</packageSourceUrl>
-    <releaseNotes>https://raw.githubusercontent.com/nunit/nunit-console/master/CHANGES.txt</releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <mailingListUrl>https://groups.google.com/forum/#!forum/nunit-discuss</mailingListUrl>
     <licenseUrl>https://raw.githubusercontent.com/nunit/nunit-console/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/choco/nunit-console-with-extensions.nuspec
+++ b/choco/nunit-console-with-extensions.nuspec
@@ -24,7 +24,7 @@
     <bugTrackerUrl>https://github.com/nunit/nunit-console/issues</bugTrackerUrl>
     <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
     <packageSourceUrl>https://github.com/nunit/nunit-console</packageSourceUrl>
-    <releaseNotes>https://raw.githubusercontent.com/nunit/nunit-console/master/CHANGES.txt</releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <mailingListUrl>https://groups.google.com/forum/#!forum/nunit-discuss</mailingListUrl>
     <licenseUrl>https://raw.githubusercontent.com/nunit/nunit-console/master/LICENSE.txt</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/nuget/deprecated/nunit.runners.nuspec
+++ b/nuget/deprecated/nunit.runners.nuspec
@@ -27,7 +27,7 @@
 
       Other extensions, if needed, must be installed separately.
     </description>
-    <releaseNotes>This release uses the latest version of the TeamCityEventListener extension.</releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2021 Charlie Poole</copyright>

--- a/nuget/engine/nunit.engine.api.nuspec
+++ b/nuget/engine/nunit.engine.api.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The NUnit Test Engine Api is used by runners to interface with the NUnit Engine in order to discover and execute tests.</summary>
     <description>This package includes the nunit.engine.api, which is normally the only assembly referenced by runners as well as by engine extensions. It is not intended for direct use by users who simply want to run tests using NUnit.</description>
-    <releaseNotes></releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd engine</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -14,7 +14,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>The NUnit Test Engine is used by runners to discover and execute tests.</summary>
     <description>This package includes nunit.engine and related assemblies, for use by runner programs. It is not intended for direct use by users who simply want to run tests.</description>
-    <releaseNotes></releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd engine</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>
@@ -50,7 +50,6 @@
   <files>
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
-    <file src="CHANGES.txt" />
     <file src="bin/net20/nunit.engine.dll" target="lib/net20" />
     <file src="bin/net20/nunit.engine.core.dll" target="lib/net20" />
     <file src="bin/net20/nunit.engine.api.dll" target="lib/net20" />

--- a/nuget/runners/nunit.console-runner-with-extensions.nuspec
+++ b/nuget/runners/nunit.console-runner-with-extensions.nuspec
@@ -25,7 +25,7 @@
 
       Other extensions, if needed, must be installed separately.
     </description>
-    <releaseNotes></releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>

--- a/nuget/runners/nunit.console-runner.netcore.nuspec
+++ b/nuget/runners/nunit.console-runner.netcore.nuspec
@@ -18,7 +18,7 @@
 
       Any extensions, if needed, may be installed as separate packages.
     </description>
-    <releaseNotes></releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>
@@ -29,7 +29,6 @@
   <files>
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
-    <file src="CHANGES.txt" />
     <file src="bin/netcoreapp3.1/nunit3-console.exe" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/nunit3-console.pdb" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/nunit3-console.dll" target="tools/netcoreapp3.1/any" />

--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -18,7 +18,7 @@
 
       Any extensions, if needed, may be installed as separate packages.
     </description>
-    <releaseNotes></releaseNotes>
+    <releaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</releaseNotes>
     <language>en-US</language>
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>
@@ -26,7 +26,6 @@
   <files>
     <file src="LICENSE.txt" />
     <file src="NOTICES.txt" />
-    <file src="CHANGES.txt" />
     <file src="bin/agents/net20/nunit-agent.exe" target="tools/agents/net20" />
     <file src="bin/agents/net20/nunit-agent.exe.config" target="tools/agents/net20" />
     <file src="bin/agents/net20/nunit-agent-x86.exe" target="tools/agents/net20" />

--- a/package-checks.cake
+++ b/package-checks.cake
@@ -20,12 +20,12 @@ public void CheckAllPackages()
             HasFile("LICENSE.txt")) &
         CheckNuGetPackage(
             "NUnit.ConsoleRunner",
-            HasFiles("LICENSE.txt", "NOTICES.txt", "CHANGES.txt"),
+            HasFiles("LICENSE.txt", "NOTICES.txt"),
             HasDirectory("tools").WithFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit.console.nuget.addins"),
             HasDirectory("tools/agents/net20").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins"),
             HasDirectory("tools/agents/net40").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins")) &
         CheckNuGetPackage("NUnit.Engine",
-            HasFiles("LICENSE.txt", "NOTICES.txt", "CHANGES.txt"),
+            HasFiles("LICENSE.txt", "NOTICES.txt"),
             HasDirectory("lib/net20").WithFiles(ENGINE_FILES),
             HasDirectory("lib/netstandard1.6").WithFiles(ENGINE_FILES),
             HasDirectory("lib/netstandard2.0").WithFiles(ENGINE_FILES),
@@ -45,7 +45,7 @@ public void CheckAllPackages()
             HasFile("LICENSE.txt")) &
         CheckChocolateyPackage(
             "nunit-console-runner",
-            HasDirectory("tools").WithFiles("LICENSE.txt", "NOTICES.txt", "CHANGES.txt", "VERIFICATION.txt").AndFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit.choco.addins"),
+            HasDirectory("tools").WithFiles("LICENSE.txt", "NOTICES.txt", "VERIFICATION.txt").AndFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit.choco.addins"),
             HasDirectory("tools/agents/net20").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins"),
             HasDirectory("tools/agents/net40").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins")) &
         CheckChocolateyPackage(


### PR DESCRIPTION
I was about to ask @SeanKilleen if he would mind updating the NuGet packages release notes in line with his changes in #866, but then found out most of them were blank anyway!

This PR changes some references from CHANGES.TXT to a direct link, to avoid multiple levels of redirection. CHANGES.TXT is retained for the msi and zip distributions, but removed from choco/nuget - with the logic that users would use the respective gallery's and interfaces to access this information instead.