### PR TITLE
Implement package tests

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		CONTRIBUTING.md = CONTRIBUTING.md
 		src\Directory.Build.props = src\Directory.Build.props
 		LICENSE.txt = LICENSE.txt
+		NetFXTests.nunit = NetFXTests.nunit
 		NOTICES.txt = NOTICES.txt
 		NuGet.config = NuGet.config
 		nunit.ico = nunit.ico

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.config = NuGet.config
 		nunit.ico = nunit.ico
 		package-checks.cake = package-checks.cake
+		package-tests.cake = package-tests.cake
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/NetFXTests.nunit
+++ b/NetFXTests.nunit
@@ -1,0 +1,11 @@
+﻿<NUnitProject>
+  <Settings processModel="Default" domainUsage="Default" />
+  <Config name="Debug" appbase="bin/Debug">
+      <assembly path="net35/mock-assembly.dll" />
+      <assembly path="net40/mock-assembly.dll" />
+  </Config>
+  <Config name="Release" appbase="bin/Release">
+      <assembly path="net35/mock-assembly.dll" />
+      <assembly path="net40/mock-assembly.dll" />
+  </Config>
+</NUnitProject>

--- a/build.cake
+++ b/build.cake
@@ -373,7 +373,7 @@ Task("CreateImage")
         CopyDirectory(BIN_DIR, CURRENT_IMG_DIR + "bin/");
     });
 
-Task("PackageNuGet")
+Task("BuildNuGetPackages")
     .Description("Creates NuGet packages of the engine/console")
     .IsDependentOn("CreateImage")
     .Does(() =>
@@ -437,7 +437,13 @@ Task("PackageNuGet")
         });
     });
 
-Task("PackageChocolatey")
+Task("TestNugetPackages")
+    .Does(() =>
+    {
+
+    });
+
+Task("BuildChocolateyPackages")
     .Description("Creates chocolatey packages of the console runner")
     .Does(() =>
     {
@@ -498,6 +504,12 @@ Task("PackageChocolatey")
             });
     });
 
+Task("TestChocolateyPackage")
+    .Does(() =>
+    {
+
+    });
+
 //////////////////////////////////////////////////////////////////////
 // PACKAGE COMBINED DISTRIBUTIONS
 //////////////////////////////////////////////////////////////////////
@@ -533,7 +545,7 @@ Task("CreateCombinedImage")
     }
 });
 
-Task("PackageMsi")
+Task("BuildMsiPackage")
 .IsDependentOn("CreateCombinedImage")
 .Does(() =>
 {
@@ -549,7 +561,13 @@ Task("PackageMsi")
         );
 });
 
-Task("PackageZip")
+Task("TestMsiPackage")
+    .Does(() =>
+    {
+
+    });
+
+Task("BuildZipPackage")
 .IsDependentOn("CreateCombinedImage")
 .Does(() =>
 {
@@ -568,6 +586,12 @@ Task("PackageZip")
     var zipPath = string.Format("{0}NUnit.Console-{1}.zip", PACKAGE_DIR, productVersion);
     Zip(ZIP_IMG, zipPath);
 });
+
+Task("TestZipPackage")
+    .Does(() =>
+    {
+
+    });
 
 Task("InstallSigningTool")
     .Does(() =>
@@ -624,8 +648,8 @@ Task("SignPackages")
         }
     });
 
