### PR TITLE
Dispose classes as required in Tests to prevent failed app domain unload

### DIFF
--- a/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/ConsoleRunnerTests.cs
@@ -17,16 +17,17 @@ namespace NUnit.ConsoleRunner.Tests
         [Test]
         public void ThrowsNUnitEngineExceptionWhenTestResultsAreNotWriteable()
         {
-            var testEngine = new TestEngine();
+            using (var testEngine = new TestEngine())
+            {
+                testEngine.Services.Add(new FakeResultService());
+                testEngine.Services.Add(new TestFilterService());
+                testEngine.Services.Add(Substitute.For<IService, IExtensionService>());
 
-            testEngine.Services.Add(new FakeResultService());
-            testEngine.Services.Add(new TestFilterService());
-            testEngine.Services.Add(Substitute.For<IService, IExtensionService>());
+                var consoleRunner = new ConsoleRunner(testEngine, ConsoleMocks.Options("mock-assembly.dll"), new ColorConsoleWriter());
 
-            var consoleRunner = new ConsoleRunner(testEngine, ConsoleMocks.Options("mock-assembly.dll"), new ColorConsoleWriter());
-            
-            var ex = Assert.Throws<NUnitEngineException>(() => { consoleRunner.Execute(); });
-            Assert.That(ex.Message, Is.EqualTo("The path specified in --result TestResult.xml could not be written to"));
+                var ex = Assert.Throws<NUnitEngineException>(() => { consoleRunner.Execute(); });
+                Assert.That(ex, Has.Message.EqualTo("The path specified in --result TestResult.xml could not be written to"));
+            }
         }
     }
 

--- a/src/NUnitEngine/nunit.engine.tests/Api/ServiceLocatorTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/ServiceLocatorTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Api.Tests
+namespace NUnit.Engine.Tests.Api
 {
     public class ServiceLocatorTests
     {
@@ -16,6 +14,12 @@ namespace NUnit.Engine.Api.Tests
         {
             _testEngine = new TestEngine();
             _testEngine.InternalTraceLevel = InternalTraceLevel.Off;
+        }
+
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            _testEngine.Dispose();
         }
 
         [TestCase(typeof(ISettings))]

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
@@ -3,10 +3,11 @@
 using System.IO;
 using System.Xml;
 using NUnit.Engine.Runners;
+using NUnit.Engine.Services;
 using NUnit.Engine.Services.Tests.Fakes;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.ResultWriters.Tests
+namespace NUnit.Engine.Tests.Services.ResultWriters
 {
     public class XmlTransformResultWriterTests
     {
@@ -26,10 +27,11 @@ namespace NUnit.Engine.Services.ResultWriters.Tests
 #if NETFRAMEWORK
             serviceContext.Add(new DomainManager());
 #endif
-
-            var runner = new MasterTestRunner(serviceContext, new TestPackage(assemblyPath));
-            runner.Load();
-            _engineResult = runner.Run(null, TestFilter.Empty);
+            using (var runner = new MasterTestRunner(serviceContext, new TestPackage(assemblyPath)))
+            {
+                runner.Load();
+                _engineResult = runner.Run(null, TestFilter.Empty);
+            }
         }
 
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestAgencyTests.cs
@@ -1,25 +1,32 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 #if NETFRAMEWORK
+using NUnit.Engine.Services;
+using NUnit.Engine.Services.Tests.Fakes;
 using NUnit.Framework;
 
-namespace NUnit.Engine.Services.Tests
+namespace NUnit.Engine.Tests.Services
 {
-    using Fakes;
-
     public class TestAgencyTests
     {
         private TestAgency _testAgency;
+        private ServiceContext _services;
 
         [SetUp]
         public void CreateServiceContext()
         {
-            var services = new ServiceContext();
-            services.Add(new FakeRuntimeService());
+            _services = new ServiceContext();
+            _services.Add(new FakeRuntimeService());
             // Use a different URI to avoid conflicting with the "real" TestAgency
             _testAgency = new TestAgency("TestAgencyTest", 0);
-            services.Add(_testAgency);
-            services.ServiceManager.StartServices();
+            _services.Add(_testAgency);
+            _services.ServiceManager.StartServices();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _services.ServiceManager.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
Fixes #949 

I believe the new TCP functionality in #937 now cause the test app domain to fail to unload if certain classes aren't Disposed. I don't think that's a problem - all the classes in question already implemented IDisposable, so to my mind should have be disposed of properly in tests anyway.

