### PR TITLE
Stop double reporting of assemblies when running after a reload

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
@@ -103,6 +103,8 @@ namespace NUnit.Engine.Runners
 
             var driverService = Services.GetService<IDriverService>();
 
+            _drivers.Clear();
+
             foreach (var subPackage in packagesToLoad)
             {
                 var testFile = subPackage.FullName;

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -172,6 +172,36 @@ namespace NUnit.Engine.Runners.Tests
         }
 
         [Test]
+        public void RunAfterReload()
+        {
+            // Engine issue #609
+            _runner.Load();
+            _runner.Reload();
+            var result = _runner.Run(this, TestFilter.Empty);
+
+            Assert.That(result.Name, Is.EqualTo("test-run"));
+            CheckTestRunResult(result, _testRunData);
+
+            CheckThatIdsAreUnique(result);
+
+            CheckTestRunEvents();
+        }
+
+        [Test]
+        public void ExploreAfterReload()
+        {
+            // Engine issue #609
+            _runner.Load();
+            _runner.Reload();
+            var result = _runner.Explore(TestFilter.Empty);
+
+            Assert.That(result.Name, Is.EqualTo("test-run"));
+            CheckResult(result, _testRunData);
+
+            CheckThatIdsAreUnique(result);
+        }
+
+        [Test]
         public void RunAsync()
         {
             _runner.Load(); // Make sure it's pre-loaded so we get count in start-run


### PR DESCRIPTION
This replaces PR #610 and fixes #609 directly, without making any of the discussed enhancements to Reload.

The reported "doubling" of assemblies after a reload was due to not clearing the list of drivers.

The bigger questions raised about how we do a reload are reserved for a future enhancement.

The old issue-609 branch can be deleted once this is merged, in addition to issue-609b.