### PR TITLE
Make DriverService a non-service

### DIFF
--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -123,10 +123,10 @@ public void InitializePackageDefinitions(ICakeContext context)
             checks: new PackageCheck[] {
                 HasDirectory("NUnit.org").WithFiles("LICENSE.txt", "NOTICES.txt", "nunit.ico"),
                 HasDirectory("NUnit.org/nunit-console").WithFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit.bundle.addins"),
-                HasDirectory("Nunit.org/nunit-console/addins").WithFiles("nunit.core.dll", "nunit.core.interfaces.dll", "nunit.v2.driver.dll", "nunit-project-loader.dll", "vs-project-loader.dll", "nunit-v2-result-writer.dll", "teamcity-event-listener.dll")
+                //HasDirectory("Nunit.org/nunit-console/addins").WithFiles("nunit.core.dll", "nunit.core.interfaces.dll", "nunit.v2.driver.dll", "nunit-project-loader.dll", "vs-project-loader.dll", "nunit-v2-result-writer.dll", "teamcity-event-listener.dll")
             },
             executable: "NUnit.org/nunit-console/nunit3-console.exe",
-            // Extensions are not yet built for 4.0
+            // TODO: NUnitProjectLoader Extension is not yet built for 4.0
             tests: StandardRunnerTests),//.Concat(new[] { NUnitProjectTest })),
 
         NUnitConsoleZipPackage = new ZipPackage(

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -27,7 +27,7 @@ static PackageTest Net35X86Test = new PackageTest(
 static PackageTest Net40Test = new PackageTest(
     "Net40Test",
     "Run mock-assembly.dll under .NET 4.x",
-    "net40/mock-assembly.dll",
+    "net40/mock-assembly.dll --trace:Debug",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net40X86Test = new PackageTest(

--- a/msi/nunit/nunit.wxs
+++ b/msi/nunit/nunit.wxs
@@ -21,7 +21,7 @@
     <?include runner-directories.wxi ?>
 
     <!-- Components and files -->
-    <?include addin-files.wxi ?>
+    <!--<?include addin-files.wxi ?>-->
     <?include console-files.wxi ?>
     <?include engine-files.wxi ?>
     <?include utility-files.wxi ?>

--- a/msi/nunit/runner-directories.wxi
+++ b/msi/nunit/runner-directories.wxi
@@ -9,7 +9,7 @@
     </Directory>
     <DirectoryRef Id="INSTALLDIR">
       <Directory Id="CONSOLE_BIN" Name="nunit-console">
-        <Directory Id="ADDINS" Name="addins" />
+        <!--<Directory Id="ADDINS" Name="addins" />-->
           <Directory Id="AGENTS" Name="agents">
               <Directory Id="NET20_AGENT_DIR" Name="net20" />
               <Directory Id="NET40_AGENT_DIR" Name="net40" />

--- a/msi/nunit/runner-features.wxi
+++ b/msi/nunit/runner-features.wxi
@@ -13,7 +13,7 @@
                Title="NUnit Engine"
                Description="Installs the NUnit engine">
         <ComponentGroupRef Id="NUNIT.ENGINE" />
-        <Feature Id="ADDINS.NUNIT.PROJECT.LOADER"
+        <!--<Feature Id="ADDINS.NUNIT.PROJECT.LOADER"
                     Level="1"
                     Title="NUnit Project Loader"
                     Description="Allows you to load NUnit Project files">
@@ -42,7 +42,7 @@
                  Title="TeamCity Event Listener"
                  Description="Provides progress messages when running under TeamCity">
           <ComponentGroupRef Id="TEAMCITY.EVENT.LISTENER" />
-        </Feature>
+        </Feature>-->
       </Feature>
 
       <Feature Id="NUNIT.CONSOLE"

--- a/src/NUnitConsole/nunit3-console.tests/BadFileTests.cs
+++ b/src/NUnitConsole/nunit3-console.tests/BadFileTests.cs
@@ -22,7 +22,6 @@ namespace NUnit.ConsoleRunner.Tests
             var services = new ServiceContext();
             services.Add(new DefaultTestRunnerFactory());
             services.Add(new ExtensionService());
-            services.Add(new DriverService());
 #if NET35
             services.Add(new RuntimeFrameworkService());
             services.Add(new TestAgency());

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -88,7 +88,6 @@ namespace NUnit.Agent
 
             // Custom Service Initialization
             engine.Services.Add(new ExtensionService());
-            engine.Services.Add(new DriverService());
 
             // Initialize Services
             log.Info("Initializing Services");

--- a/src/NUnitEngine/nunit.engine.core.tests/Runners/DirectTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/Runners/DirectTestRunnerTests.cs
@@ -28,10 +28,8 @@ namespace NUnit.Engine.Runners.Tests
                 string.Empty, 
                 false).ReturnsForAnyArgs(_driver);
 
-            var serviceLocator = Substitute.For<IServiceLocator>();
-            serviceLocator.GetService<IDriverService>().Returns(driverService);
-
-            _directTestRunner = new EmptyDirectTestRunner(serviceLocator, new TestPackage("mock-assembly.dll"));
+            _directTestRunner = new EmptyDirectTestRunner(new ServiceContext(), new TestPackage("mock-assembly.dll"));
+            _directTestRunner.DriverService = driverService;
         }
 
         [Test]

--- a/src/NUnitEngine/nunit.engine.core.tests/Runners/TestEngineRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/Runners/TestEngineRunnerTests.cs
@@ -47,7 +47,6 @@ namespace NUnit.Engine.Runners.Tests
             // Add all services needed by any of our TestEngineRunners
             _services = new ServiceContext();
             _services.Add(new Services.ExtensionService());
-            _services.Add(new Services.DriverService());
             _services.ServiceManager.StartServices();
 
             var mockAssemblyPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "mock-assembly.dll");

--- a/src/NUnitEngine/nunit.engine.core.tests/Services/DriverServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/Services/DriverServiceTests.cs
@@ -17,19 +17,8 @@ namespace NUnit.Engine.Services.Tests
         [SetUp]
         public void CreateDriverFactory()
         {
-            var serviceContext = new ServiceContext();
-            serviceContext.Add(new ExtensionService());
             _driverService = new DriverService();
-            serviceContext.Add(_driverService);
-            serviceContext.ServiceManager.StartServices();
         }
-
-        [Test]
-        public void ServiceIsStarted()
-        {
-            Assert.That(_driverService.Status, Is.EqualTo(ServiceStatus.Started), "Failed to start service");
-        }
-
 
 #if NET5_0_OR_GREATER
         [TestCase("mock-assembly.dll", false, typeof(NUnitNetCore31Driver))]

--- a/src/NUnitEngine/nunit.engine.core/CoreEngine.cs
+++ b/src/NUnitEngine/nunit.engine.core/CoreEngine.cs
@@ -60,7 +60,6 @@ namespace NUnit.Engine
                 // Services that depend on other services must be added after their dependencies
                 // For example, ResultService uses ExtensionService, so ExtensionService is added
                 // later.
-                Services.Add(new DriverService());
                 Services.Add(new ExtensionService());
             }
 

