### PR TITLE
Make sure `AssemblyDefinitions` are disposed after use.

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -78,7 +78,7 @@ namespace NUnit.Engine.Drivers
 
             assemblyPath = Path.GetFullPath(assemblyPath);  //AssemblyLoadContext requires an absolute path
             var assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
-
+            
             try
             {
                 _testAssembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -78,7 +78,6 @@ namespace NUnit.Engine.Drivers
 
             assemblyPath = Path.GetFullPath(assemblyPath);  //AssemblyLoadContext requires an absolute path
             var assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
-            
             try
             {
                 _testAssembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs
@@ -81,29 +81,30 @@ namespace NUnit.Engine.Drivers
         {
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
 
-            var assemblyRef = AssemblyDefinition.ReadAssembly(testAssembly);
-            _testAssembly = Assembly.Load(new AssemblyName(assemblyRef.FullName));
-            if(_testAssembly == null)
-                throw new NUnitEngineException(string.Format(FAILED_TO_LOAD_TEST_ASSEMBLY, assemblyRef.FullName));
+            using (var assemblyRef = AssemblyDefinition.ReadAssembly(testAssembly)) {
+                _testAssembly = Assembly.Load(new AssemblyName(assemblyRef.FullName));
+                if(_testAssembly == null)
+                    throw new NUnitEngineException(string.Format(FAILED_TO_LOAD_TEST_ASSEMBLY, assemblyRef.FullName));
 
-            var nunitRef = assemblyRef.MainModule.AssemblyReferences.Where(reference => reference.Name.Equals("nunit.framework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-            if (nunitRef == null)
-                throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
+                var nunitRef = assemblyRef.MainModule.AssemblyReferences.Where(reference => reference.Name.Equals("nunit.framework", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                if (nunitRef == null)
+                    throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 
-            var nunit = Assembly.Load(new AssemblyName(nunitRef.FullName));
-            if (nunit == null)
-                throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
+                var nunit = Assembly.Load(new AssemblyName(nunitRef.FullName));
+                if (nunit == null)
+                    throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 
-            _frameworkAssembly = nunit;
+                _frameworkAssembly = nunit;
 
-            _frameworkController = CreateObject(CONTROLLER_TYPE, _testAssembly, idPrefix, settings);
-            if (_frameworkController == null)
-                throw new NUnitEngineException(INVALID_FRAMEWORK_MESSAGE);
+                _frameworkController = CreateObject(CONTROLLER_TYPE, _testAssembly, idPrefix, settings);
+                if (_frameworkController == null)
+                    throw new NUnitEngineException(INVALID_FRAMEWORK_MESSAGE);
 
-            _frameworkControllerType = _frameworkController.GetType();
+                _frameworkControllerType = _frameworkController.GetType();
 
-            log.Info("Loading {0} - see separate log file", _testAssembly.FullName);
-            return ExecuteMethod(LOAD_METHOD) as string;
+                log.Info("Loading {0} - see separate log file", _testAssembly.FullName);
+                return ExecuteMethod(LOAD_METHOD) as string;
+            }
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionAssembly.cs
+++ b/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionAssembly.cs
@@ -28,7 +28,7 @@ using NUnit.Engine.Internal;
 
 namespace NUnit.Engine.Extensibility
 {
-    internal class ExtensionAssembly : IExtensionAssembly
+    internal class ExtensionAssembly : IExtensionAssembly, IDisposable
     {
         public ExtensionAssembly(string filePath, bool fromWildCard)
         {
@@ -71,6 +71,11 @@ namespace NUnit.Engine.Extensibility
             var parameters = new ReaderParameters { AssemblyResolver = resolver };
 
             return AssemblyDefinition.ReadAssembly(FilePath, parameters);
+        }
+
+        public void Dispose()
+        {
+            Assembly?.Dispose();
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
@@ -34,7 +34,7 @@ namespace NUnit.Engine.Internal
 
         public CustomAssemblyLoadContext(string mainAssemblyToLoadPath)
         {
-            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath); 
+            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
         }
 
         protected override Assembly Load(AssemblyName name)

--- a/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
@@ -34,7 +34,7 @@ namespace NUnit.Engine.Internal
 
         public CustomAssemblyLoadContext(string mainAssemblyToLoadPath)
         {
-            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+            _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath); 
         }
 
         protected override Assembly Load(AssemblyName name)

--- a/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
@@ -73,29 +73,30 @@ namespace NUnit.Engine.Services
 
             try
             {
-                var assemblyDef = AssemblyDefinition.ReadAssembly(assemblyPath);
-
-                if (skipNonTestAssemblies)
+                using (var assemblyDef = AssemblyDefinition.ReadAssembly(assemblyPath))
                 {
-                    foreach (var attr in assemblyDef.CustomAttributes)
-                        if (attr.AttributeType.FullName == "NUnit.Framework.NonTestAssemblyAttribute")
-                            return new SkippedAssemblyFrameworkDriver(assemblyPath);
-                }
-
-                var references = new List<AssemblyName>();
-                foreach (var cecilRef in assemblyDef.MainModule.AssemblyReferences)
-                    references.Add(new AssemblyName(cecilRef.FullName));
-
-                foreach (var factory in _factories)
-                {
-                    foreach (var reference in references)
+                    if (skipNonTestAssemblies)
                     {
-                        if (factory.IsSupportedTestFramework(reference))
+                        foreach (var attr in assemblyDef.CustomAttributes)
+                            if (attr.AttributeType.FullName == "NUnit.Framework.NonTestAssemblyAttribute")
+                                return new SkippedAssemblyFrameworkDriver(assemblyPath);
+                    }
+
+                    var references = new List<AssemblyName>();
+                    foreach (var cecilRef in assemblyDef.MainModule.AssemblyReferences)
+                        references.Add(new AssemblyName(cecilRef.FullName));
+
+                    foreach (var factory in _factories)
+                    {
+                        foreach (var reference in references)
+                        {
+                            if (factory.IsSupportedTestFramework(reference))
 #if !NETFRAMEWORK
                             return factory.GetDriver(reference);
 #else
-                            return factory.GetDriver(domain, reference);
+                                return factory.GetDriver(domain, reference);
 #endif
+                        }
                     }
                 }
             }

--- a/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
@@ -94,7 +94,7 @@ namespace NUnit.Engine.Services
 #if !NETFRAMEWORK
                             return factory.GetDriver(reference);
 #else
-                                return factory.GetDriver(domain, reference);
+                            return factory.GetDriver(domain, reference);
 #endif
                         }
                     }

--- a/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/ExtensionService.cs
@@ -203,6 +203,17 @@ namespace NUnit.Engine.Services
             }
         }
 
+        public override void StopService()
+        {
+            // Make sure all assemblies release the underlying file streams. 
+            foreach (var assembly in _assemblies)
+            {
+                assembly.Dispose();
+            }
+
+            Status = ServiceStatus.Stopped;
+        }
+
         /// <summary>
         /// Find the extension points in a loaded assembly.
         /// Public for testing.

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -230,24 +230,25 @@ namespace NUnit.Engine.Services
             }
             else if (File.Exists(packageName) && PathUtils.IsAssemblyFileType(packageName))
             {
-                var assembly = AssemblyDefinition.ReadAssembly(packageName);
-
-                targetVersion = assembly.GetRuntimeVersion();
-                log.Debug($"Assembly {packageName} uses version {targetVersion}");
-
-                frameworkName = assembly.GetFrameworkName();
-                log.Debug($"Assembly {packageName} targets {frameworkName}");
-
-                if (assembly.RequiresX86())
+                using (var assembly = AssemblyDefinition.ReadAssembly(packageName))
                 {
-                    requiresX86 = true;
-                    log.Debug($"Assembly {packageName} will be run x86");
-                }
+                    targetVersion = assembly.GetRuntimeVersion();
+                    log.Debug($"Assembly {packageName} uses version {targetVersion}");
 
-                if (assembly.HasAttribute("NUnit.Framework.TestAssemblyDirectoryResolveAttribute"))
-                {
-                    requiresAssemblyResolver = true;
-                    log.Debug($"Assembly {packageName} requires default app domain assembly resolver");
+                    frameworkName = assembly.GetFrameworkName();
+                    log.Debug($"Assembly {packageName} targets {frameworkName}");
+
+                    if (assembly.RequiresX86())
+                    {
+                        requiresX86 = true;
+                        log.Debug($"Assembly {packageName} will be run x86");
+                    }
+
+                    if (assembly.HasAttribute("NUnit.Framework.TestAssemblyDirectoryResolveAttribute"))
+                    {
+                        requiresAssemblyResolver = true;
+                        log.Debug($"Assembly {packageName} requires default app domain assembly resolver");
+                    }
                 }
             }
 


### PR DESCRIPTION
NUnit does not correctly release the file lock for some of the assemblies. This PR makes sure the `Dispose` functionality is called thereby releasing all the underlying file resources.

### Mono Cecil (Fixed in this PR)
 `Mono.Cecil.AsseblyDefinition` is not disposed of, this locks the assembly until the caller application closes.

- https://github.com/nunit/nunit-console/blob/master/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs#L76
- https://github.com/nunit/nunit-console/blob/master/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs#L233
- https://github.com/nunit/nunit-console/blob/master/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetStandardDriver.cs#L84
- https://github.com/nunit/nunit-console/blob/master/src/NUnitEngine/nunit.engine.core/Extensibility/ExtensionAssembly.cs#L37

### CustomAssemblyLoadContext (Not fixed in this PR)

Currently, an assembly is loaded by this [code](https://github.com/nunit/nunit-console/blob/master/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs#L84). 

```csharp
var assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
_testAssembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
```

Next, the following private fields are initialized:

```csharp
Assembly _testAssembly;
Assembly _frameworkAssembly;
object _frameworkController;
Type _frameworkControllerType;
```

Those have to be released in order for `CustomAssemblyLoadContext.Unload()` to be able to release its resources. 

_microsoft [article](https://docs.microsoft.com/en-us/dotnet/standard/assembly/unloadability):_
![image](https://user-images.githubusercontent.com/19969910/107093757-110ba380-6806-11eb-8b6f-c62780711f8c.png)

### Related Issues
Fixes: #894 

### Work Left for other PR
- Make `CustomAssemblyLoadContext.Unload()` working see [this article](https://docs.microsoft.com/en-us/dotnet/standard/assembly/unloadability). Lets discuss this issue in the related issue.

