### PR TITLE
Issue1139 add nunit4 tests

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,9 +15,8 @@ See also [Building and testing for Linux on a Windows machine](#building-and-tes
 
 ## Prerequisites
 
-- Visual Studio 2017 Update 5 or newer to build on Windows
-- .NET 4.5+ or Mono 5.10.0+
-- .NET Core 1.1.6 or newer
+- Visual Studio 2022 or newer to build on Windows
+- .NET 6.0.100 or newer
 
 ## Solution Build
 

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -132,6 +132,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "zip", "zip", "{20005864-BE8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.engine.core.tests", "src\NUnitEngine\nunit.engine.core.tests\nunit.engine.core.tests.csproj", "{CACC0520-B452-4310-A33C-DC944129ACDD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1BB98666-7219-4F38-A4C7-DBE498022AAE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NUnitEngine", "NUnitEngine", "{9A010A5F-0941-42C0-93BF-FB79BFD45120}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "mock-assembly-nunit4", "src\NUnitEngine\mock-assembly-nunit4\mock-assembly-nunit4.csproj", "{E9C5FA69-52D3-44CC-A54F-1F8A49BF7CF5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -186,6 +192,10 @@ Global
 		{CACC0520-B452-4310-A33C-DC944129ACDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CACC0520-B452-4310-A33C-DC944129ACDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CACC0520-B452-4310-A33C-DC944129ACDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9C5FA69-52D3-44CC-A54F-1F8A49BF7CF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9C5FA69-52D3-44CC-A54F-1F8A49BF7CF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9C5FA69-52D3-44CC-A54F-1F8A49BF7CF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9C5FA69-52D3-44CC-A54F-1F8A49BF7CF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -212,6 +222,8 @@ Global
 		{0C0D20CE-70CD-4CEF-BE9B-AEB8A2DE9C8A} = {49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}
 		{20005864-BE82-412D-99BF-288E2D8370E9} = {49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}
 		{CACC0520-B452-4310-A33C-DC944129ACDD} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
+		{9A010A5F-0941-42C0-93BF-FB79BFD45120} = {1BB98666-7219-4F38-A4C7-DBE498022AAE}
+		{E9C5FA69-52D3-44CC-A54F-1F8A49BF7CF5} = {9A010A5F-0941-42C0-93BF-FB79BFD45120}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8E4FC26-5422-4C51-8BBC-D1AC0A578711}

--- a/cake/constants.cake
+++ b/cake/constants.cake
@@ -35,6 +35,7 @@ var CONSOLE_PROJECT = SOURCE_DIR + "NUnitConsole/nunit3-console/nunit3-console.c
 var CONSOLE_TESTS_PROJECT = SOURCE_DIR + "NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj";
 var MOCK_ASSEMBLY_PROJECT = SOURCE_DIR + "NUnitEngine/mock-assembly/mock-assembly.csproj";
 var MOCK_ASSEMBLY_X86_PROJECT = SOURCE_DIR + "NUnitEngine/mock-assembly-x86/mock-assembly-x86.csproj";
+var MOCK_ASSEMBLY_NUNIT4_PROJECT = SOURCE_DIR + "NUnitEngine/mock-assembly-nunit4/mock-assembly-nunit4.csproj";
 var NOTEST_PROJECT = SOURCE_DIR + "NUnitEngine/notest-assembly/notest-assembly.csproj";
 // Console Runner
 var NET20_CONSOLE = BIN_DIR + "net20/nunit3-console.exe";

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -23,6 +23,7 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net35X86Test,
         Net40Test,
         Net40X86Test,
+        Net45NUnit4Test,
         Net35PlusNet40Test,
         NetCore21Test,
         NetCore31Test,
@@ -30,7 +31,11 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net60Test,
         NetCore21PlusNetCore31Test,
         NetCore21PlusNetCore31PlusNet50PlusNet60Test,
-        Net40PlusNet60Test
+        Net40PlusNet60Test,
+        NetCore31NUnit4Test,
+        Net50NUnit4Test,
+        Net60NUnit4Test,
+        Net45PlusNet60NUnit4Test
     };
 
     if (dotnetX86Available)
@@ -47,7 +52,10 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net50Test,
         Net60Test,
         NetCore21PlusNetCore31Test,
-        NetCore21PlusNetCore31PlusNet50PlusNet60Test
+        NetCore21PlusNetCore31PlusNet50PlusNet60Test,
+        NetCore31NUnit4Test,
+        Net50NUnit4Test,
+        Net60NUnit4Test,
     };
 
     AllPackages.AddRange(new PackageDefinition[] {

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -36,6 +36,12 @@ static PackageTest Net40X86Test = new PackageTest(
     "net40/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
+static PackageTest Net45NUnit4Test = new PackageTest(
+    "Net45NUnit4Test",
+    "Run mock-assembly-nunit4.dll under .NET 4.x",
+    "net45/mock-assembly-nunit4.dll",
+    MockAssemblyExpectedResult(1));
+
 static PackageTest Net35PlusNet40Test = new PackageTest(
     "Net35PlusNet40Test",
     "Run both copies of mock-assembly together",
@@ -66,6 +72,24 @@ static PackageTest NetCore31X86Test = new PackageTest(
     "netcoreapp3.1/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
+static PackageTest Net60NUnit4Test = new PackageTest(
+    "Net60NUnit4Test",
+    "Run mock-assembly-nunit4.dll under .NET 6.0",
+    "net6.0/mock-assembly-nunit4.dll",
+    MockAssemblyExpectedResult(1));
+
+static PackageTest Net50NUnit4Test = new PackageTest(
+    "Net50NUnit4Test",
+    "Run mock-assembly-nunit4.dll under .NET 5.0",
+    "net5.0/mock-assembly-nunit4.dll",
+    MockAssemblyExpectedResult(1));
+
+static PackageTest NetCore31NUnit4Test = new PackageTest(
+    "NetCore31NUnit4Test",
+    "Run mock-assembly-nunit4.dll under .NET Core 3.1",
+    "netcoreapp3.1/mock-assembly-nunit4.dll",
+    MockAssemblyExpectedResult(1));
+
 static PackageTest NetCore21Test = new PackageTest(
     "NetCore21Test",
     "Run mock-assembly.dll targeting .NET Core 2.1",
@@ -94,6 +118,12 @@ static PackageTest Net40PlusNet60Test = new PackageTest(
     "Net40PlusNet60Test",
     "Run mock-assembly under .Net Framework 4.0 and .Net 6.0 together",
     "net40/mock-assembly.dll net6.0/mock-assembly.dll",
+    MockAssemblyExpectedResult(2));
+
+static PackageTest Net45PlusNet60NUnit4Test = new PackageTest(
+    "Net45PlusNet60Test",
+    "Run mock-assembly-nunit4 under .Net Framework 4.0 and .Net 6.0 together",
+    "net45/mock-assembly-nunit4.dll net6.0/mock-assembly-nunit4.dll",
     MockAssemblyExpectedResult(2));
 
 static PackageTest NUnitProjectTest;

--- a/cake/utilities.cake
+++ b/cake/utilities.cake
@@ -67,17 +67,17 @@ MSBuildSettings CreateMSBuildSettings(string target)
 
     if (IsRunningOnWindows())
     {
-        // The fallback is in case only a preview of VS is installed.
         var vsInstallation =
-            VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild" })
-            ?? VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild", IncludePrerelease = true });
+            VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild" });
+
+        if (vsInstallation == null || !vsInstallation.FullPath.Contains("2022"))
+        {
+            vsInstallation = VSWhereLatest(new VSWhereLatestSettings { Requires = "Microsoft.Component.MSBuild", IncludePrerelease = true });
+        }
 
         if (vsInstallation != null)
         {
             var msBuildPath = vsInstallation.CombineWithFilePath(@"MSBuild\Current\Bin\MSBuild.exe");
-
-            if (!FileExists(msBuildPath))
-                msBuildPath = vsInstallation.CombineWithFilePath(@"MSBuild\15.0\Bin\MSBuild.exe");
 
             if (FileExists(msBuildPath))
                 settings.ToolPath = msBuildPath;

--- a/src/NUnitEngine/mock-assembly-nunit4/mock-assembly-nunit4.csproj
+++ b/src/NUnitEngine/mock-assembly-nunit4/mock-assembly-nunit4.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>NUnit.Tests</RootNamespace>
+    <TargetFrameworks>net45;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
+    <RestoreAdditionalProjectSource>https://www.myget.org/F/nunit/api/v3/index.json</RestoreAdditionalProjectSource>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Product>NUnit Engine</Product>
+    <AssemblyTitle>NUnit4 Mock Assembly ($(TargetFramework))</AssemblyTitle>
+    <Description>Assembly used in testing the engine</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.0.0-dev-07273" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\mock-assembly\*.cs" />
+    <None Include="..\..\nunit.snk" Link="nunit.snk" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #1139 

First commit is to find a preview version of VS2022 when VS2019 is installed.
The code should preferably throw if it can't find MSBuild 17.0 as the .NET 6 sdk complains it it is run with MSBuild 15.0
Also update the minimum requirement in BUILDING.md

Second commit adds mock-assembly-nunit4 and associated tests.