### PR TITLE
Include .NET Core 3.1 build of engine in engine package

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -271,6 +271,19 @@ Task("TestNetStandard20Engine")
     });
 
 //////////////////////////////////////////////////////////////////////
+// TEST NETSTANDARD 2.0 ENGINE
+//////////////////////////////////////////////////////////////////////
+
+Task("TestNetCore31Engine")
+    .Description("Tests the .NET Core 3.1 Engine")
+    .IsDependentOn("Build")
+    .OnError(exception => { UnreportedErrors.Add(exception.Message); })
+    .Does(() =>
+    {
+        RunDotnetNUnitLiteTests(NETCORE_ENGINE_TESTS, "netcoreapp3.1");
+    });
+
+//////////////////////////////////////////////////////////////////////
 // TEST .NET FRAMEWORK  CONSOLE
 //////////////////////////////////////////////////////////////////////
 
@@ -739,7 +752,8 @@ Task("TestEngineCore")
 Task("TestEngine")
     .Description("Builds and tests the engine assembly")
     .IsDependentOn("TestNetFxEngine")
-    .IsDependentOn("TestNetStandard20Engine");
+    .IsDependentOn("TestNetStandard20Engine")
+    .IsDependentOn("TestNetCore31Engine");
 
 Task("Test")
     .Description("Builds and tests the engine and console runner")

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -167,14 +167,17 @@ public void InitializePackageDefinitions(ICakeContext context)
                 HasFiles("LICENSE.txt", "NOTICES.txt"),
                 HasDirectory("lib/net462").WithFiles(ENGINE_FILES),
                 HasDirectory("lib/netstandard2.0").WithFiles(ENGINE_FILES),
+                HasDirectory("lib/netcoreapp3.1").WithFiles(ENGINE_FILES),
                 HasDirectory("contentFiles/any/lib/net20").WithFile("nunit.engine.nuget.addins"),
                 HasDirectory("contentFiles/any/lib/netstandard2.0").WithFile("nunit.engine.nuget.addins"),
+                HasDirectory("contentFiles/any/lib/netcoreapp3.1").WithFile("nunit.engine.nuget.addins"),
                 HasDirectory("contentFiles/any/agents/net20").WithFiles(AGENT_FILES_NET20),
                 HasDirectory("contentFiles/any/agents/net462").WithFiles(AGENT_FILES_NET462)
             },
             symbols: new PackageCheck[] {
                 HasDirectory("lib/net462").WithFiles(ENGINE_PDB_FILES),
                 HasDirectory("lib/netstandard2.0").WithFiles(ENGINE_PDB_FILES),
+                HasDirectory("lib/netcoreapp3.1").WithFiles(ENGINE_PDB_FILES),
                 HasDirectory("contentFiles/any/agents/net20").WithFiles(AGENT_PDB_FILES_NET20),
                 HasDirectory("contentFiles/any/agents/net462").WithFiles(AGENT_PDB_FILES_NET462)
             }),

--- a/nuget/engine/nunit.engine.nuspec
+++ b/nuget/engine/nunit.engine.nuspec
@@ -89,6 +89,15 @@
     <file src="netstandard2.0/testcentric.engine.metadata.dll" target="lib/netstandard2.0" />
     <file src="../../nuget/engine/nunit.engine.nuget.addins" target="contentFiles/any/lib/netstandard2.0"/>
 
+    <file src="netcoreapp3.1/nunit.engine.dll" target="lib/netcoreapp3.1" />
+    <file src="netcoreapp3.1/nunit.engine.pdb" target="lib/netcoreapp3.1" />
+    <file src="netcoreapp3.1/nunit.engine.core.dll" target="lib/netcoreapp3.1" />
+    <file src="netcoreapp3.1/nunit.engine.core.pdb" target="lib/netcoreapp3.1" />
+    <file src="netcoreapp3.1/testcentric.engine.metadata.dll" target="lib/netcoreapp3.1" />
+    <file src="netstandard2.0/nunit.engine.api.dll" target="lib/netcoreapp3.1" />
+    <file src="netstandard2.0/nunit.engine.api.pdb" target="lib/netcoreapp3.1" />
+    <file src="../../nuget/engine/nunit.engine.nuget.addins" target="contentFiles/any/lib/netcoreapp3.1" />
+    
     <file src="../../nuget/engine/build/**/*" target="build" />
     <file src="../../nunit_256.png" target="images" />
   </files>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net462;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitEngine/nunit.engine/nunit.engine.csproj
+++ b/src/NUnitEngine/nunit.engine/nunit.engine.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>


### PR DESCRIPTION
Port of issue #1225 fix from verson 3 code. Part of #1258.