### PR TITLE
Eliminate exception when running Windows Forms or ASP.NET Core tests under .NET 6.0

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -138,6 +138,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit.engine.core.tests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit3-netcore-console", "src\NUnitConsole\nunit3-netcore-console\nunit3-netcore-console.csproj", "{472314FE-1F18-4359-B620-FF20BF3AF553}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "windows-test", "src\NUnitEngine\windows-test\windows-test.csproj", "{D3A28EEB-A7C4-4A03-B958-4D161C208963}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -196,6 +198,10 @@ Global
 		{472314FE-1F18-4359-B620-FF20BF3AF553}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{472314FE-1F18-4359-B620-FF20BF3AF553}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{472314FE-1F18-4359-B620-FF20BF3AF553}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -223,6 +229,7 @@ Global
 		{20005864-BE82-412D-99BF-288E2D8370E9} = {49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}
 		{CACC0520-B452-4310-A33C-DC944129ACDD} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 		{472314FE-1F18-4359-B620-FF20BF3AF553} = {576DB1E6-C5EC-4FEF-A826-EC19D8BEE572}
+		{D3A28EEB-A7C4-4A03-B958-4D161C208963} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8E4FC26-5422-4C51-8BBC-D1AC0A578711}

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -140,6 +140,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "nunit3-netcore-console", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "windows-test", "src\NUnitEngine\windows-test\windows-test.csproj", "{D3A28EEB-A7C4-4A03-B958-4D161C208963}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "aspnetcore-test", "src\NUnitEngine\aspnetcore-test\aspnetcore-test.csproj", "{25FFAF61-C456-4BF9-87BE-34930F22B669}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -202,6 +204,10 @@ Global
 		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3A28EEB-A7C4-4A03-B958-4D161C208963}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25FFAF61-C456-4BF9-87BE-34930F22B669}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25FFAF61-C456-4BF9-87BE-34930F22B669}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25FFAF61-C456-4BF9-87BE-34930F22B669}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25FFAF61-C456-4BF9-87BE-34930F22B669}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,6 +236,7 @@ Global
 		{CACC0520-B452-4310-A33C-DC944129ACDD} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 		{472314FE-1F18-4359-B620-FF20BF3AF553} = {576DB1E6-C5EC-4FEF-A826-EC19D8BEE572}
 		{D3A28EEB-A7C4-4A03-B958-4D161C208963} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
+		{25FFAF61-C456-4BF9-87BE-34930F22B669} = {31B45C4C-206F-4F31-9CC6-33BF11DFEE39}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8E4FC26-5422-4C51-8BBC-D1AC0A578711}

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -20,25 +20,20 @@ public void InitializePackageDefinitions(ICakeContext context)
     var StandardRunnerTests = new List<PackageTest>
     {
         Net35Test,
-        Net35X86Test,
         Net40Test,
-        Net40X86Test,
-        Net35PlusNet40Test,
         NetCore21Test,
         NetCore31Test,
         Net50Test,
         Net60Test,
         Net70Test,
-        NetCore21PlusNetCore31Test,
-        NetCore21PlusNetCore31PlusNet50PlusNet60Test,
-        Net40PlusNet60Test
+        Net35PlusNet40Test,
+        Net40PlusNet60Test,
+        Net35X86Test,
+        Net40X86Test
     };
 
     if (dotnetX86Available)
-    {
-        StandardRunnerTests.Add(NetCore21X86Test);
         StandardRunnerTests.Add(NetCore31X86Test);
-    }
 
     // Tests run for the NETCORE runner package
     var NetCoreRunnerTests = new List<PackageTest>
@@ -47,8 +42,6 @@ public void InitializePackageDefinitions(ICakeContext context)
         NetCore31Test,
         Net50Test,
         Net60Test,
