### PR TITLE
Add mock-assembly using nunit framework version 4.0.0

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -100,6 +100,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit-agent-x86", "src\NUni
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mock-assembly-x86", "src\NUnitEngine\mock-assembly-x86\mock-assembly-x86.csproj", "{9D3015EE-5B84-41B3-A1D3-1A439370C392}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "mock-nunit4-assembly", "src\NUnitEngine\mock-nunit4-assembly\mock-nunit4-assembly.csproj", "{7AD14816-BC16-4BA8-851E-572E8BBD1801}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -150,6 +152,10 @@ Global
 		{9D3015EE-5B84-41B3-A1D3-1A439370C392}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9D3015EE-5B84-41B3-A1D3-1A439370C392}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9D3015EE-5B84-41B3-A1D3-1A439370C392}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AD14816-BC16-4BA8-851E-572E8BBD1801}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AD14816-BC16-4BA8-851E-572E8BBD1801}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AD14816-BC16-4BA8-851E-572E8BBD1801}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AD14816-BC16-4BA8-851E-572E8BBD1801}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -171,6 +177,7 @@ Global
 		{A19C026B-1C0F-4AA3-AC49-7D8B4C7231CF} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 		{333D2FBC-CCA7-46AF-9453-C310671A67B0} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 		{9D3015EE-5B84-41B3-A1D3-1A439370C392} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
+		{7AD14816-BC16-4BA8-851E-572E8BBD1801} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8E4FC26-5422-4C51-8BBC-D1AC0A578711}

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -202,6 +202,20 @@ public abstract class NetFXPackageTester : PackageTester
             }));
 
         PackageTests.Add(new PackageTest(
+            "net40",
+            "Run mock-nunit4-assembly.dll under .NET 4.x",
+            "net45/mock-nunit4-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 37,
+                Passed = 23,
+                Failed = 5,
+                Warnings = 1,
+                Inconclusive = 1,
+                Skipped = 7
+            }));
+
+        PackageTests.Add(new PackageTest(
             "netcoreapp3.1",
             "Run mock-assembly.dll under .NET Core 3.1",
             "netcoreapp3.1/mock-assembly.dll",
@@ -229,6 +243,20 @@ public abstract class NetFXPackageTester : PackageTester
                     Inconclusive = 1,
                     Skipped = 7
                 }));
+
+        PackageTests.Add(new PackageTest(
+            "netcoreapp3.1",
+            "Run mock-nunit4-assembly.dll under .NET Core 3.1",
+            "netcoreapp3.1/mock-nunit4-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 37,
+                Passed = 23,
+                Failed = 5,
+                Warnings = 1,
+                Inconclusive = 1,
+                Skipped = 7
+            }));
     }
 }
 
@@ -279,6 +307,21 @@ public abstract class NetCorePackageTester : PackageTester
                 Inconclusive = 2 * 1,
                 Skipped = 2 * 7
             }));
+
+        PackageTests.Add(new PackageTest(
+            "netcoreapp3.1",
+            "Run mock-nunit4-assembly targeting .NET Core 3.1",
+            "netcoreapp3.1/mock-nunit4-assembly.dll",
+            new ExpectedResult("Failed")
+            {
+                Total = 37,
+                Passed = 23,
+                Failed = 5,
+                Warnings = 1,
+                Inconclusive = 1,
+                Skipped = 7
+            }));
+
     }
 }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7</LangVersion>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NUnitEngine/mock-nunit4-assembly/Properties/AssemblyInfo.cs
+++ b/src/NUnitEngine/mock-nunit4-assembly/Properties/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Reflection;
+
+// Information about this assembly is defined by the following attributes. 
+// Change them to the _values specific to your project.
+
+[assembly: AssemblyTitle("mock-nunit4-assembly")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCulture("")]

--- a/src/NUnitEngine/mock-nunit4-assembly/mock-nunit4-assembly.csproj
+++ b/src/NUnitEngine/mock-nunit4-assembly/mock-nunit4-assembly.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <RestoreAdditionalProjectSource>
+        https://www.myget.org/F/nunit/api/v3/index.json
+    </RestoreAdditionalProjectSource>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.0.0-dev-07273" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\EngineVersion.cs" LinkBase="Properties" />
+    <Compile Include="..\mock-assembly\*.cs" />
+    <None Include="..\..\nunit.snk" Link="nunit.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #1139 

Added mock-nunit4-assembly based upon mock-assembly-x86
Added mock-nunit4 tests to package-tests.cake

nunit4 support net45, netcoreapp3.1 and net5.0/net6.0

I dropped net5.0/net6.0:
Testing net5.0 package with nunit-console netcore3.1 runner failed.
net6.0 is outside the VS2017 scope.