### PR TITLE
v4: Create ITestPackage interface

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ConsoleMocks.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleMocks.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using System.Text;
 using NSubstitute;
 using NUnit.Common;
 
@@ -12,6 +13,22 @@ namespace NUnit.ConsoleRunner.Tests
             var mockFileSystem = Substitute.For<IFileSystem>();
             var mockDefaultsProvider = Substitute.For<IDefaultOptionsProvider>();
             return new ConsoleOptions(mockDefaultsProvider, mockFileSystem, args);
+        }
+
+        public class ExtendedTextWriter  : NUnit.ConsoleRunner.ExtendedTextWriter
+        {
+            public override Encoding Encoding { get; }
+            public override void Write(ColorStyle style, string value) { }
+
+            public override void WriteLine(ColorStyle style, string value) { }
+
+            public override void WriteLabel(string label, object option) { }
+
+            public override void WriteLabel(string label, object option, ColorStyle valueStyle) { }
+
+            public override void WriteLabelLine(string label, object option) { }
+
+            public override void WriteLabelLine(string label, object option, ColorStyle valueStyle) { }
         }
     }
 }

--- a/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit3-console/ConsoleRunner.cs
@@ -85,7 +85,7 @@ namespace NUnit.ConsoleRunner
 
             DisplayTestFiles();
 
-            TestPackage package = MakeTestPackage(_options);
+            var package = MakeTestPackage(_options);
 
             // We display the filters at this point so  that any exception message
             // thrown by CreateTestFilter will be understandable.
@@ -107,7 +107,7 @@ namespace NUnit.ConsoleRunner
             _outWriter.WriteLine();
         }
 
-        private int ExploreTests(TestPackage package, TestFilter filter)
+        private int ExploreTests(ITestPackage package, TestFilter filter)
         {
             XmlNode result;
 
@@ -130,7 +130,7 @@ namespace NUnit.ConsoleRunner
             return ConsoleRunner.OK;
         }
 
-        private int RunTests(TestPackage package, TestFilter filter)
+        private int RunTests(ITestPackage package, TestFilter filter)
         {
 
             var writer = new ColorConsoleWriter(!_options.NoColor);
@@ -364,9 +364,9 @@ namespace NUnit.ConsoleRunner
         }
 
         // This is public static for ease of testing
