### PR TITLE
feat:  Allow more flexibility in extension naming

### DIFF
--- a/nuget/runners/nunit.console.nuget.addins
+++ b/nuget/runners/nunit.console.nuget.addins
@@ -1,4 +1,4 @@
-../../NUnit.Extension.*/**/tools/        # nuget v2 layout
-../../../NUnit.Extension.*/**/tools/     # nuget v3 layout
-../../nunit.extension.*/**/tools/        # nuget v2 layout
-../../../nunit.extension.*/**/tools/     # nuget v3 layout
+../../*NUnit.Extension.*/**/tools/        # nuget v2 layout
+../../../*NUnit.Extension.*/**/tools/     # nuget v3 layout
+../../*nunit.extension.*/**/tools/        # nuget v2 layout
+../../../*nunit.extension.*/**/tools/     # nuget v3 layout


### PR DESCRIPTION
This change will allow developers to use a different base namespace and have those packages searched by default as well instead of updating a file within the NuGet package’s folder, which would be bad practice.  For example, it will match, SomeTeam.NUnit.Extensions.MyProjectLoader