-Task("CheckPackages")
-    .Description("Check content of NuGet packages")
+Task("CheckPackageContent")
+    .Description("Check content of all the packages we build")
     .Does(() =>
     {
         CheckAllPackages();
@@ -825,14 +849,26 @@ Task("Test")
     .IsDependentOn("TestEngine")
     .IsDependentOn("TestConsole");
 
+Task("BuildPackages")
+    .Description("Builds all packages for distribution")
+    .IsDependentOn("BuildNuGetPackages")
+    .IsDependentOn("BuildChocolateyPackages")
+    .IsDependentOn("BuildMsiPackage")
+    .IsDependentOn("BuildZipPackage");
+
+Task("TestPackages")
+    .Description("Tests the packages")
+    .IsDependentOn("TestNugetPackages")
+    .IsDependentOn("TestChocolateyPackage")
+    .IsDependentOn("TestMsiPackage")
+    .IsDependentOn("TestZipPackage");
+
 Task("Package")
-    .Description("Packages the engine and console runner")
+    .Description("Builds and tests all packages")
     .IsDependentOn("CheckForError")
-    .IsDependentOn("PackageNuGet")
-    .IsDependentOn("PackageChocolatey")
-    .IsDependentOn("PackageMsi")
-    .IsDependentOn("PackageZip")
-    .IsDependentOn("CheckPackages");
+    .IsDependentOn("BuildPackages")
+    .IsDependentOn("CheckPackageContent")
+    .IsDependentOn("TestPackages");
 
 Task("Appveyor")
     .Description("Builds, tests and packages on AppVeyor")

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,6 @@
 #load ci.cake
 #load package-checks.cake
+#load package-tests.cake
 
 // Install Tools
 #tool NuGet.CommandLine&version=5.3.1
@@ -440,7 +441,9 @@ Task("BuildNuGetPackages")
 Task("TestNugetPackages")
     .Does(() =>
     {
+        new NuGetNetFXPackageTester(Context, productVersion).RunTests();
 
+        new NuGetNetCorePackageTester(Context, productVersion).RunTests();
     });
 
 Task("BuildChocolateyPackages")
@@ -507,7 +510,7 @@ Task("BuildChocolateyPackages")
 Task("TestChocolateyPackage")
     .Does(() =>
     {
-
+        new ChocolateyPackageTester(Context, productVersion).RunTests();
     });
 
 //////////////////////////////////////////////////////////////////////
@@ -564,7 +567,7 @@ Task("BuildMsiPackage")
 Task("TestMsiPackage")
     .Does(() =>
     {
-
+        new MsiPackageTester(Context, version).RunTests();
     });
 
 Task("BuildZipPackage")
@@ -590,7 +593,7 @@ Task("BuildZipPackage")
 Task("TestZipPackage")
     .Does(() =>
     {
-
+        new ZipPackageTester(Context, productVersion).RunTests();
     });
 
 Task("InstallSigningTool")

--- a/build.cake
+++ b/build.cake
@@ -107,7 +107,7 @@ Setup(context =>
             else
                 suffix += "-" + System.Text.RegularExpressions.Regex.Replace(branch, "[^0-9A-Za-z-]+", "-");
 
-            // Nuget limits "special version part" to 20 chars. Add one for the hyphen.
+            // NuGet limits "special version part" to 20 chars. Add one for the hyphen.
             if (suffix.Length > 21)
                 suffix = suffix.Substring(0, 21);
 
@@ -439,7 +439,7 @@ Task("BuildNuGetPackages")
         });
     });
 
-Task("TestNugetPackages")
+Task("TestNuGetPackages")
     .Does(() =>
     {
         new NuGetNetFXPackageTester(Context, productVersion).RunTests();
@@ -862,7 +862,7 @@ Task("BuildPackages")
 
 Task("TestPackages")
     .Description("Tests the packages")
-    .IsDependentOn("TestNugetPackages")
+    .IsDependentOn("TestNuGetPackages")
     .IsDependentOn("TestChocolateyPackage")
     .IsDependentOn("TestMsiPackage")
     .IsDependentOn("TestZipPackage");

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,6 @@
 #load ci.cake
 #load package-checks.cake
+#load test-results.cake
 #load package-tests.cake
 
 // Install Tools

--- a/package-checks.cake
+++ b/package-checks.cake
@@ -13,6 +13,7 @@ public void CheckAllPackages()
     string[] AGENT_FILES = { 
         "nunit-agent.exe", "nunit-agent.exe.config", "nunit-agent-x86.exe", "nunit-agent-x86.exe.config", "nunit.engine.core.dll", "nunit.engine.api.dll", "testcentric.engine.metadata.dll" };
     string[] CONSOLE_FILES = { "nunit3-console.exe", "nunit3-console.exe.config" };
+    string[] CONSOLE_FILES_NETCORE = { "nunit3-console.exe", "nunit3-console.dll", "nunit3-console.dll.config" };
 
     bool isOK =
         CheckNuGetPackage(
@@ -24,6 +25,10 @@ public void CheckAllPackages()
             HasDirectory("tools").WithFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit.console.nuget.addins"),
             HasDirectory("tools/agents/net20").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins"),
             HasDirectory("tools/agents/net40").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins")) &
+        CheckNuGetPackage(
+            "NUnit.ConsoleRunner.NetCore",
+            HasFiles("LICENSE.txt", "NOTICES.txt"),
+            HasDirectory("tools/netcoreapp3.1/any").WithFiles(CONSOLE_FILES_NETCORE).AndFiles(ENGINE_FILES).AndFile("nunit.console.nuget.addins")) &
         CheckNuGetPackage("NUnit.Engine",
             HasFiles("LICENSE.txt", "NOTICES.txt"),
             HasDirectory("lib/net20").WithFiles(ENGINE_FILES),

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -129,6 +129,32 @@ public abstract class NetFXPackageTester : PackageTester
                 Inconclusive = 1,
                 Skipped = 7
             }));
+
+        PackageTests.Add(new PackageTest(
+            "Run mock-assembly.dll under .NET 4.x",
+            "net40/mock-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 37,
+                Passed = 23,
+                Failed = 5,
+                Warnings = 0,
+                Inconclusive = 1,
+                Skipped = 7
+            }));
+
+        PackageTests.Add(new PackageTest(
+            "Run both copies of mock-assembly together",
+            "net35/mock-assembly.dll net40/mock-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 2 * 37,
+                Passed = 2 * 23,
+                Failed = 2 * 5,
+                Warnings = 0,
+                Inconclusive = 2 * 1,
+                Skipped = 2 * 7
+            }));
     }
 }
 