--- a/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
@@ -39,9 +39,12 @@ namespace NUnit.Engine.Runners
 
         private readonly List<IFrameworkDriver> _drivers = new List<IFrameworkDriver>();
 
-        private ProvidedPathsAssemblyResolver _assemblyResolver;
+        private readonly ProvidedPathsAssemblyResolver _assemblyResolver;
 
         protected AppDomain TestDomain { get; set; }
+
+        // Used to inject DriverService for testing
+        internal IDriverService DriverService { get; set; }
 
         public DirectTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
         {
@@ -101,7 +104,8 @@ namespace NUnit.Engine.Runners
             // found in the terminal nodes.
             var packagesToLoad = TestPackage.Select(p => !p.HasSubPackages());
 
-            var driverService = Services.GetService<IDriverService>();
+            if (DriverService == null)
+                DriverService = new Services.DriverService();
 
             _drivers.Clear();
 
@@ -120,7 +124,7 @@ namespace NUnit.Engine.Runners
                     _assemblyResolver.AddPathFromFile(testFile);
                 }
 
-                IFrameworkDriver driver = driverService.GetDriver(TestDomain, testFile, targetFramework, skipNonTestAssemblies);
+                IFrameworkDriver driver = DriverService.GetDriver(TestDomain, testFile, targetFramework, skipNonTestAssemblies);
 
                 driver.ID = subPackage.ID;
                 result.Add(LoadDriver(driver, testFile, subPackage));

