### PR TITLE
Remove unused dependencies from .NET Standard 2.0 builds

### DIFF
--- a/nuget/engine/nunit.engine.api.nuspec
+++ b/nuget/engine/nunit.engine.api.nuspec
@@ -18,12 +18,6 @@
     <language>en-US</language>
     <tags>nunit test testing tdd engine</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>
-    <dependencies>
-      <group targetFramework="net20" />
-      <group targetFramework="netstandard2.0">
-        <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" exclude="compile" />
-      </group>
-    </dependencies>
   </metadata>
   <files>
     <file src="LICENSE.txt" />

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -22,17 +22,9 @@
       <group targetFramework="net20" />
       <group targetFramework="netstandard2.0">
         <dependency id="NETStandard.Library" version="2.0.0" />
-        <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" exclude="compile" />
-        <dependency id="System.Reflection" version="4.3.0" exclude="compile" />
-        <dependency id="System.Diagnostics.Process" version="4.3.0" exclude="compile" />
-        <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" exclude="compile" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="NETStandard.Library" version="2.0.0" />
-        <dependency id="System.ComponentModel.TypeConverter" version="4.3.0" exclude="compile" />
-        <dependency id="System.Reflection" version="4.3.0" exclude="compile" />
-        <dependency id="System.Diagnostics.Process" version="4.3.0" exclude="compile" />
-        <dependency id="System.Xml.XPath.XmlDocument" version="4.3.0" exclude="compile" />
       </group>
     </dependencies>
     <contentFiles>

--- a/nuget/runners/nunit.console-runner.netcore.nuspec
+++ b/nuget/runners/nunit.console-runner.netcore.nuspec
@@ -44,7 +44,6 @@
     <file src="bin/netcoreapp3.1/nunit.engine.api.pdb" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/nunit.engine.api.xml" target="tools/netcoreapp3.1/any" />
     <file src="bin/netcoreapp3.1/testcentric.engine.metadata.dll" target="tools/netcoreapp3.1/any" />
-    <file src="bin/netcoreapp3.1/System.Xml.XPath.XmlDocument.dll" target="tools/netcoreapp3.1/any" />
     <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools/netcoreapp3.1/any"/>
     <file src="../../nuget/runners/DotnetToolSettings.xml" target="tools/netcoreapp3.1/any"/>
     <file src="../../nunit_256.png" target="images"/>

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -9,9 +9,6 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\EngineApiVersion.cs" LinkBase="Properties" />
   </ItemGroup>

--- a/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
+++ b/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
@@ -9,12 +9,6 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
   </ItemGroup>

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -10,10 +10,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
+
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />


### PR DESCRIPTION
Fixes #908.

When these dependencies were added, they were all added for both the .NET Standard 1.3 and 2.0 builds. I don't believe any of them are actually required, now we've removed .NET Standard 1.3.