@@ -148,6 +174,32 @@ public abstract class NetCorePackageTester : PackageTester
                 Warnings = 0,
                 Inconclusive = 1,
                 Skipped = 7
+            }));
+
+        PackageTests.Add(new PackageTest(
+            "Run mock-assembly targeting .NET Core 3.1",
+            "netcoreapp3.1/mock-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 37,
+                Passed = 23,
+                Failed = 5,
+                Warnings = 0,
+                Inconclusive = 1,
+                Skipped = 7
+            }));
+
+        PackageTests.Add(new PackageTest(
+            "Run both copies of mock-assembly together",
+            "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 2 * 37,
+                Passed = 2 * 23,
+                Failed = 2 * 5,
+                Warnings = 0,
+                Inconclusive = 2 * 1,
+                Skipped = 2 * 7
             }));
     }
 }

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -274,8 +274,10 @@ public class MsiPackageTester : NetFXPackageTester
             Console.WriteLine($"  ERROR: Installer returned {rc.ToString()}");
         else
         {
-            // Administrative install doesn't copy these files to
-            // their final destination, so we do it.
+            // Administrative install is used to create a file image, from which
+            // users may do their own installls. For security reasons, we can't
+            // do a full install so we simulate the user portion of the install,
+            // copying certain files to their final destination.
             _context.CopyFiles(
                 PackageBinDir + "*.dll",
                 PackageBinDir + "agents/net20/");

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -19,6 +19,7 @@ public abstract class PackageTester
     protected ICakeContext _context;
     protected string _packageVersion;
     protected string _packageDir;
+    protected string _config;
     protected string _outputDir;
 
     public PackageTester(ICakeContext context, string packageVersion)
@@ -26,7 +27,8 @@ public abstract class PackageTester
         _context = context;
         _packageVersion = packageVersion;
         _packageDir = System.IO.Path.GetFullPath(context.Argument("artifact-dir", "package")) + "/";
-        _outputDir = System.IO.Path.GetFullPath("bin/" + context.Argument("configuration", "Release")) + "/";
+        _config = context.Argument("configuration", "Release");
+        _outputDir = System.IO.Path.GetFullPath($"bin/{_config}/");
 
         PackageTests = new List<PackageTest>();
     }
