### PR TITLE
Removed support for .NET Core 1.1

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Internal/FileSystemAccess/Default/FileSystemTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/FileSystemAccess/Default/FileSystemTests.cs
@@ -160,11 +160,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
 
         private string GetTestFileLocation()
         {
-#if NETCOREAPP1_1
-            return Assembly.GetEntryAssembly().Location;
-#else
             return Assembly.GetAssembly(typeof(FileTests)).Location;
-#endif
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Internal/FileSystemAccess/Default/FileTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Internal/FileSystemAccess/Default/FileTests.cs
@@ -109,11 +109,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
 
         private string GetTestFileLocation()
         {
-#if NETCOREAPP1_1
-            return Assembly.GetEntryAssembly().Location;
-#else
             return Assembly.GetAssembly(typeof(FileTests)).Location;
-#endif
         }
     }
 }


### PR DESCRIPTION
While working on #789, I found some .NET Core 1.1 code that is not required anymore.