### PR TITLE
Set version to 3.99 when building in IDE

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -58,27 +58,28 @@ Task("Clean")
     .Description("Cleans directories.")
     .Does(() =>
     {
-        CleanDirectory(PROJECT_DIR + "bin/");
-        CleanDirectory(PROJECT_DIR + "packages/");
+        CleanDirectory(BIN_DIR);
+        CleanDirectory(PACKAGE_DIR);
         CleanDirectory(IMAGE_DIR);
         CleanDirectory(EXTENSIONS_DIR);
         CleanDirectory(PACKAGE_DIR);
     });
 
-Task("DeleteObjectDirectories")
-    .WithCriteria(BuildSystem.IsLocalBuild)
+Task("CleanAll")
+    .Description("Cleans both Debug and Release Directories followed by deleting object directories")
     .Does(() =>
     {
-        Information("Deleting object directories");
+        Information("Cleaning both Debug and Release");
+        CleanDirectory(PROJECT_DIR + "bin");
+        CleanDirectory(PACKAGE_DIR);
+        CleanDirectory(IMAGE_DIR);
+        CleanDirectory(EXTENSIONS_DIR);
+        CleanDirectory(PACKAGE_DIR);
 
+        Information("Deleting object directories");
         foreach (var dir in GetDirectories("src/**/obj/"))
             DeleteDirectory(dir, new DeleteDirectorySettings() { Recursive = true });
     });
-
-Task("CleanAll")
-    .Description("Perform standard 'Clean' followed by deleting object directories")
-    .IsDependentOn("Clean")
-    .IsDependentOn("DeleteObjectDirectories");
 
 //////////////////////////////////////////////////////////////////////
 // BUILD ENGINE AND CONSOLE

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,11 +5,14 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7</LangVersion>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <Company>NUnit Software</Company>
     <Copyright>Copyright (c) 2022 Charlie Poole, Rob Prouse</Copyright>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Version)'==''">
+    <AssemblyVersion>3.99.0.0</AssemblyVersion>
+    <FileVersion>3.99.0.0</FileVersion>
+    <InformationalVersion>3.99.0.0-VSIDE</InformationalVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
+++ b/src/NUnitEngine/nunit.engine.api/nunit.engine.api.csproj
@@ -15,7 +15,7 @@
     <AssemblyTitle>NUnit Engine API ($(TargetFramework))</AssemblyTitle>
     <Description>Defines the interfaces used to access the NUnit Engine</Description>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>$(ApiFileVersion)</FileVersion>
+    <FileVersion>3.99.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net20'">


### PR DESCRIPTION
Fix to earlier PR #1109 which left version at 1.0.0.0 when building in the IDE. This code sets it to 3.99.0.0 instead and uses suffix -VSIDE for informational version.