@@ -240,7 +242,21 @@ public class ChocolateyPackageTester : NetFXPackageTester
 public class MsiPackageTester : NetFXPackageTester
 {
     public MsiPackageTester(ICakeContext context, string packageVersion)
-        : base(context, packageVersion) { }
+        : base(context, packageVersion)
+    {
+        PackageTests.Add(new PackageTest(
+            "Run project with both copies of mock-assembly",
+            $"../../NetFXTests.nunit --config={_config}",
+            new ExpectedResult("Failed")
+            {
+                Total = 2 * 37,
+                Passed = 2 * 23,
+                Failed = 2 * 5,
+                Warnings = 0,
+                Inconclusive = 2 * 1,
+                Skipped = 2 * 7
+            }));
+    }
 
     protected override string PackageName => $"NUnit.Console-{_packageVersion}.msi";
     protected override string PackageInstallDirectory => _packageDir + "test/msi/";
@@ -272,7 +288,21 @@ public class MsiPackageTester : NetFXPackageTester
 public class ZipPackageTester : NetFXPackageTester
 {
     public ZipPackageTester(ICakeContext context, string packageVersion)
-        : base(context, packageVersion) { }
+        : base(context, packageVersion)
+    {
+        PackageTests.Add(new PackageTest(
+            "Run project with both copies of mock-assembly",
+            $"../../NetFXTests.nunit --config={_config}",
+            new ExpectedResult("Failed")
+            {
+                Total = 2 * 37,
+                Passed = 2 * 23,
+                Failed = 2 * 5,
+                Warnings = 0,
+                Inconclusive = 2 * 1,
+                Skipped = 2 * 7
+            }));
+    }
 
     protected override string PackageName => $"NUnit.Console-{_packageVersion}.zip";
     protected override string PackageInstallDirectory => _packageDir + "test/zip/";

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -1,0 +1,187 @@
+// Representation of a single test to be run against a pre-built package.
+public struct PackageTest
+{
+    public string Description;
+    public string Arguments;
+
+    public PackageTest(string description, string arguments)
+    {
+        Description = description;
+        Arguments = arguments;
+    }
+}
+
+// Abstract base for all package testers. 
+public abstract class PackageTester
+{
+    protected ICakeContext _context;
+    protected string _packageVersion;
+    protected string _packageDir;
+    protected string _outputDir;
+
+    public PackageTester(ICakeContext context, string packageVersion)
+    {
+        _context = context;
+        _packageVersion = packageVersion;
+        _packageDir = System.IO.Path.GetFullPath(context.Argument("artifact-dir", "package")) + "/";
+        _outputDir = System.IO.Path.GetFullPath("bin/" + context.Argument("configuration", "Release")) + "/";
+
+        PackageTests = new List<PackageTest>();
+    }
+
+    protected abstract string PackageName { get; }
+    protected abstract string PackageInstallDirectory { get; }
+    protected abstract string PackageBinDir { get; }
+    //protected abstract string ExtensionInstallDirectory { get; }
+
+    protected string PackageUnderTest => _packageDir + PackageName;
+    protected List<PackageTest> PackageTests { get; }
+
+    public void RunTests()
+    {
+        Console.WriteLine("Testing package " + PackageName);
+
+        Console.WriteLine($"Creating Test Directory:\n  {PackageInstallDirectory}");
+        CreatePackageInstallDirectory();
+
+        RunPackageTests();
+    }
+
+    // Default is to just unzip... individual package testers may override
+    protected virtual void CreatePackageInstallDirectory()
+    {
+        _context.CleanDirectory(PackageInstallDirectory);
+        _context.Unzip(PackageUnderTest, PackageInstallDirectory);
+    }
+
+    private void RunPackageTests()
+    {
+        foreach (var packageTest in PackageTests)
+        {
+            DisplayBanner(packageTest.Description);
+            DisplayTestEnvironment(packageTest);
+
+            int rc = _context.StartProcess(
+                PackageBinDir + "nunit3-console.exe",
+                new ProcessSettings()
+                {
+                    Arguments = packageTest.Arguments,
+                    WorkingDirectory = _outputDir
+                });
+        }
+    }
+
+    private void DisplayBanner(string message)
+    {
+        Console.WriteLine("\n=================================================="); ;
+        Console.WriteLine(message);
+        Console.WriteLine("==================================================");
+    }
+
+    private void DisplayTestEnvironment(PackageTest test)
+    {
+        Console.WriteLine("Test Environment");
+        Console.WriteLine($"   OS Version: {Environment.OSVersion.VersionString}");
+        Console.WriteLine($"  CLR Version: {Environment.Version}");
+        Console.WriteLine($"    Arguments: {test.Arguments}");
+        Console.WriteLine();
+    }
+}
+
+public abstract class NetFXPackageTester : PackageTester
+{
+    public NetFXPackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion)
+    {
+        PackageTests.Add(new PackageTest(
+            "Run mock-assembly.dll under .NET 3.5",
+            "net35/mock-assembly.dll"));
+    }
+}
+
+public abstract class NetCorePackageTester : PackageTester
+{
+    public NetCorePackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion)
+    {
+        PackageTests.Add(new PackageTest(
+            "Run mock-assembly.dll targeting .NET Core 2.1",
+            "netcoreapp2.1/mock-assembly.dll"));
+    }
+}
+
+public class NuGetNetFXPackageTester : NetFXPackageTester
+{
+    public NuGetNetFXPackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion) { }
+
+    protected override string PackageName => $"NUnit.ConsoleRunner.{_packageVersion}.nupkg";
+    protected override string PackageInstallDirectory => _packageDir + "test/nuget-netfx/";
+    protected override string PackageBinDir => PackageInstallDirectory + "tools/";
+    //protected override string ExtensionInstallDirectory => _parameters.PackageInstallDirectory;
+}
+
+public class NuGetNetCorePackageTester : NetCorePackageTester
+{
+    public NuGetNetCorePackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion) { }
+
+    protected override string PackageName => $"NUnit.ConsoleRunner.NetCore.{_packageVersion}.nupkg";
+    protected override string PackageInstallDirectory => _packageDir + "test/nuget-netcore/";
+    protected override string PackageBinDir => PackageInstallDirectory + "tools/netcoreapp3.1/any/";
+    //protected override string ExtensionInstallDirectory => _parameters.PackageInstallDirectory;
+}
+
+public class ChocolateyPackageTester : NetFXPackageTester
+{
+    public ChocolateyPackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion) { }
+
+    protected override string PackageName => $"nunit-console-runner.{_packageVersion}.nupkg";
+    protected override string PackageInstallDirectory => _packageDir + "test/choco/";
+    protected override string PackageBinDir => PackageInstallDirectory + "tools/";
+    //protected override string ExtensionInstallDirectory => _parameters.PackageInstallDirectory;
+}
+
+public class MsiPackageTester : NetFXPackageTester
+{
+    public MsiPackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion) { }
+
+    protected override string PackageName => $"NUnit.Console-{_packageVersion}.msi";
+    protected override string PackageInstallDirectory => _packageDir + "test/msi/";
+    protected override string PackageBinDir => PackageInstallDirectory + "NUnit.org/nunit-console/";
+    //protected override string ExtensionInstallDirectory => _parameters.PackageInstallDirectory;
+
+    protected override void CreatePackageInstallDirectory()
+    {
+        // Msiexec does not tolerate forward slashes!
+        string package = PackageUnderTest.ToString().Replace("/", "\\");
+        string testDir = PackageInstallDirectory.Replace("/", "\\");
+        int rc = _context.StartProcess("msiexec", $"/a {package} TARGETDIR={testDir} /q");
+        if (rc != 0)
+            Console.WriteLine($"  ERROR: Installer returned {rc.ToString()}");
+        else
+        {
+            // Administrative install doesn't copy these files to
+            // their final destination, so we do it.
+            _context.CopyFiles(
+                PackageBinDir + "*.dll",
+                PackageBinDir + "agents/net20/");
+            _context.CopyFiles(
+                PackageBinDir + "*.dll",
+                PackageBinDir + "agents/net40/");
+        }
+    }
+}
+
+public class ZipPackageTester : NetFXPackageTester
+{
+    public ZipPackageTester(ICakeContext context, string packageVersion)
+        : base(context, packageVersion) { }
+
+    protected override string PackageName => $"NUnit.Console-{_packageVersion}.zip";
+    protected override string PackageInstallDirectory => _packageDir + "test/zip/";
+    protected override string PackageBinDir => PackageInstallDirectory + "bin/net20/";
+    //protected override string ExtensionInstallDirectory => _parameters.PackageInstallDirectory;
+}

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -10,6 +10,9 @@ public struct PackageTest
         Description = description;
         Arguments = arguments;
         ExpectedResult = expectedResult;
