### PR TITLE
Don't throw exception when VS Solution contains a .NET Standard assembly

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
@@ -109,7 +109,7 @@ namespace NUnit.Engine.Runners
             {
                 var testFile = subPackage.FullName;
 
-                string targetFramework = subPackage.GetSetting(InternalEnginePackageSettings.ImageTargetFrameworkName, (string)null);
+                string targetFramework = subPackage.GetSetting(EnginePackageSettings.TargetRuntimeFramework, (string)null);
                 bool skipNonTestAssemblies = subPackage.GetSetting(EnginePackageSettings.SkipNonTestAssemblies, false);
 
                 if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain()

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -130,7 +130,7 @@ namespace NUnit.Engine.Services
 
             if (string.IsNullOrEmpty(imageTargetFrameworkNameSetting))
             {
-                // Assume .NET Framework
+                // Assume .NET Framework 2.0
                 targetRuntime = currentFramework.Runtime;
                 targetVersion = package.GetSetting(InternalEnginePackageSettings.ImageRuntimeVersion, new Version(2, 0));
             }
@@ -142,15 +142,19 @@ namespace NUnit.Engine.Services
                 {
                     case ".NETFramework":
                         targetRuntime = RuntimeType.Net;
+                        targetVersion = frameworkName.Version;
                         break;
                     case ".NETCoreApp":
                         targetRuntime = RuntimeType.NetCore;
+                        targetVersion = frameworkName.Version;
+                        break;
+                    case ".NETStandard":
+                        targetRuntime = RuntimeType.NetCore;
+                        targetVersion = new Version(3, 1);
                         break;
                     default:
                         throw new NUnitEngineException("Unsupported Target Framework: " + imageTargetFrameworkNameSetting);
                 }
-
-                targetVersion = frameworkName.Version;
             }
 
             if (!new RuntimeFramework(targetRuntime, targetVersion).IsAvailable)


### PR DESCRIPTION
Fixes #1182