### PR TITLE
Fix for net7

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -14,7 +14,7 @@
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
-var productVersion = Argument("productVersion", "3.13.0");
+var productVersion = Argument("productVersion", "3.16.0-alpha.2");
 
 var ErrorDetail = new List<string>();
 var installedNetCoreRuntimes = GetInstalledNetCoreRuntimes();

--- a/src/NUnitConsole/ConsoleVersion.cs
+++ b/src/NUnitConsole/ConsoleVersion.cs
@@ -3,5 +3,5 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("NUnit Console Runner")]
-[assembly: AssemblyVersion("3.13.0")]
-[assembly: AssemblyInformationalVersion("3.13.0")]
+[assembly: AssemblyVersion("3.16.0")]
+[assembly: AssemblyInformationalVersion("3.16.0-alpha.2")]

--- a/src/NUnitEngine/EngineApiVersion.cs
+++ b/src/NUnitEngine/EngineApiVersion.cs
@@ -4,5 +4,5 @@ using System.Reflection;
 
 [assembly: AssemblyProduct("NUnit Engine API")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyInformationalVersion("3.13.0")]
+[assembly: AssemblyInformationalVersion("3.16.0-alpha.2")]
 [assembly: AssemblyFileVersion("3.13.0")]

--- a/src/NUnitEngine/EngineVersion.cs
+++ b/src/NUnitEngine/EngineVersion.cs
@@ -3,5 +3,5 @@
 using System.Reflection;
 
 [assembly: AssemblyProduct("NUnit Engine")]
-[assembly: AssemblyVersion("3.13.0")]
-[assembly: AssemblyInformationalVersion("3.13.0")]
+[assembly: AssemblyVersion("3.16.0")]
+[assembly: AssemblyInformationalVersion("3.16.0-alpha.2")]

--- a/src/NUnitEngine/nunit.engine.core/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine.core/RuntimeFramework.cs
@@ -151,11 +151,13 @@ namespace NUnit.Engine
                             return new Version(5, 0, 1);
                         case 6:
                             return new Version(6, 0, 0);
+                        case 7:
+                            return new Version(7, 0, 0);
                     }
                     break;
             }
 
-            throw new ArgumentException("Unknown framework version " + frameworkVersion.ToString(), "version");
+            throw new ArgumentException($"Unknown framework version {frameworkVersion}.\nIf Microsoft is releasing a new major version, that version has to be inserted into the GetClrVersionForFramework method in the RuntimeFramework class.\nVersion 1-7 is supported now.", "version");
         }
 
         private Version GetFrameworkVersionForClr(Version clrVersion)
@@ -225,8 +227,10 @@ namespace NUnit.Engine
                             minor = 5;
                         }
 
-                    _currentFramework = new RuntimeFramework(runtime, new Version(major, minor));
-                    _currentFramework.ClrVersion = Environment.Version;
+                    _currentFramework = new RuntimeFramework(runtime, new Version(major, minor))
+                    {
+                        ClrVersion = Environment.Version
+                    };
 
                     if (isMono)
                     {


### PR DESCRIPTION
Adds "support" for .net 7 framework.

Not sure what version number is next up, so just put it as 3.16.  
A local version of this is added to the nunit3testadapter 4.3.0-alpha-net7.4 version.

Solves #1176 