### PR TITLE
Make default TestAgency URI unique per run

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Acceptance/InstantiateEngineInsideTest.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Acceptance/InstantiateEngineInsideTest.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
 using System.IO;
 using NUnit.Framework;
 
@@ -25,8 +24,16 @@ namespace NUnit.Engine.Tests.Acceptance
                 var engine = TestEngineActivator.CreateInstance();
                 var mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
                 var package = new TestPackage(mockAssemblyPath);
-                engine.GetRunner(package).Run(null, null);
+                engine.GetRunner(package).Run(new NullListener(), TestFilter.Empty);
             });
+        }
+
+        private class NullListener : ITestEventListener
+        {
+            public void OnTestEvent(string testEvent)
+            {
+                // No action
+            }
         }
 
     }

--- a/src/NUnitEngine/nunit.engine.tests/Acceptance/InstantiateEngineInsideTest.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Acceptance/InstantiateEngineInsideTest.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Tests.Acceptance
+{
+    class InstantiateEngineInsideTest
+    {
+
+        /// <summary>
+        /// Historically it wasn't possible to instantiate a full engine inside
+        /// a running NUnit test due to issues with URI collisions for
+        /// inter-process communication.
+        ///
+        /// This is a useful feature to maintain, to allow runners to create full
+        /// end-to-end acceptance-style tests in NUnit.
+        /// </summary>
+        [Test]
+        public void CanInstantiateEngineInsideTest()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var engine = TestEngineActivator.CreateInstance();
+                var mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");
+                var package = new TestPackage(mockAssemblyPath);
+                engine.GetRunner(package).Run(null, null);
+            });
+        }
+
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -51,7 +51,7 @@ namespace NUnit.Engine.Runners.Tests
 #if NETFRAMEWORK
             _services.Add(new Services.DomainManager());
             _services.Add(new Services.RuntimeFrameworkService());
-            _services.Add(new Services.TestAgency("ProcessRunnerTests", 0));
+            _services.Add(new Services.TestAgency());
 #endif
             _services.Add(new Services.DriverService());
             _services.Add(new Services.DefaultTestRunnerFactory());

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
@@ -16,8 +16,7 @@ namespace NUnit.Engine.Services.Tests
         {
             var services = new ServiceContext();
             services.Add(new FakeRuntimeService());
-            // Use a different URI to avoid conflicting with the "real" TestAgency
-            _testAgency = new TestAgency("TestAgencyTest", 0);
+            _testAgency = new TestAgency();
             services.Add(_testAgency);
             services.ServiceManager.StartServices();
         }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -37,10 +37,10 @@ namespace NUnit.Engine.Services
         internal virtual string RemotingUrl => _remotingTransport.ServerUrl;
         //internal virtual string TcpEndPoint => _tcpTransport.ServerUrl;
 
-        public TestAgency() : this("TestAgency-" + Guid.NewGuid(), 0) { }
-
-        public TestAgency( string uri, int port )
+        public TestAgency()
         {
+            var uri = "TestAgency-" + Guid.NewGuid();
+            var port = 0;
             _remotingTransport = new TestAgencyRemotingTransport(this, uri, port);
             //_tcpTransport = new TestAgencyTcpTransport(this, port);
         }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Services
         internal virtual string RemotingUrl => _remotingTransport.ServerUrl;
         //internal virtual string TcpEndPoint => _tcpTransport.ServerUrl;
 
-        public TestAgency() : this("TestAgency", 0) { }
+        public TestAgency() : this("TestAgency-" + Guid.NewGuid(), 0) { }
 
         public TestAgency( string uri, int port )
         {

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Services
         internal virtual string RemotingUrl => _remotingTransport.ServerUrl;
         //internal virtual string TcpEndPoint => _tcpTransport.ServerUrl;
 
-        public TestAgency() : this( "TestAgency", 0 ) { }
+        public TestAgency() : this("TestAgency", 0) { }
 
         public TestAgency( string uri, int port )
         {


### PR DESCRIPTION
Currently, it's not possible to instantiate an engine inside a test run, due to two TestAgency's colliding on the same URI. This causes problems when testing runners and the engine, and requires injecting a second URI into the test TestAgency, which isn't possible for runners accessing the engine through the ITestEngine interface.

As far as I can think - a TestAgency URI needs to be fixed-per-run, but there's no requirement for it to be fixed across different runs. I think adding a GUID to the default TestAgency URI would be a simple change to resolve this problem, and make it easier for runners to test?

@CharliePoole - you've been working in this area recently - do you agree with my logic here?