### PR TITLE
Use EnterContextualReflection to address .NET Core dependency loading issues

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -38,6 +38,7 @@ namespace NUnit.Engine.Drivers
         Assembly _frameworkAssembly;
         object _frameworkController;
         Type _frameworkControllerType;
+        CustomAssemblyLoadContext _assemblyLoadContext;
 
         /// <summary>
         /// An id prefix that will be passed to the test framework and used as part of the
@@ -56,10 +57,11 @@ namespace NUnit.Engine.Drivers
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
 
             assemblyPath = Path.GetFullPath(assemblyPath);  //AssemblyLoadContext requires an absolute path
-            var assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
+            _assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
+
             try
             {
-                _testAssembly = assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
+                _testAssembly = _assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);
             }
             catch (Exception e)
             {
@@ -67,11 +69,11 @@ namespace NUnit.Engine.Drivers
             }
 
             var nunitRef = _testAssembly.GetReferencedAssemblies().FirstOrDefault(reference => reference.Name.Equals("nunit.framework", StringComparison.OrdinalIgnoreCase));
-            
+
             if (nunitRef == null)
                 throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 
-            _frameworkAssembly = assemblyLoadContext.LoadFromAssemblyName(nunitRef);
+            _frameworkAssembly = _assemblyLoadContext.LoadFromAssemblyName(nunitRef);
             if (_frameworkAssembly == null)
                 throw new NUnitEngineException(FAILED_TO_LOAD_NUNIT);
 
@@ -112,7 +114,7 @@ namespace NUnit.Engine.Drivers
         }
 
         /// <summary>
-        /// Executes the tests in an assembly asyncronously.
+        /// Executes the tests in an assembly asynchronously.
         /// </summary>
         /// <param name="callback">A callback that receives XML progress notices</param>
         /// <param name="filter">A filter that controls which tests are executed</param>
@@ -179,7 +181,11 @@ namespace NUnit.Engine.Drivers
             {
                 throw new NUnitEngineException(INVALID_FRAMEWORK_MESSAGE);
             }
-            return method.Invoke(_frameworkController, args);
+
+            using (_assemblyLoadContext.EnterContextualReflection())
+            {
+                return method.Invoke(_frameworkController, args);
+            }
         }
     }
 }


### PR DESCRIPTION
Hopefully fixes #828 and #916 

This uses the new EnterContextualReflection API introduced in netcore30, which will hopefully solve our .NET Core dependency loading issues. I wasn't aware of this previously as I don't think Microsoft's docs have yet been updated to include this - however there's some design documentation at the link below. (Thanks @Learfin for mentioning it in your write-up!) From what I understand, the API was added to tackle issues with xUnit that seem to be very similar to the problems we've been hitting.

https://github.com/dotnet/coreclr/blob/master/Documentation/design-docs/AssemblyLoadContext.ContextualReflection.md

I wanted to add a test for this, but unfortunately it's not really possible our current build structure. It's another example where a proper suite of acceptance test assembly's would be really handy - hopefully we'll get round to that one day.

Note the only change is in the final commit - this is just branched off #923 as they will interact. Once #923 is merged, I'll rebase this.

-------

@Learfin, @joeltankam, @VoltanFr, @bouchraRekhadda, @runehalfdan, @webMan1 - I gather you've all encountered this issue in one form or another. I've tested against the repro's provided in #916 and #939, but would really appreciate anyone who could test against their particular usecase before merging this. You should be able to download updated packages from the CI build here: https://ci.appveyor.com/project/CharliePoole/nunit-console/builds/38972209/artifacts