### PR TITLE
fix for test assembly loading failure in NUnit.ConsoleRunner.NetCore

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -59,6 +59,12 @@ namespace NUnit.Engine.Drivers
             assemblyPath = Path.GetFullPath(assemblyPath);  //AssemblyLoadContext requires an absolute path
             _assemblyLoadContext = new CustomAssemblyLoadContext(assemblyPath);
 
+            _assemblyLoadContext.Resolving += (context, assemblyName) =>
+            {
+                var calc = context as CustomAssemblyLoadContext; 
+                return calc?.LoadFallback(assemblyName);
+            };
+
             try
             {
                 _testAssembly = _assemblyLoadContext.LoadFromAssemblyPath(assemblyPath);

--- a/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/CustomAssemblyLoadContext.cs
@@ -4,22 +4,47 @@
 
 using System.Reflection;
 using System.Runtime.Loader;
+using System.IO;
 
 namespace NUnit.Engine.Internal
 {
     internal class CustomAssemblyLoadContext : AssemblyLoadContext
     {
         private readonly AssemblyDependencyResolver _resolver;
+        private readonly string _basePath;
 
         public CustomAssemblyLoadContext(string mainAssemblyToLoadPath)
         {
             _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath);
+            _basePath = Path.GetDirectoryName(mainAssemblyToLoadPath);
         }
 
         protected override Assembly Load(AssemblyName name)
         {
             var assemblyPath = _resolver.ResolveAssemblyToPath(name);
             return assemblyPath != null ? LoadFromAssemblyPath(assemblyPath) : null;
+        }
+
+        /// <summary>
+        /// Loads assemblies that are dependencies, and in the same folder as the parent assembly,
+        /// but are not fully specified in parent assembly deps.json file. This happens when the
+        /// dependencies reference in the csproj file has CopyLocal=false, and for example, the
+        /// reference is a projectReference and has the same output directory as the parent.
+        ///
+        /// LoadFallback should be called via the CustomAssemblyLoadContext.Resolving callback when
+        /// a dependent assembly of that referred to in a previous 'CustomAssemblyLoadContext.Load' call
+        /// could not be loaded by CustomAssemblyLoadContext.Load nor by the default ALC; to which the
+        /// runtime will fallback when CustomAssemblyLoadContext.Load fails (to let the default ALC
+        /// load system assemblies).
+        /// </summary>
+        /// <param name="assemblyName"></param>
+        /// <returns></returns>
+        public Assembly LoadFallback(AssemblyName name)
+        {
+            string assemblyPath = Path.Combine(_basePath, name.Name + ".dll");
+            if (File.Exists(assemblyPath))
+                return LoadFromAssemblyPath(assemblyPath);
+            return null;
         }
     }
 }


### PR DESCRIPTION
Assembly dependencies without entries in the deps.json file, but present in the same directory as the assembly, are not loadable by the NUnitNetCore31Driver, as the CustomAssemblyLoadContext.Resolving callback is not handled.  So, some netcore test assemblies cannot be loaded by nunit. This issue is in "NUnit.ConsoleRunner.NetCore --version 3.12-beta2", but probably older versions as well. The dependencies dep.json entries will be missing if a dependency reference did not have CopyLocal set to 'yes' in the csproj. 

[see this stackoverflow question, which includes a failing example](https://stackoverflow.com/questions/67518375/assembly-loading-issue-with-netcore3-1-and-nunit), this includes a description of how to reproduce the issue, and a link to a git repo with a visual studio solution affected by this issue.

Apologies if I have not followed github or nunit protocol in this PR. This is my first ever PR to a github project. I can be emailed on ian144@hotmail.com if fixups are required.