+
+        // Add Common tests here - currently there are none
+        // Derived classes may add more tests
     }
 }
 
@@ -83,15 +86,16 @@ public abstract class PackageTester
             try
             {
                 var result = new ActualResult(resultFile);
-                reporter.AddResult(packageTest, result);
+                var report = new TestReport(packageTest, result);
+                reporter.AddReport(report);
 
-                Console.WriteLine(result.Errors.Count == 0
+                Console.WriteLine(report.Errors.Count == 0
                     ? "\nSUCCESS: Test Result matches expected result!"
                     : "\nERROR: Test Result not as expected!");
             }
             catch (Exception ex)
             {
-                reporter.AddResult(packageTest, ex);
+                reporter.AddReport(new TestReport(packageTest, ex));
 
                 Console.WriteLine("\nERROR: No result found!");
             }
@@ -117,6 +121,7 @@ public abstract class NetFXPackageTester : PackageTester
     public NetFXPackageTester(ICakeContext context, string packageVersion)
         : base(context, packageVersion)
     {
+        // Add common tests for running under .NET Framework
         PackageTests.Add(new PackageTest(
             "Run mock-assembly.dll under .NET 3.5",
             "net35/mock-assembly.dll",
@@ -163,6 +168,7 @@ public abstract class NetCorePackageTester : PackageTester
     public NetCorePackageTester(ICakeContext context, string packageVersion)
         : base(context, packageVersion)
     {
+        // Add common tests for running under .NET Core (2.1 or higher)
         PackageTests.Add(new PackageTest(
             "Run mock-assembly.dll targeting .NET Core 2.1",
             "netcoreapp2.1/mock-assembly.dll",
@@ -239,6 +245,7 @@ public class MsiPackageTester : NetFXPackageTester
     public MsiPackageTester(ICakeContext context, string packageVersion)
         : base(context, packageVersion)
     {
+        // Add tests specific to the msi package
         PackageTests.Add(new PackageTest(
             "Run project with both copies of mock-assembly",
             $"../../NetFXTests.nunit --config={_config}",
@@ -284,6 +291,7 @@ public class ZipPackageTester : NetFXPackageTester
     public ZipPackageTester(ICakeContext context, string packageVersion)
         : base(context, packageVersion)
     {
+        // Add tests specific to the zip package
         PackageTests.Add(new PackageTest(
             "Run project with both copies of mock-assembly",
             $"../../NetFXTests.nunit --config={_config}",

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/test-results.cake
+++ b/test-results.cake
@@ -1,0 +1,127 @@
+// This file contains classes used to interpret the result XML that is
+// produced by test runs of the GUI.
+
+using System.Xml;
+
+public class ResultSummary
+{
+	public ResultSummary(XmlNode testRun)
+	{
+		OverallResult = GetAttribute(testRun, "result");
+		Total = IntAttribute(testRun, "total");
+		Passed = IntAttribute(testRun, "passed");
+		Failed = IntAttribute(testRun, "failed");
+		Warnings = IntAttribute(testRun, "warnings");
+		Inconclusive = IntAttribute(testRun, "inconclusive");
+		Skipped = IntAttribute(testRun, "skipped");
+	}
+
+	protected ResultSummary()
+	{
+	}
+
+	public string OverallResult { get; set; }
+	public int Total  { get; set; }
+	public int Passed  { get; set; }
+	public int Failed  { get; set; }
+	public int Warnings  { get; set; }
+	public int Inconclusive  { get; set; }
+	public int Skipped { get; set; }
+
+	private string GetAttribute(XmlNode testRun, string name)
+	{
+		return testRun.Attributes[name]?.Value;
+	}
+
+	private int IntAttribute(XmlNode node, string name)
+	{
+		string s = GetAttribute(node, name);
+		return s == null ? 0 : int.Parse(s);
+	}
+}
+
+public class ExpectedResult : ResultSummary
+{
+	public ExpectedResult(string overallResult)
+	{
+		OverallResult = overallResult;
+		// Initialize counters to -1, indicating no expected value.
+		// Set properties of those items to be checked.
+		Total = Passed = Failed = Warnings = Inconclusive = Skipped = -1;
+	}
+
+    private int _errorCount;
+
+	public int CheckResult(ResultSummary actual)
+	{
+        _errorCount = 0;
+
+        if (OverallResult != actual.OverallResult)
+            ReportError($"  Expected: Overall Result = {OverallResult}\n   But was: {actual.OverallResult}");
+        CheckCounter("Test Count", Total, actual.Total);
+        CheckCounter("Passed", Passed, actual.Passed);
+        CheckCounter("Failed", Failed, actual.Failed);
+        CheckCounter("Warnings", Warnings, actual.Warnings);
+        CheckCounter("Inconclusive", Inconclusive, actual.Inconclusive);
+        CheckCounter("Skipped", Skipped, actual.Skipped);
+
+        if (_errorCount == 0)
+            Console.WriteLine("SUCCESS: Test Result matches expected result!");
+
+		return _errorCount;
+	}
+
+    private void CheckCounter(string label, int expected, int actual)
+    {
+        if (expected > 0 && expected != actual)
+            ReportError($"  Expected: {label} = {expected}\n   But was: {actual}");
+    }
+
+    private void ReportError(string message)
+    {
+        if (_errorCount++ == 0)
+            Console.WriteLine("ERROR: Test Result not as expected!\n");
+        Console.WriteLine(message);
+    }
+}
+
+public class ResultReporter
+{
+	private string _resultFile;
+	private XmlNode _testRun;
+
+	public ResultReporter(string resultFile)
+	{
+		_resultFile = resultFile;
+	
+		var doc = new XmlDocument();
+		doc.Load(resultFile);
+
+		_testRun = doc.DocumentElement;
+		if (_testRun.Name != "test-run")
+			throw new Exception("The test-run element was not found.");
+
+		Summary = new ResultSummary(_testRun);
+		
+		if (Summary.OverallResult == null)
+			throw new Exception("The test-run element has no result attribute.");
+	}
+
+	public ResultSummary Summary { get; }
+
+	public int Report(ExpectedResult expectedResult)
+	{
+		Console.WriteLine("\nTest Run Summary");
+		Console.WriteLine("  Overall Result: " + Summary.OverallResult);
+
+		Console.WriteLine($"  Test Count: {Summary.Total}, Passed: {Summary.Passed}, Failed: {Summary.Failed}"
+			+$" Warnings: {Summary.Warnings}, Inconclusive: {Summary.Inconclusive}, Skipped: {Summary.Skipped}\n");
+
+		return  expectedResult.CheckResult(Summary);
+	}
+
+	private string GetAttribute(XmlNode node, string name)
+	{
+		return node.Attributes[name]?.Value;
+	}
+}

--- a/test-results.cake
+++ b/test-results.cake
@@ -3,41 +3,15 @@
 
 using System.Xml;
 
-public class ResultSummary
+public abstract class ResultSummary
 {
-	public ResultSummary(XmlNode testRun)
-	{
-		OverallResult = GetAttribute(testRun, "result");
-		Total = IntAttribute(testRun, "total");
-		Passed = IntAttribute(testRun, "passed");
-		Failed = IntAttribute(testRun, "failed");
-		Warnings = IntAttribute(testRun, "warnings");
-		Inconclusive = IntAttribute(testRun, "inconclusive");
-		Skipped = IntAttribute(testRun, "skipped");
-	}
-
-	protected ResultSummary()
-	{
-	}
-
-	public string OverallResult { get; set; }
-	public int Total  { get; set; }
-	public int Passed  { get; set; }
-	public int Failed  { get; set; }
-	public int Warnings  { get; set; }
-	public int Inconclusive  { get; set; }
-	public int Skipped { get; set; }
-
-	private string GetAttribute(XmlNode testRun, string name)
-	{
-		return testRun.Attributes[name]?.Value;
-	}
-
-	private int IntAttribute(XmlNode node, string name)
-	{
-		string s = GetAttribute(node, name);
-		return s == null ? 0 : int.Parse(s);
-	}
+    public string OverallResult { get; set; }
+    public int Total { get; set; }
+    public int Passed { get; set; }
+    public int Failed { get; set; }
+    public int Warnings { get; set; }
+    public int Inconclusive { get; set; }
+    public int Skipped { get; set; }
 }
 
 public class ExpectedResult : ResultSummary
@@ -57,7 +31,7 @@ public class ExpectedResult : ResultSummary
         _errorCount = 0;
 
         if (OverallResult != actual.OverallResult)
-            ReportError($"  Expected: Overall Result = {OverallResult}\n   But was: {actual.OverallResult}");
+            ReportError($"   Expected: Overall Result = {OverallResult}\n    But was: {actual.OverallResult}");
         CheckCounter("Test Count", Total, actual.Total);
         CheckCounter("Passed", Passed, actual.Passed);
         CheckCounter("Failed", Failed, actual.Failed);
@@ -65,63 +39,155 @@ public class ExpectedResult : ResultSummary
         CheckCounter("Inconclusive", Inconclusive, actual.Inconclusive);
         CheckCounter("Skipped", Skipped, actual.Skipped);
 
-        if (_errorCount == 0)
-            Console.WriteLine("SUCCESS: Test Result matches expected result!");
+        Console.WriteLine(_errorCount == 0
+            ? "   SUCCESS: Test Result matches expected result!"
+            : "   ERROR: Test Result not as expected!\n");
 
-		return _errorCount;
+        return _errorCount;
 	}
 
     private void CheckCounter(string label, int expected, int actual)
     {
         if (expected > 0 && expected != actual)
-            ReportError($"  Expected: {label} = {expected}\n   But was: {actual}");
+            ReportError($"     Expected: {label} = {expected}\n      But was: {actual}");
     }
 
     private void ReportError(string message)
     {
-        if (_errorCount++ == 0)
-            Console.WriteLine("ERROR: Test Result not as expected!\n");
+        _errorCount++;
         Console.WriteLine(message);
+    }
+}
+
+public class ActualResult : ResultSummary
+{
+    public ActualResult(string resultFile)
+    {
+        var doc = new XmlDocument();
+        doc.Load(resultFile);
+
+        var testRun = doc.DocumentElement;
+        if (testRun.Name != "test-run")
+            throw new Exception("The test-run element was not found.");
+
+        OverallResult = GetAttribute(testRun, "result");
+        Total = IntAttribute(testRun, "total");
+        Passed = IntAttribute(testRun, "passed");
+        Failed = IntAttribute(testRun, "failed");
+        Warnings = IntAttribute(testRun, "warnings");
+        Inconclusive = IntAttribute(testRun, "inconclusive");
+        Skipped = IntAttribute(testRun, "skipped");
+    }
+
+    public XmlNode XmlResult { get; }
+    public List<string> Errors { get; }  = new List<string>();
+    public bool HasErrors => Errors.Count > 0;
+
+    private string GetAttribute(XmlNode testRun, string name)
+    {
+        return testRun.Attributes[name]?.Value;
+    }
+
+    private int IntAttribute(XmlNode node, string name)
+    {
+        string s = GetAttribute(node, name);
+        return s == null ? 0 : int.Parse(s);
+    }
+}
+
+public class TestReport
+{
+    public PackageTest Test;
+    public ActualResult Result;
+    public List<string> Errors;
+
+    public TestReport(PackageTest test, ActualResult result)
+    {
+        Test = test;
+        Result = result;
+        Errors = new List<string>();
+
+        var expected = test.ExpectedResult;
+
+        if (result.OverallResult == null)
+            Errors.Add("The test-run element has no result attribute.");
+        else if (expected.OverallResult != result.OverallResult)
+            Errors.Add($"   Expected: Overall Result = {expected.OverallResult}\n    But was: {result.OverallResult}");
+        CheckCounter("Test Count", expected.Total, result.Total);
+        CheckCounter("Passed", expected.Passed, result.Passed);
+        CheckCounter("Failed", expected.Failed, result.Failed);
+        CheckCounter("Warnings", expected.Warnings, result.Warnings);
+        CheckCounter("Inconclusive", expected.Inconclusive, result.Inconclusive);
+        CheckCounter("Skipped", expected.Skipped, result.Skipped);
+    }
+
+    public TestReport(PackageTest test, Exception ex)
+    {
+        Test = test;
+        Result = null;
+        Errors = new List<string>();
+        Errors.Add($"     {ex.Message}");
+    }
+
+    public void Display(int index)
+    {
+        Console.WriteLine($"\n{index}. {Test.Description}");
+        Console.WriteLine($"   Args: {Test.Arguments}\n");
+
+        foreach (var error in Errors)
+            Console.WriteLine(error);
+
+        Console.WriteLine(Errors.Count == 0
+            ? "   SUCCESS: Test Result matches expected result!"
+            : "\n   ERROR: Test Result not as expected!");
+    }
+
+    private void CheckCounter(string label, int expected, int actual)
+    {
+        if (expected > 0 && expected != actual)
+            Errors.Add($"     Expected: {label} = {expected}\n      But was: {actual}");
     }
 }
 
 public class ResultReporter
 {
-	private string _resultFile;
-	private XmlNode _testRun;
+    private string _packageName;
+    private List<TestReport> _reports = new List<TestReport>();
 
-	public ResultReporter(string resultFile)
-	{
-		_resultFile = resultFile;
-	
-		var doc = new XmlDocument();
-		doc.Load(resultFile);
+    public ResultReporter(string packageName)
+    {
+        _packageName = packageName;
+    }
 
-		_testRun = doc.DocumentElement;
-		if (_testRun.Name != "test-run")
-			throw new Exception("The test-run element was not found.");
+    public void AddResult(PackageTest test, ActualResult result)
+    {
+        _reports.Add(new TestReport(test, result));
+    }
 
-		Summary = new ResultSummary(_testRun);
-		
-		if (Summary.OverallResult == null)
-			throw new Exception("The test-run element has no result attribute.");
-	}
+    public void AddResult(PackageTest test, Exception ex)
+    {
+        _reports.Add(new TestReport(test, ex));
+    }
 
-	public ResultSummary Summary { get; }
+    public bool ReportResults()
+    {
+        Console.WriteLine("\n=================================================="); ;
+        Console.WriteLine($"Test Results for {_packageName}");
+        Console.WriteLine("=================================================="); ;
 
-	public int Report(ExpectedResult expectedResult)
-	{
-		Console.WriteLine("\nTest Run Summary");
-		Console.WriteLine("  Overall Result: " + Summary.OverallResult);
+        Console.WriteLine("\nTest Environment");
+        Console.WriteLine($"   OS Version: {Environment.OSVersion.VersionString}");
+        Console.WriteLine($"  CLR Version: {Environment.Version}\n");
 
-		Console.WriteLine($"  Test Count: {Summary.Total}, Passed: {Summary.Passed}, Failed: {Summary.Failed}"
-			+$" Warnings: {Summary.Warnings}, Inconclusive: {Summary.Inconclusive}, Skipped: {Summary.Skipped}\n");
+        int index = 0;
+        bool hasErrors = false;
 
-		return  expectedResult.CheckResult(Summary);
-	}
+        foreach (var report in _reports)
+        {
+            hasErrors |= report.Errors.Count > 0;
+            report.Display(++index);
+        }
 
-	private string GetAttribute(XmlNode node, string name)
-	{
-		return node.Attributes[name]?.Value;
-	}
+        return hasErrors;
+    }
 }


### PR DESCRIPTION
Fixes #892 (originally #852)

This PR replaces #896, with a simpler implementation more in keeping with the existing, primarily procedural, structure of the build script. It contains only the code needed to do what it does, with no "hooks" in place for further expansion.

INCLUDED

1. Added testing for five console packages: NuGet for .NET FX, NuGet for .NET Core, Chocolatey, Zip and MSi. There are currently four test runs for each .NET FX package and three for the .NET Core package. The tests are not extensive but they verify that the executable can run without crashing and that the top-level result counters match what is expected.

2.  The tests of the MSI and ZIP packages include running a `.nunit` project file. The required extension is already present in those packages.

3. Added a .NET 4.0 build of mock-assembly so it could be used in one of the .NET FX tests.

4. A summary report of test results for each package tested is displayed.

NOT INCLUDED:

1. Tests of .nunit project under any other packages, which would require a separate installing the extension. This is reserved for a separate issue if desired.

2. No other extensions are currently tested.

3. No automatic package uploading or release. That's a separate issue.