-        NetCore21PlusNetCore31Test,
-        NetCore21PlusNetCore31PlusNet50PlusNet60Test
     };
 
     AllPackages.AddRange(new PackageDefinition[] {

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -29,7 +29,8 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net35PlusNet40Test,
         Net40PlusNet60Test,
         Net35X86Test,
-        Net40X86Test
+        Net40X86Test,
+        Net60WindowsFormsTest
     };
 
     if (dotnetX86Available)

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -30,7 +30,8 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net40PlusNet60Test,
         Net35X86Test,
         Net40X86Test,
-        Net60WindowsFormsTest
+        Net60WindowsFormsTest,
+        Net60AspNetCoreTest
     };
 
     if (dotnetX86Available)

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -76,6 +76,14 @@ static PackageTest NetCore31X86Test = new PackageTest(
     "src/NUnitEngine/mock-assembly-x86/bin/Release/netcoreapp3.1/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
+// Special Test Situations
+
+static PackageTest Net60WindowsFormsTest = new PackageTest(
+    "Net60WindowsTest",
+    "Run test using windows forms under .NET 6.0",
+    "src/NUnitEngine/windows-test/bin/Release/net6.0-windows/windows-test.dll",
+    new ExpectedResult("Passed"));
+
 // Multiple Assemblies
 
 static PackageTest Net35PlusNet40Test = new PackageTest(

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -12,16 +12,12 @@ static ExpectedResult MockAssemblyExpectedResult(int nCopies = 1) => new Expecte
     Skipped = 7 * nCopies
 };
 
+//Single Assembly Tests using each agent
+
 static PackageTest Net35Test = new PackageTest(
     "Net35Test",
     "Run mock-assembly.dll under .NET 3.5",
     "src/NUnitEngine/mock-assembly/bin/Release/net35/mock-assembly.dll",
-    MockAssemblyExpectedResult(1));
-
-static PackageTest Net35X86Test = new PackageTest(
-    "Net35X86Test",
-    "Run mock-assembly-x86.dll under .NET 3.5",
-    "src/NUnitEngine/mock-assembly-x86/bin/Release/net35/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net40Test = new PackageTest(
@@ -30,17 +26,23 @@ static PackageTest Net40Test = new PackageTest(
     "src/NUnitEngine/mock-assembly/bin/Release/net462/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
-static PackageTest Net40X86Test = new PackageTest(
-    "Net40X86Test",
-    "Run mock-assembly-x86.dll under .NET 4.x",
-    "src/NUnitEngine/mock-assembly-x86/bin/Release/net462/mock-assembly-x86.dll",
+static PackageTest NetCore21Test = new PackageTest(
+    "NetCore21Test",
+    "Run mock-assembly.dll targeting .NET Core 2.1",
+    "src/NUnitEngine/mock-assembly/bin/Release/netcoreapp2.1/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
-static PackageTest Net35PlusNet40Test = new PackageTest(
-    "Net35PlusNet40Test",
-    "Run both copies of mock-assembly together",
-    "src/NUnitEngine/mock-assembly/bin/Release/net35/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/net462/mock-assembly.dll",
-    MockAssemblyExpectedResult(2));
+static PackageTest NetCore31Test = new PackageTest(
+    "NetCore31Test",
+    "Run mock-assembly.dll under .NET Core 3.1",
+    "src/NUnitEngine/mock-assembly/bin/Release/netcoreapp3.1/mock-assembly.dll",
+    MockAssemblyExpectedResult(1));
+
+static PackageTest Net50Test = new PackageTest(
+    "Net50Test",
+    "Run mock-assembly.dll under .NET 5.0",
+    "src/NUnitEngine/mock-assembly/bin/Release/net5.0/mock-assembly.dll",
+    MockAssemblyExpectedResult(1));
 
 static PackageTest Net60Test = new PackageTest(
     "Net60Test",
@@ -54,16 +56,18 @@ static PackageTest Net70Test = new PackageTest(
     "src/NUnitEngine/mock-assembly/bin/Release/net7.0/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
-static PackageTest Net50Test = new PackageTest(
-    "Net50Test",
-    "Run mock-assembly.dll under .NET 5.0",
-    "src/NUnitEngine/mock-assembly/bin/Release/net5.0/mock-assembly.dll",
+// X86 Tests
+
+static PackageTest Net35X86Test = new PackageTest(
+    "Net35X86Test",
+    "Run mock-assembly-x86.dll under .NET 3.5",
+    "src/NUnitEngine/mock-assembly-x86/bin/Release/net35/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
-static PackageTest NetCore31Test = new PackageTest(
-    "NetCore31Test",
-    "Run mock-assembly.dll under .NET Core 3.1",
-    "src/NUnitEngine/mock-assembly/bin/Release/netcoreapp3.1/mock-assembly.dll",
+static PackageTest Net40X86Test = new PackageTest(
+    "Net40X86Test",
+    "Run mock-assembly-x86.dll under .NET 4.x",
+    "src/NUnitEngine/mock-assembly-x86/bin/Release/net462/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest NetCore31X86Test = new PackageTest(
@@ -72,35 +76,21 @@ static PackageTest NetCore31X86Test = new PackageTest(
     "src/NUnitEngine/mock-assembly-x86/bin/Release/netcoreapp3.1/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
-static PackageTest NetCore21Test = new PackageTest(
-    "NetCore21Test",
-    "Run mock-assembly.dll targeting .NET Core 2.1",
-    "src/NUnitEngine/mock-assembly/bin/Release/netcoreapp2.1/mock-assembly.dll",
-    MockAssemblyExpectedResult(1));
+// Multiple Assemblies
 
-static PackageTest NetCore21X86Test = new PackageTest(
-    "NetCore21X86Test",
-    "Run mock-assembly-x86.dll under .NET Core 2.1",
-    "src/NUnitEngine/mock-assembly-x86/bin/Release/netcoreapp2.1/mock-assembly-x86.dll",
-    MockAssemblyExpectedResult(1));
-
-static PackageTest NetCore21PlusNetCore31Test = new PackageTest(
-    "NetCore21PlusNetCore31Test",
-    "Run two copies of mock-assembly together",
-    "src/NUnitEngine/mock-assembly/bin/Release/netcoreapp2.1/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/netcoreapp3.1/mock-assembly.dll",
+static PackageTest Net35PlusNet40Test = new PackageTest(
+    "Net35PlusNet40Test",
+    "Run both copies of mock-assembly together",
+    "src/NUnitEngine/mock-assembly/bin/Release/net35/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/net462/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
-
-static PackageTest NetCore21PlusNetCore31PlusNet50PlusNet60Test = new PackageTest(
-    "NetCore21PlusNetCore31PlusNet50PlusNet60Test",
-    "Run four copies of mock-assembly together",
-    "src/NUnitEngine/mock-assembly/bin/Release/netcoreapp2.1/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/netcoreapp3.1/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/net5.0/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/net6.0/mock-assembly.dll",
-    MockAssemblyExpectedResult(4));
 
 static PackageTest Net40PlusNet60Test = new PackageTest(
     "Net40PlusNet60Test",
     "Run mock-assembly under .Net Framework 4.0 and .Net 6.0 together",
     "src/NUnitEngine/mock-assembly/bin/Release/net462/mock-assembly.dll src/NUnitEngine/mock-assembly/bin/Release/net6.0/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
+
+// NUnit Project
 
 static PackageTest NUnitProjectTest;
 NUnitProjectTest = new PackageTest(

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -79,9 +79,15 @@ static PackageTest NetCore31X86Test = new PackageTest(
 // Special Test Situations
 
 static PackageTest Net60WindowsFormsTest = new PackageTest(
-    "Net60WindowsTest",
+    "Net60WindowsFormsTest",
     "Run test using windows forms under .NET 6.0",
     "src/NUnitEngine/windows-test/bin/Release/net6.0-windows/windows-test.dll",
+    new ExpectedResult("Passed"));
+
+static PackageTest Net60AspNetCoreTest = new PackageTest(
+    "Net60AspNetCoreTest",
+    "Run test using AspNetCore under .NET 6.0",
+    "src/NUnitEngine/aspnetcore-test/bin/Release/net6.0/aspnetcore-test.dll",
     new ExpectedResult("Passed"));
 
 // Multiple Assemblies

--- a/src/NUnitEngine/aspnetcore-test/AspNetCoreTest.cs
+++ b/src/NUnitEngine/aspnetcore-test/AspNetCoreTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework;
+using Microsoft.AspNetCore.Components.Forms;
+
+// Test which resolves issue #1203
+namespace Test1
+{
+    [TestFixture]
+    public class Class1
+    {
+        [Test]
+        public void WithoutFramework()
+        {
+            Assert.Pass();
+        }
+
+        [Test]
+        public void WithFramework()
+        {
+            InputCheckbox checkbox = new InputCheckbox();
+            Assert.Pass();
+        }
+    }
+}

--- a/src/NUnitEngine/aspnetcore-test/aspnetcore-test.csproj
+++ b/src/NUnitEngine/aspnetcore-test/aspnetcore-test.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -10,6 +10,11 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'!='net20' and '$(TargetFramework)'!='net462'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
+  </ItemGroup>
+  
   <PropertyGroup>
     <Product>NUnit Engine</Product>
     <AssemblyTitle>NUnit Agent ($(TargetFramework))</AssemblyTitle>

--- a/src/NUnitEngine/windows-test/WindowsTest.cs
+++ b/src/NUnitEngine/windows-test/WindowsTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System.Windows.Forms;
+using NUnit.Framework;
+
+// Test which resolves issue #1203
+namespace Test1
+{
+    [TestFixture]
+    public class Class1
+    {
+        [Test]
+        public void WithoutFramework()
+        {
+            Assert.Pass();
+        }
+
+        [Test]
+        public void WithFramework()
+        {
+            var checkbox = new CheckBox();
+            Assert.Pass();
+        }
+    }
+}

--- a/src/NUnitEngine/windows-test/windows-test.csproj
+++ b/src/NUnitEngine/windows-test/windows-test.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #1203

May also fix #1202