### PR TITLE
Correct packaging of x86 .NET 4.0 agent in msi

### DIFF
--- a/msi/nunit/engine-files.wxi
+++ b/msi/nunit/engine-files.wxi
@@ -79,9 +79,9 @@
             <Component Id="NUNIT_AGENT_NET40_X86" Location="local" Guid="8EB0C529-56D8-4746-804E-6679744699F6">
                 <File Id="nunit_agent_net40_x86.exe"
                       ProcessorArchitecture="x86"
-                      Source="$(var.InstallImage)bin/agents/net20/nunit-agent-x86.exe" />
+                      Source="$(var.InstallImage)bin/agents/net40/nunit-agent-x86.exe" />
                 <File Id="nunit_agent_net40_x86.exe.config"
-                      Source="$(var.InstallImage)bin/agents/net20/nunit-agent-x86.exe.config" />
+                      Source="$(var.InstallImage)bin/agents/net40/nunit-agent-x86.exe.config" />
             </Component>
             <Component Id="NUNIT_AGENT_ADDINS_NET40" Location="local" Guid="">
                 <File Id="nunit.agent.net40.addins" Source="$(var.InstallImage)nunit.agent.addins" />


### PR DESCRIPTION
Fixes #872 - fixes a copy-paste error in the msi installer.

@nunit/engine-team - this built off the 3.12.0 release branch. As this is just a packaging issue, unless anyone can think of a good reason not to, I plat to just rebuild the msi and update the GitHub artifact for this issue, rather than doing a full 3.12.1 release. Would appreciate a second opinion on that however...before something goes wrong!