-        public static TestPackage MakeTestPackage(ConsoleOptions options)
+        public ITestPackage MakeTestPackage(ConsoleOptions options)
         {
-            TestPackage package = new TestPackage(options.InputFiles);
+            var package = _engine.CreatePackage(options.InputFiles);
 
             if (options.ProcessModelSpecified)
                 package.AddSetting(EnginePackageSettings.ProcessModel, options.ProcessModel);
@@ -453,7 +453,7 @@ namespace NUnit.ConsoleRunner
         /// <summary>
         /// Sets test parameters, handling backwards compatibility.
         /// </summary>
-        private static void AddTestParametersSetting(TestPackage testPackage, IDictionary<string, string> testParameters)
+        private static void AddTestParametersSetting(ITestPackage testPackage, IDictionary<string, string> testParameters)
         {
             testPackage.AddSetting(FrameworkPackageSettings.TestParametersDictionary, testParameters);
 

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IProject.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IProject.cs
@@ -33,7 +33,7 @@ namespace NUnit.Engine.Extensibility
         /// specified in the project format.
         /// </summary>
         /// <returns>A TestPackage</returns>
-        TestPackage GetTestPackage();
+        ITestPackage GetTestPackage();
 
         /// <summary>
         /// Gets a TestPackage for a specific configuration
@@ -43,6 +43,6 @@ namespace NUnit.Engine.Extensibility
         /// </summary>
         /// <param name="configName">The name of the config to use</param>
         /// <returns>A TestPackage for the named configuration.</returns>
-        TestPackage GetTestPackage(string configName);
+        ITestPackage GetTestPackage(string configName);
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
@@ -32,6 +32,6 @@ namespace NUnit.Engine
         /// </summary>
         /// <param name="package">A TestPackage</param>
         /// <returns>The selected RuntimeFramework</returns>
-        string SelectRuntimeFramework(TestPackage package);
+        string SelectRuntimeFramework(ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/ITestEngine.cs
+++ b/src/NUnitEngine/nunit.engine.api/ITestEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Collections.Generic;
 using System.Xml;
 
 namespace NUnit.Engine
@@ -47,11 +48,29 @@ namespace NUnit.Engine
         void Initialize();
 
         /// <summary>
+        /// Construct a top-level ITestPackage that wraps one or more
+        /// test files, contained as subpackages.
+        /// </summary>
+        /// <remarks>
+        /// Semantically equivalent to the array method.
+        /// </remarks>
+        ITestPackage CreatePackage(IList<string> testFiles);
+
+        /// <summary>
+        /// Construct a top-level ITestPackage that wraps one or more
+        /// test files, contained as subpackages.
+        /// </summary>
+        /// <remarks>
+        /// Semantically equivalent to the IList method.
+        /// </remarks>
+        ITestPackage CreatePackage(params string[] testFiles);
+
+        /// <summary>
         /// Returns a test runner instance for use by clients in discovering,
         /// exploring and executing tests.
         /// </summary>
-        /// <param name="package">The TestPackage for which the runner is intended.</param>
+        /// <param name="package">The ITestPackage for which the runner is intended.</param>
         /// <returns>An ITestRunner.</returns>
-        ITestRunner GetRunner(TestPackage package);
+        ITestRunner GetRunner(ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/ITestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/ITestPackage.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+
+using System.Collections.Generic;
+
+namespace NUnit.Engine
+{
+    /// <summary>
+    /// ITestPackage holds information about a set of test files to
+    /// be loaded by a TestRunner. Each ITestPackage represents
+    /// tests for one or more test files.
+    /// 
+    /// Upon construction, a package is given an ID (string), which
+    /// remains unchanged for the lifetime of the ITestPackage instance.
+    /// The package ID is passed to the test framework for use in generating
+    /// test IDs.
+    /// 
+    /// A runner that reloads test assemblies and wants the ids to remain stable
+    /// should avoid creating a new package but should instead use the original
+    /// package, changing settings as needed. This gives the best chance for the
+    /// tests in the reloaded assembly to match those originally loaded.
+    /// </summary>
+    public interface ITestPackage
+    {
+        /// <summary>
+        /// Every test package gets a unique ID used to prefix test IDs within that package.
+        /// </summary>
+        /// <remarks>
+        /// The generated ID is only unique for packages created within the same application domain.
+        /// For that reason, NUnit pre-creates all test packages that will be needed.
+        /// </remarks>
+        string ID { get; }
+
+        /// <summary>
+        /// Gets the name of the package
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the path to the file containing tests. It may be
+        /// an assembly or a recognized project type.
+        /// </summary>
+        string FullName { get; }
+
+        /// <summary>
+        /// Gets the list of SubPackages contained in this package
+        /// </summary>
+        IList<ITestPackage> SubPackages { get; }
+
+        /// <summary>
+        /// Gets the settings dictionary for this package.
+        /// </summary>
+        IDictionary<string, object> Settings { get; }
+
+        /// <summary>
+        /// Add a subpackage to the package.
+        /// </summary>
+        /// <param name="subPackage">The subpackage to be added</param>
+        void AddSubPackage(ITestPackage subPackage);
+
+        /// <summary>
+        /// Add a subpackage to the package, specifying its name. This is
+        /// the only way to add a named subpackage to the top-level package.
+        /// </summary>
+        /// <param name="packageName">The name of the subpackage to be added</param>
+        ITestPackage AddSubPackage(string packageName);
+
+        /// <summary>
+        /// Add a setting to a package and all of its subpackages.
+        /// </summary>
+        /// <param name="name">The name of the setting</param>
+        /// <param name="value">The value of the setting</param>
+        /// <remarks>
+        /// Once a package is created, subpackages may have been created
+        /// as well. If you add a setting directly to the Settings dictionary
+        /// of the package, the subpackages are not updated. This method is
+        /// used when the settings are intended to be reflected to all the
+        /// subpackages under the package.
+        /// </remarks>
+        void AddSetting(string name, object value);
+
+        /// <summary>
+        /// Return the value of a setting or a default, which
+        /// is specified by the caller.
+        /// </summary>
+        /// <param name="name">The name of the setting</param>
+        /// <param name="defaultSetting">The default value</param>
+        /// <returns></returns>
+        T GetSetting<T>(string name, T defaultSetting);
+    }
+}

--- a/src/NUnitEngine/nunit.engine.core/Agents/RemoteTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine.core/Agents/RemoteTestAgent.cs
@@ -36,7 +36,7 @@ namespace NUnit.Engine.Agents
             Transport.Stop();
         }
 
-        public override ITestEngineRunner CreateRunner(TestPackage package)
+        public override ITestEngineRunner CreateRunner(ITestPackage package)
         {
             return Services.GetService<ITestRunnerFactory>().MakeTestRunner(package);
         }

--- a/src/NUnitEngine/nunit.engine.core/Agents/TestAgent.cs
+++ b/src/NUnitEngine/nunit.engine.core/Agents/TestAgent.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine.Agents
         /// <summary>
         ///  Creates a test runner
         /// </summary>
-        public abstract ITestEngineRunner CreateRunner(TestPackage package);
+        public abstract ITestEngineRunner CreateRunner(ITestPackage package);
 
         public bool WaitForStop(int timeout)
         {

--- a/src/NUnitEngine/nunit.engine.core/Communication/Transports/ITestAgentTransport.cs
+++ b/src/NUnitEngine/nunit.engine.core/Communication/Transports/ITestAgentTransport.cs
@@ -11,6 +11,6 @@ namespace NUnit.Engine.Communication.Transports
     public interface ITestAgentTransport : ITransport
     {
         TestAgent Agent { get; }
-        ITestEngineRunner CreateRunner(TestPackage package);
+        ITestEngineRunner CreateRunner(ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/Communication/Transports/Remoting/TestAgentRemotingTransport.cs
+++ b/src/NUnitEngine/nunit.engine.core/Communication/Transports/Remoting/TestAgentRemotingTransport.cs
@@ -95,7 +95,7 @@ namespace NUnit.Engine.Communication.Transports.Remoting
             });
         }
 
-        public ITestEngineRunner CreateRunner(TestPackage package)
+        public ITestEngineRunner CreateRunner(ITestPackage package)
         {
             _runner = Agent.CreateRunner(package);
             return this;

--- a/src/NUnitEngine/nunit.engine.core/Communication/Transports/Tcp/TestAgentTcpTransport.cs
+++ b/src/NUnitEngine/nunit.engine.core/Communication/Transports/Tcp/TestAgentTcpTransport.cs
@@ -64,7 +64,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
             Agent.StopSignal.Set();
         }
 
-        public ITestEngineRunner CreateRunner(TestPackage package)
+        public ITestEngineRunner CreateRunner(ITestPackage package)
         {
             return Agent.CreateRunner(package);
         }

--- a/src/NUnitEngine/nunit.engine.core/ITestAgent.cs
+++ b/src/NUnitEngine/nunit.engine.core/ITestAgent.cs
@@ -28,6 +28,6 @@ namespace NUnit.Engine
         /// <summary>
         ///  Creates a test runner
         /// </summary>
-        ITestEngineRunner CreateRunner(TestPackage package);
+        ITestEngineRunner CreateRunner(ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/ITestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/ITestRunnerFactory.cs
@@ -14,7 +14,7 @@ namespace NUnit.Engine
         /// </summary>
         /// <param name="package">The test package to be loaded by the runner</param>
         /// <returns>A TestRunner</returns>
-        ITestEngineRunner MakeTestRunner(TestPackage package);
+        ITestEngineRunner MakeTestRunner(ITestPackage package);
 
         /// <summary>
         /// Return true if the provided runner is suitable for reuse in loading
@@ -24,6 +24,6 @@ namespace NUnit.Engine
         /// <param name="runner">An ITestRunner to possibly be used.</param>
         /// <param name="package">The TestPackage to be loaded.</param>
         /// <returns>True if the runner may be reused for the provided package.</returns>
-        bool CanReuse(ITestEngineRunner runner, TestPackage package);
+        bool CanReuse(ITestEngineRunner runner, ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/Internal/ResultHelper.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/ResultHelper.cs
@@ -54,7 +54,7 @@ namespace NUnit.Engine.Internal
         /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project.</param>
         /// <param name="package">The <see cref="TestPackage"/> for which we are aggregating.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult MakeProjectResult(this TestEngineResult result, TestPackage package)
+        public static TestEngineResult MakeProjectResult(this TestEngineResult result, ITestPackage package)
         {
             return Aggregate(result, TEST_SUITE_ELEMENT, PROJECT_SUITE_TYPE, package.ID, package.Name, package.FullName);
         }
@@ -65,7 +65,7 @@ namespace NUnit.Engine.Internal
         /// <param name="result">A new TestEngineResult with xml nodes for each assembly or project.</param>
         /// <param name="package">The <see cref="TestPackage"/> for which we are aggregating.</param>
         /// <returns>A TestEngineResult with a single top-level element.</returns>
-        public static TestEngineResult MakeTestRunResult(this TestEngineResult result, TestPackage package)
+        public static TestEngineResult MakeTestRunResult(this TestEngineResult result, ITestPackage package)
         {
             return Aggregate(result, TEST_RUN_ELEMENT, package.ID, package.Name, package.FullName);
         }

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestPackageExtensions.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestPackageExtensions.cs
@@ -1,37 +1,36 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
 using System.Collections.Generic;
 
 namespace NUnit.Engine.Internal
 {
-    public delegate bool TestPackageSelectorDelegate(TestPackage p);
+    public delegate bool TestPackageSelectorDelegate(ITestPackage p);
 
     /// <summary>
     /// Extension methods for use with TestPackages
     /// </summary>
     public static class TestPackageExtensions
     {
-        public static bool IsAssemblyPackage(this TestPackage package)
+        public static bool IsAssemblyPackage(this ITestPackage package)
         {
             return package.FullName != null && PathUtils.IsAssemblyFileType(package.FullName);
         }
 
-        public static bool HasSubPackages(this TestPackage package)
+        public static bool HasSubPackages(this ITestPackage package)
         {
             return package.SubPackages.Count > 0;
         }
 
-        public static IList<TestPackage> Select(this TestPackage package, TestPackageSelectorDelegate selector)
+        public static IList<ITestPackage> Select(this ITestPackage package, TestPackageSelectorDelegate selector)
         {
-            var selection = new List<TestPackage>();
+            var selection = new List<ITestPackage>();
 
             AccumulatePackages(package, selection, selector);
 
             return selection;
         }
 
-        private static void AccumulatePackages(TestPackage package, IList<TestPackage> selection, TestPackageSelectorDelegate selector)
+        private static void AccumulatePackages(ITestPackage package, IList<ITestPackage> selection, TestPackageSelectorDelegate selector)
         {
             if (selector(package))
                 selection.Add(package);

--- a/src/NUnitEngine/nunit.engine.core/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/nunit.engine.core/Properties/AssemblyInfo.cs
@@ -13,6 +13,13 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+[assembly: InternalsVisibleTo("nunit.engine, PublicKey=" +
+    "002400000480000094000000060200000024000052534131000400000100010031eea370b1984b" +
+    "fa6d1ea760e1ca6065cee41a1a279ca234933fe977a096222c0e14f9e5a17d5689305c6d7f1206" +
+    "a85a53c48ca010080799d6eeef61c98abd18767827dc05daea6b6fbd2e868410d9bee5e972a004" +
+    "ddd692dec8fa404ba4591e847a8cf35de21c2d3723bc8d775a66b594adeb967537729fe2a446b5" +
+    "48cd57a6")]
+
 [assembly: InternalsVisibleTo("nunit.engine.tests, PublicKey="+
     "002400000480000094000000060200000024000052534131000400000100010031eea370b1984b" +
     "fa6d1ea760e1ca6065cee41a1a279ca234933fe977a096222c0e14f9e5a17d5689305c6d7f1206"+

--- a/src/NUnitEngine/nunit.engine.core/Runners/AbstractTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/AbstractTestRunner.cs
@@ -14,7 +14,7 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public abstract class AbstractTestRunner : ITestEngineRunner
     {
-        public AbstractTestRunner(IServiceLocator services, TestPackage package)
+        public AbstractTestRunner(IServiceLocator services, ITestPackage package)
         {
             Services = services;
             TestRunnerFactory = Services.GetService<ITestRunnerFactory>();
@@ -24,14 +24,14 @@ namespace NUnit.Engine.Runners
         /// <summary>
         /// Our Service Context
         /// </summary>
-        protected IServiceLocator Services { get; private set; }
+        protected IServiceLocator Services { get; }
 
-        protected ITestRunnerFactory TestRunnerFactory { get; private set; }
+        protected ITestRunnerFactory TestRunnerFactory { get; }
 
         /// <summary>
         /// The TestPackage for which this is the runner
         /// </summary>
-        protected TestPackage TestPackage { get; set; }
+        protected ITestPackage TestPackage { get; }
 
         /// <summary>
         /// The result of the last call to LoadPackage

--- a/src/NUnitEngine/nunit.engine.core/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/AggregatingTestRunner.cs
@@ -65,7 +65,7 @@ namespace NUnit.Engine.Runners
             }
         }
 
-        public AggregatingTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        public AggregatingTestRunner(IServiceLocator services, ITestPackage package) : base(services, package)
         {
         }
 
@@ -222,7 +222,7 @@ namespace NUnit.Engine.Runners
                 throw new NUnitEngineUnloadException(_unloadExceptions);
         }
 
-        protected virtual ITestEngineRunner CreateRunner(TestPackage package)
+        protected virtual ITestEngineRunner CreateRunner(ITestPackage package)
         {
             return TestRunnerFactory.MakeTestRunner(package);
         }

--- a/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
@@ -43,7 +43,7 @@ namespace NUnit.Engine.Runners
 
         protected AppDomain TestDomain { get; set; }
 
-        public DirectTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        public DirectTestRunner(IServiceLocator services, ITestPackage package) : base(services, package)
         {
             // Bypass the resolver if not in the default AppDomain. This prevents trying to use the resolver within
             // NUnit's own automated tests (in a test AppDomain) which does not make sense anyway.
@@ -101,6 +101,9 @@ namespace NUnit.Engine.Runners
             // found in the terminal nodes.
             var packagesToLoad = TestPackage.Select(p => !p.HasSubPackages());
 
+            var testPackage = new TestPackage();
+            testPackage.Select(p => !p.HasSubPackages());
+
             var driverService = Services.GetService<IDriverService>();
 
             _drivers.Clear();
@@ -129,7 +132,7 @@ namespace NUnit.Engine.Runners
             return result;
         }
 
-        private static string LoadDriver(IFrameworkDriver driver, string testFile, TestPackage subPackage)
+        private static string LoadDriver(IFrameworkDriver driver, string testFile, ITestPackage subPackage)
         {
             try
             {

--- a/src/NUnitEngine/nunit.engine.core/Runners/LocalTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/LocalTestRunner.cs
@@ -9,7 +9,7 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public class LocalTestRunner : DirectTestRunner
     {
-        public LocalTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        public LocalTestRunner(IServiceLocator services, ITestPackage package) : base(services, package)
         {
             TestDomain = AppDomain.CurrentDomain;
         }

--- a/src/NUnitEngine/nunit.engine.core/Runners/MultipleTestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/MultipleTestDomainRunner.cs
@@ -14,9 +14,9 @@ namespace NUnit.Engine.Runners
         /// </summary>
         /// <param name="services">The services.</param>
         /// <param name="package">The package.</param>
-        public MultipleTestDomainRunner(IServiceLocator services, TestPackage package) : base(services, package) { }
+        public MultipleTestDomainRunner(IServiceLocator services, ITestPackage package) : base(services, package) { }
 
-        protected override ITestEngineRunner CreateRunner(TestPackage package)
+        protected override ITestEngineRunner CreateRunner(ITestPackage package)
         {
             return new TestDomainRunner(Services, package);
         }

--- a/src/NUnitEngine/nunit.engine.core/Runners/TestDomainRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/TestDomainRunner.cs
@@ -13,7 +13,7 @@ namespace NUnit.Engine.Runners
     {
         private DomainManager _domainManager;
 
-        public TestDomainRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        public TestDomainRunner(IServiceLocator services, ITestPackage package) : base(services, package)
         {
             _domainManager = Services.GetService<DomainManager>();
         }

--- a/src/NUnitEngine/nunit.engine.core/Services/DomainManager.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/DomainManager.cs
@@ -30,7 +30,7 @@ namespace NUnit.Engine.Services
         /// Construct an application domain for running a test package
         /// </summary>
         /// <param name="package">The TestPackage to be run</param>
-        public AppDomain CreateDomain( TestPackage package )
+        public AppDomain CreateDomain(ITestPackage package)
         {
             AppDomainSetup setup = CreateAppDomainSetup(package);
 
@@ -71,7 +71,7 @@ namespace NUnit.Engine.Services
         }
 
         // Made separate and internal for testing
-        AppDomainSetup CreateAppDomainSetup(TestPackage package)
+        AppDomainSetup CreateAppDomainSetup(ITestPackage package)
         {
             AppDomainSetup setup = new AppDomainSetup();
 
@@ -180,7 +180,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="package">The package</param>
         /// <returns>The ApplicationBase</returns>
-        public static string GetApplicationBase(TestPackage package)
+        public static string GetApplicationBase(ITestPackage package)
         {
             Guard.ArgumentNotNull(package, "package");
 
@@ -203,7 +203,7 @@ namespace NUnit.Engine.Services
             return appBase;
         }
 
-        public static string GetConfigFile(string appBase, TestPackage package)
+        public static string GetConfigFile(string appBase, ITestPackage package)
         {
             Guard.ArgumentNotNullOrEmpty(appBase, "appBase");
             Guard.ArgumentNotNull(package, "package");
@@ -241,7 +241,7 @@ namespace NUnit.Engine.Services
             return ext == ".dll" || ext == ".exe";
         }
 
-        public static string GetCommonAppBase(IList<TestPackage> packages)
+        private static string GetCommonAppBase(IList<ITestPackage> packages)
         {
             var assemblies = new List<string>();
             foreach (var package in packages)
@@ -271,7 +271,7 @@ namespace NUnit.Engine.Services
             return GetPrivateBinPath(basePath, new string[] { fileName });
         }
 
-        public static string GetPrivateBinPath(string appBase, TestPackage package)
+        public static string GetPrivateBinPath(string appBase, ITestPackage package)
         {
             var binPath = package.GetSetting(EnginePackageSettings.PrivateBinPath, string.Empty);
 
@@ -285,7 +285,7 @@ namespace NUnit.Engine.Services
             return binPath;
         }
 
-        public static string GetPrivateBinPath(string basePath, IList<TestPackage> packages)
+        private static string GetPrivateBinPath(string basePath, IList<ITestPackage> packages)
         {
             var assemblies = new List<string>();
             foreach (var package in packages)

--- a/src/NUnitEngine/nunit.engine.core/Services/InProcessTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/InProcessTestRunnerFactory.cs
@@ -20,7 +20,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="package">The TestPackage to be loaded and run</param>
         /// <returns>An ITestEngineRunner</returns>
-        public virtual ITestEngineRunner MakeTestRunner(TestPackage package)
+        public virtual ITestEngineRunner MakeTestRunner(ITestPackage package)
         {
 #if !NETFRAMEWORK
             return new LocalTestRunner(ServiceContext, package);
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Services
 #endif
         }
 
-        public virtual bool CanReuse(ITestEngineRunner runner, TestPackage package)
+        public virtual bool CanReuse(ITestEngineRunner runner, ITestPackage package)
         {
             return false;
         }

--- a/src/NUnitEngine/nunit.engine.core/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.core/TestPackage.cs
@@ -23,7 +23,7 @@ namespace NUnit.Engine
     /// tests in the reloaded assembly to match those originally loaded.
     /// </summary>
     [Serializable]
-    public class TestPackage
+    public class TestPackage : ITestPackage
     {
         /// <summary>
         /// Construct a top-level TestPackage that wraps one or more
@@ -90,7 +90,7 @@ namespace NUnit.Engine
         /// <summary>
         /// Gets the list of SubPackages contained in this package
         /// </summary>
-        public IList<TestPackage> SubPackages { get; } = new List<TestPackage>();
+        public IList<ITestPackage> SubPackages { get; } = new List<ITestPackage>();
 
         /// <summary>
         /// Gets the settings dictionary for this package.
@@ -101,7 +101,7 @@ namespace NUnit.Engine
         /// Add a subpackage to the package.
         /// </summary>
         /// <param name="subPackage">The subpackage to be added</param>
-        public void AddSubPackage(TestPackage subPackage)
+        public void AddSubPackage(ITestPackage subPackage)
         {
             SubPackages.Add(subPackage);
 
@@ -114,9 +114,9 @@ namespace NUnit.Engine
         /// the only way to add a named subpackage to the top-level package.
         /// </summary>
         /// <param name="packageName">The name of the subpackage to be added</param>
-        public TestPackage AddSubPackage(string packageName)
+        public ITestPackage AddSubPackage(string packageName)
         {
-            var subPackage = new TestPackage() { FullName = Path.GetFullPath(packageName) };
+            var subPackage = new TestPackage { FullName = Path.GetFullPath(packageName) };
             SubPackages.Add(subPackage);
 
             return subPackage;

--- a/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Api.Tests
             Assert.That(_package.SubPackages.Count, Is.EqualTo(_fileNames.Length));
             for (int i = 0; i < _fileNames.Length; i++)
             {
-                TestPackage subPackage = _package.SubPackages[i];
+                var subPackage = _package.SubPackages[i];
                 string fileName = _fileNames[i];
 
                 Assert.That(subPackage.Name, Is.EqualTo(fileName));

--- a/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/TestEngineRunnerTests.cs
@@ -25,7 +25,7 @@ namespace NUnit.Engine.Runners.Tests
     //[TestFixture(typeof(MultipleTestProcessRunner), 1)]
     //[TestFixture(typeof(MultipleTestProcessRunner), 3)]
     //[Platform(Exclude = "Mono", Reason = "Currently causing long delays or hangs under Mono")]
-    public class TestEngineRunnerTests<TRunner> where TRunner : AbstractTestRunner
+    internal class TestEngineRunnerTests<TRunner> where TRunner : AbstractTestRunner
     {
         protected TestPackage _package;
         protected ServiceContext _services;

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.DummyTestAgent.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.DummyTestAgent.cs
@@ -16,7 +16,7 @@ namespace NUnit.Engine.Services.Tests
 
             public Guid Id { get; }
 
-            public ITestEngineRunner CreateRunner(TestPackage package)
+            public ITestEngineRunner CreateRunner(ITestPackage package)
             {
                 throw new NotImplementedException();
             }

--- a/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/DomainManagerTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.Engine.Services.Tests
         private DomainManager _domainManager;
         // We use a named subpackage because that's what is normally
         // used by the Domain Manager
-        private TestPackage _package = new TestPackage(MockAssembly.AssemblyPath).SubPackages[0];
+        private readonly ITestPackage _package = new TestPackage(MockAssembly.AssemblyPath).SubPackages[0];
 
         [SetUp]
         public void CreateDomainManager()

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeProjectService.cs
@@ -22,7 +22,7 @@ namespace NUnit.Engine.Services.Tests.Fakes
             _projects.Add(projectName, assemblies);
         }
 
-        void IProjectService.ExpandProjectPackage(TestPackage package)
+        void IProjectService.ExpandProjectPackage(ITestPackage package)
         {
             if (_projects.ContainsKey(package.Name))
             {

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
@@ -9,7 +9,7 @@ namespace NUnit.Engine.Services.Tests.Fakes
             return true;
         }
 
-        string IRuntimeFrameworkService.SelectRuntimeFramework(TestPackage package)
+        string IRuntimeFrameworkService.SelectRuntimeFramework(ITestPackage package)
         {
             return string.Empty;
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestRunnerFactoryTests/RunnerSelectionTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Engine.Tests.Services.TestRunnerFactoryTests
         }
 
         [TestCaseSource(nameof(TestCases))]
-        public void RunnerSelectionTest(TestPackage package, RunnerResult expected)
+        public void RunnerSelectionTest(ITestPackage package, RunnerResult expected)
         {
             var masterRunner = new MasterTestRunner(_services, package);
             var runner = masterRunner.GetEngineRunner();

--- a/src/NUnitEngine/nunit.engine.tests/WorkingDirectoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/WorkingDirectoryTests.cs
@@ -23,10 +23,14 @@ namespace NUnit.Engine.Tests
             Directory.SetCurrentDirectory(_origWorkingDir);
         }
 
-        [Test]
+        [Test, Platform("Net")] //https://github.com/nunit/nunit-console/issues/946
         public void EngineCanBeCreatedFromAnyWorkingDirectory()
         {
-            Assert.That(() => TestEngineActivator.CreateInstance(), Throws.Nothing);
+            Assert.That(() =>
+            {
+                var engine = TestEngineActivator.CreateInstance();
+                engine.Dispose();
+            }, Throws.Nothing);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Remoting/TestAgentRemotingProxy.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Remoting/TestAgentRemotingProxy.cs
@@ -23,7 +23,7 @@ namespace NUnit.Engine.Communication.Transports.Remoting
 
         public Guid Id { get; private set; }
 
-        public ITestEngineRunner CreateRunner(TestPackage package)
+        public ITestEngineRunner CreateRunner(ITestPackage package)
         {
             return _remoteAgent.CreateRunner(package);
         }

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgentTcpProxy.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgentTcpProxy.cs
@@ -24,7 +24,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
 
         public Guid Id { get; }
 
-        public ITestEngineRunner CreateRunner(TestPackage package)
+        public ITestEngineRunner CreateRunner(ITestPackage package)
         {
             SendCommandMessage("CreateRunner", package);
 

--- a/src/NUnitEngine/nunit.engine/IProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/IProjectService.cs
@@ -20,12 +20,12 @@ namespace NUnit.Engine.Services
         bool CanLoadFrom(string path);
 
         /// <summary>
-        /// Expands a TestPackage based on a known project format, populating it
+        /// Expands an ITestPackage based on a known project format, populating it
         /// with the project contents and any settings the project provides. 
         /// Note that the package file path must be checked to ensure that it is
         /// a known project format before calling this method.
         /// </summary>
-        /// <param name="package">The TestPackage to be expanded</param>
-        void ExpandProjectPackage(TestPackage package);
+        /// <param name="package">The ITestPackage to be expanded</param>
+        void ExpandProjectPackage(ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Runners
 
         private const int WAIT_FOR_CANCEL_TO_COMPLETE = 5000;
 
-        public MasterTestRunner(IServiceLocator services, TestPackage package)
+        public MasterTestRunner(IServiceLocator services, ITestPackage package)
         {
             if (services == null) throw new ArgumentNullException("services");
             if (package == null) throw new ArgumentNullException("package");
@@ -72,7 +72,7 @@ namespace NUnit.Engine.Runners
         /// <summary>
         /// The TestPackage for which this is the runner
         /// </summary>
-        protected TestPackage TestPackage { get; set; }
+        protected ITestPackage TestPackage { get; set; }
 
         /// <summary>
         /// The result of the last call to LoadPackage
@@ -326,7 +326,7 @@ namespace NUnit.Engine.Runners
             return topLevelResult;
         }
 
-        private void EnsurePackagesAreExpanded(TestPackage package)
+        private void EnsurePackagesAreExpanded(ITestPackage package)
         {
             if (package == null) throw new ArgumentNullException("package");
 
@@ -341,7 +341,7 @@ namespace NUnit.Engine.Runners
             }
         }
 
-        private bool IsProjectPackage(TestPackage package)
+        private bool IsProjectPackage(ITestPackage package)
         {
             if (package == null) throw new ArgumentNullException("package");
 

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -16,7 +16,7 @@ namespace NUnit.Engine.Runners
         /// </summary>
         /// <param name="services">The services.</param>
         /// <param name="package">The package.</param>
-        public MultipleTestProcessRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        public MultipleTestProcessRunner(IServiceLocator services, ITestPackage package) : base(services, package)
         {
         }
 
@@ -29,7 +29,7 @@ namespace NUnit.Engine.Runners
             }
         }
 
-        protected override ITestEngineRunner CreateRunner(TestPackage package)
+        protected override ITestEngineRunner CreateRunner(ITestPackage package)
         {
             return new ProcessRunner(Services, package);
         }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -28,7 +28,7 @@ namespace NUnit.Engine.Runners
         private ITestEngineRunner _remoteRunner;
         private TestAgency _agency;
 
-        public ProcessRunner(IServiceLocator services, TestPackage package) : base(services, package)
+        public ProcessRunner(IServiceLocator services, ITestPackage package) : base(services, package)
         {
             _agency = Services.GetService<TestAgency>();
         }

--- a/src/NUnitEngine/nunit.engine/Services/AgentLease.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentLease.cs
@@ -12,6 +12,6 @@ namespace NUnit.Engine.Services
         /// <summary>
         /// Creates a test runner on the acquired agent.
         /// </summary>
-        ITestEngineRunner CreateRunner(TestPackage package);
+        ITestEngineRunner CreateRunner(ITestPackage package);
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -14,7 +14,7 @@ namespace NUnit.Engine.Services
     {
         private static readonly Logger log = InternalTrace.GetLogger(typeof(AgentProcess));
 
-        public AgentProcess(TestAgency agency, TestPackage package, Guid agentId)
+        public AgentProcess(TestAgency agency, ITestPackage package, Guid agentId)
         {
             // Get target runtime
             string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");

--- a/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/DefaultTestRunnerFactory.cs
@@ -33,7 +33,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="package">The TestPackage to be loaded and run</param>
         /// <returns>A TestRunner</returns>
-        public override ITestEngineRunner MakeTestRunner(TestPackage package)
+        public override ITestEngineRunner MakeTestRunner(ITestPackage package)
         {
 #if !NETFRAMEWORK
             if (package.SubPackages.Count > 1)
@@ -50,7 +50,7 @@ namespace NUnit.Engine.Services
                 default:
                 case ProcessModel.Default:
                     bool isNested = false;
-                    foreach (TestPackage subPackage in package.SubPackages)
+                    foreach (var subPackage in package.SubPackages)
                     {
                         if (subPackage.SubPackages.Count > 0)
                         {
@@ -78,7 +78,7 @@ namespace NUnit.Engine.Services
 
         // TODO: Review this method once used by a gui - the implementation is
         // overly simplistic. It is not currently used by any known runner.
-        public override bool CanReuse(ITestEngineRunner runner, TestPackage package)
+        public override bool CanReuse(ITestEngineRunner runner, ITestPackage package)
         {
             ProcessModel processModel = GetTargetProcessModel(package);
 
@@ -101,7 +101,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="package">A TestPackage</param>
         /// <returns>The string representation of the process model or "Default" if none was specified.</returns>
-        private ProcessModel GetTargetProcessModel(TestPackage package)
+        private ProcessModel GetTargetProcessModel(ITestPackage package)
         {
             return (ProcessModel)System.Enum.Parse(
                 typeof(ProcessModel),

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -34,7 +34,7 @@ namespace NUnit.Engine.Services
         /// a known project format before calling this method.
         /// </summary>
         /// <param name="package">The TestPackage to be expanded</param>
-        public void ExpandProjectPackage(TestPackage package)
+        public void ExpandProjectPackage(ITestPackage package)
         {
             Guard.ArgumentNotNull(package, "package");
             Guard.ArgumentValid(package.SubPackages.Count == 0, "Package is already expanded", "package");
@@ -52,7 +52,7 @@ namespace NUnit.Engine.Services
             else
                 Guard.ArgumentValid(project.ConfigNames.Contains(activeConfig), $"Requested configuration {activeConfig} was not found", "package");
 
-            TestPackage tempPackage = project.GetTestPackage(activeConfig);
+            var tempPackage = project.GetTestPackage(activeConfig);
 
             // Add info about the configurations to the project package
             tempPackage.Settings[EnginePackageSettings.ActiveConfig] = activeConfig;

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -92,7 +92,7 @@ namespace NUnit.Engine.Services
         /// </summary>
         /// <param name="package">A TestPackage</param>
         /// <returns>A string representing the selected RuntimeFramework</returns>
-        public string SelectRuntimeFramework(TestPackage package)
+        public string SelectRuntimeFramework(ITestPackage package)
         {
             // Evaluate package target framework
             ApplyImageData(package);
@@ -101,7 +101,7 @@ namespace NUnit.Engine.Services
             return targetFramework.ToString();
         }
 
-        private RuntimeFramework SelectRuntimeFrameworkInner(TestPackage package)
+        private RuntimeFramework SelectRuntimeFrameworkInner(ITestPackage package)
         {
             foreach (var subPackage in package.SubPackages)
             {
@@ -200,8 +200,7 @@ namespace NUnit.Engine.Services
         /// Use Mono.Cecil to get information about all assemblies and
         /// apply it to the package using special internal keywords.
         /// </summary>
-        /// <param name="package"></param>
-        private static void ApplyImageData(TestPackage package)
+        private static void ApplyImageData(ITestPackage package)
         {
             string packageName = package.FullName;
 

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine.Services
             _agentStore.Register(agent);
         }
 
-        public ITestAgent GetAgent(TestPackage package)
+        public ITestAgent GetAgent(ITestPackage package)
         {
             // Target Runtime must be specified by this point
             string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using NUnit.Engine.Internal;
 using NUnit.Engine.Services;
 
@@ -74,12 +72,32 @@ namespace NUnit.Engine
         }
 
         /// <summary>
+        /// Creates a new test package
+        /// </summary>
+        /// <param name="testFiles">A list of either test assemblies or project files, which will
+        /// be added to the ITestPackage as sub-packages</param>
+        public ITestPackage CreatePackage(IList<string> testFiles)
+        {
+            return new TestPackage(testFiles);
+        }
+
+        /// <summary>
+        /// Creates a new test package
+        /// </summary>
+        /// <param name="testFiles">A list of either test assemblies or project files, which will
+        /// be added to the ITestPackage as sub-packages</param>
+        public ITestPackage CreatePackage(params string[] testFiles)
+        {
+            return new TestPackage(testFiles);
+        }
+
+        /// <summary>
         /// Returns a test runner for use by clients that need to load the
         /// tests once and run them multiple times. If necessary, the
         /// services are initialized first.
         /// </summary>
         /// <returns>An ITestRunner.</returns>
-        public ITestRunner GetRunner(TestPackage package)
+        public ITestRunner GetRunner(ITestPackage package)
         {
             if(!Services.ServiceManager.ServicesInitialized)
                 Initialize();

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
     <Compile Include="..\nunit-agent\AgentExitCodes.cs" LinkBase="Agents" />
-    <Compile Include="..\nunit.engine.core\Internal\ExceptionHelper.cs" Link="Internal\ExceptionHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="TestCentric.Metadata" Version="1.4.1" />


### PR DESCRIPTION
Fixes #919. Addressing this first, as it's blocking #885.

This creates an ITestPackage interface, and moves the TestPackage class to nunit.engine.core.dll. In the longer term vision (#885) - I'd expect ITestPackage to be moving to the "extensions-core" API assembly, which is the primary motivation to bring in a minimal interface rather than keeping the class itself in that assembly.

This leaves us in the slightly ugly interim state where the only way for a runner to create a TestPackage is by first creating a TestEngine through TestEngineActivator. My thinking is that when (if) we address #948 that will be addressed, and we can re-expose the normal TestPackage constructors.