--- a/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/DriverService.cs
@@ -96,18 +96,17 @@ namespace NUnit.Engine.Services
 
         public override void StartService()
         {
-            Guard.OperationValid(ServiceContext != null, "Can't start DriverService outside of a ServiceContext");
-
+            // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
             try
             {
-                var extensionService = ServiceContext.GetService<ExtensionService>();
-                if (extensionService != null)
+                var extensionManager = new ExtensionManager();
+                if (extensionManager != null)
                 {
-                    foreach (IDriverFactory factory in extensionService.GetExtensions<IDriverFactory>())
+                    foreach (IDriverFactory factory in extensionManager.GetExtensions<IDriverFactory>())
                         _factories.Add(factory);
 
 #if NETFRAMEWORK
-                    var node = extensionService.GetExtensionNode("/NUnit/Engine/NUnitV2Driver");
+                    var node = extensionManager.GetExtensionNode("/NUnit/Engine/NUnitV2Driver");
                     if (node != null)
                         _factories.Add(new NUnit2DriverFactory(node));
 #endif

--- a/src/NUnitEngine/nunit.engine.core/Services/ExtensionManager.cs
+++ b/src/NUnitEngine/nunit.engine.core/Services/ExtensionManager.cs
@@ -21,7 +21,7 @@ namespace NUnit.Engine.Services
 {
     public sealed class ExtensionManager : IDisposable
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionService));
+        static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionManager));
         static readonly Version ENGINE_VERSION = typeof(ExtensionService).Assembly.GetName().Version;
 
         private readonly IFileSystem _fileSystem;
@@ -215,6 +215,8 @@ namespace NUnit.Engine.Services
         /// </summary>
         private ExtensionPoint DeduceExtensionPointFromType(TypeReference typeRef)
         {
+            log.Debug("Trying to deduce ExtensionPoint from " + typeRef.Name);
+
             var ep = GetExtensionPoint(typeRef);
             if (ep != null)
                 return ep;

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -97,7 +97,6 @@ namespace NUnit.Engine.Runners.Tests
             _services.Add(new RuntimeFrameworkService());
             _services.Add(new TestAgency());
 #endif
-            _services.Add(new DriverService());
             _services.Add(new DefaultTestRunnerFactory());
             _services.ServiceManager.StartServices();
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
@@ -21,7 +21,6 @@ namespace NUnit.Engine.Tests.Services.ResultWriters
             var assemblyPath = GetLocalPath(AssemblyName);
 
             var serviceContext = new ServiceContext();
-            serviceContext.Add(new DriverService());
             serviceContext.Add(new DefaultTestRunnerFactory());
 #if NETFRAMEWORK
             serviceContext.Add(new TestAgency());

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -64,7 +64,6 @@ namespace NUnit.Engine
                 Services.Add(new RuntimeFrameworkService());
                 Services.Add(new TestAgency());
 #endif
-                Services.Add(new DriverService());
                 Services.Add(new ResultService());
                 Services.Add(new DefaultTestRunnerFactory());
             }


### PR DESCRIPTION
Fixes #1122

@jnm2 @mikkelbu  I've been merging some changes without a review, but I think this one needs to be looked at by one or both of you. It's the last service in core except for ExtensionService itself so once it's gone I can move all of the service and servicemanager implementation to the engine itself.

The DriverService probably needs a new name but I haven't done that yet. Suggestions?

The Azure build is hanging. At first I thought it may be due to problems they were having but it's always in the same place... right after the net20 engine tests run. Looking for ideas.