### PR TITLE
Consider later NUnit versions as a valid framework.

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
@@ -9,7 +9,7 @@ namespace NUnit.Engine.Drivers
 {
     public class NUnit3DriverFactory : IDriverFactory
     {
-        private const string NUNIT_FRAMEWORK = "nunit.framework";
+        public const string NUNIT_FRAMEWORK = "nunit.framework";
 
         /// <summary>
         /// Gets a flag indicating whether a given assembly name and version

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
@@ -18,7 +18,7 @@ namespace NUnit.Engine.Drivers
         /// <param name="reference">An AssemblyName referring to the possible test framework.</param>
         public bool IsSupportedTestFramework(AssemblyName reference)
         {
-            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && reference.Version.Major == 3;
+            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && reference.Version.Major >= 3;
         }
 
 #if NETFRAMEWORK

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3DriverFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3DriverFactoryTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Engine.Drivers;
+using NUnit.Framework;
+using System;
+using System.Reflection;
+
+namespace NUnit.Engine.Tests.Drivers
+{
+    public class NUnit3DriverFactoryTests
+    {
+        private NUnit3DriverFactory _factory;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _factory = new NUnit3DriverFactory();
+        }
+
+        [TestCase(2, ExpectedResult = false)]
+        [TestCase(3, ExpectedResult = true)]
+        [TestCase(4, ExpectedResult = true)]
+        public bool SupportsNetFramework(int majorVersion)
+        {
+            AssemblyName name = new AssemblyName(NUnit3DriverFactory.NUNIT_FRAMEWORK)
+            {
+                Version = new Version(majorVersion, 0)
+            };
+
+            return _factory.IsSupportedTestFramework(name);
+        }
+
+        [Test]
+        public void DoesNotSupportOtherFrameworks()
+        {
+            AssemblyName name = new AssemblyName("VSTest.dll")
+            {
+                Version = new Version(3, 0)
+            };
+
+            Assert.That(_factory.IsSupportedTestFramework(name), Is.False);
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3DriverFactoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Drivers/NUnit3DriverFactoryTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Engine.Drivers;
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Engine.Drivers;
 using NUnit.Framework;
 using System;
 using System.Reflection;


### PR DESCRIPTION
This goes towards fixing https://github.com/nunit/nunit/issues/3867 