### PR TITLE
Save results of each package test separately

### DIFF
--- a/cake/package-tester.cake
+++ b/cake/package-tester.cake
@@ -81,7 +81,8 @@ public class PackageTester
 
         foreach (var packageTest in _packageTests)
         {
-            var resultFile = _resultDirectory + "TestResult.xml";
+            var testResultDir = _resultDirectory + packageTest.Name + "/";
+            var resultFile = testResultDir + "TestResult.xml";
 
             DisplayBanner(packageTest.Description);
 
@@ -93,7 +94,7 @@ public class PackageTester
                 _installDirectory + _testExecutable,
                 new ProcessSettings()
                 {
-                    Arguments = $"{packageTest.Arguments} --work={_resultDirectory}",
+                    Arguments = $"{packageTest.Arguments} --work={testResultDir}",
                     WorkingDirectory = outputDir
                 });
 

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -13,77 +13,92 @@ static ExpectedResult MockAssemblyExpectedResult(int nCopies = 1) => new Expecte
 };
 
 static PackageTest Net35Test = new PackageTest(
+    "Net35Test",
     "Run mock-assembly.dll under .NET 3.5",
     "net35/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net35X86Test = new PackageTest(
+    "Net35X86Test",
     "Run mock-assembly-x86.dll under .NET 3.5",
     "net35/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net40Test = new PackageTest(
+    "Net40Test",
     "Run mock-assembly.dll under .NET 4.x",
     "net40/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net40X86Test = new PackageTest(
+    "Net40X86Test",
     "Run mock-assembly-x86.dll under .NET 4.x",
     "net40/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net35PlusNet40Test = new PackageTest(
+    "Net35PlusNet40Test",
     "Run both copies of mock-assembly together",
     "net35/mock-assembly.dll net40/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
 
 static PackageTest Net60Test = new PackageTest(
+    "Net60Test",
     "Run mock-assembly.dll under .NET 6.0",
     "net6.0/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net50Test = new PackageTest(
+    "Net50Test",
     "Run mock-assembly.dll under .NET 5.0",
     "net5.0/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest NetCore31Test = new PackageTest(
+    "NetCore31Test",
     "Run mock-assembly.dll under .NET Core 3.1",
     "netcoreapp3.1/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest NetCore31X86Test = new PackageTest(
+    "NetCore31X86Test",
     "Run mock-assembly-x86.dll under .NET Core 3.1",
     "netcoreapp3.1/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest NetCore21Test = new PackageTest(
-        "Run mock-assembly.dll targeting .NET Core 2.1",
-        "netcoreapp2.1/mock-assembly.dll",
+    "NetCore21Test",
+    "Run mock-assembly.dll targeting .NET Core 2.1",
+    "netcoreapp2.1/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest NetCore21X86Test = new PackageTest(
+    "NetCore21X86Test",
     "Run mock-assembly-x86.dll under .NET Core 2.1",
     "netcoreapp2.1/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest NetCore21PlusNetCore31Test = new PackageTest(
+    "NetCore21PlusNetCore31Test",
     "Run two copies of mock-assembly together",
     "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
 
 static PackageTest NetCore21PlusNetCore31PlusNet50PlusNet60Test = new PackageTest(
+    "NetCore21PlusNetCore31PlusNet50PlusNet60Test",
     "Run four copies of mock-assembly together",
     "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll net5.0/mock-assembly.dll net6.0/mock-assembly.dll",
     MockAssemblyExpectedResult(4));
 
 static PackageTest Net40PlusNet60Test = new PackageTest(
+    "Net40PlusNet60Test",
     "Run mock-assembly under .Net Framework 4.0 and .Net 6.0 together",
     "net40/mock-assembly.dll net6.0/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
 
 static PackageTest NUnitProjectTest;
 NUnitProjectTest = new PackageTest(
+    "NUnitProjectTest",
     "Run project with both copies of mock-assembly",
     $"../../NetFXTests.nunit --config={Configuration}",
     MockAssemblyExpectedResult(2));
@@ -91,12 +106,14 @@ NUnitProjectTest = new PackageTest(
 // Representation of a single test to be run against a pre-built package.
 public struct PackageTest
 {
+    public string Name;
     public string Description;
     public string Arguments;
     public ExpectedResult ExpectedResult;
 
-    public PackageTest(string description, string arguments, ExpectedResult expectedResult)
+    public PackageTest(string name, string description, string arguments, ExpectedResult expectedResult)
     {
+        Name = name;
         Description = description;
         Arguments = arguments;
         ExpectedResult = expectedResult;


### PR DESCRIPTION
Currently, package test results are saved in one folder per package, so only the last test run is available. For better debugging, this PR saves each individual test run in its own folder.