### PR TITLE
Allow Mono 4+ to run all .NET 4 versions

### DIFF
--- a/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
@@ -196,7 +196,9 @@ namespace NUnit.ConsoleRunner
         [TestCase("DefaultTestNamePattern", "test-name-format", new string[] { "{m}{a}" }, new string[0])]
         [TestCase("ConsoleEncoding", "encoding", new string[] { "utf-8", "ascii", "unicode" }, new string[0])]
 #if NETFRAMEWORK
-        [TestCase("RuntimeFramework", "framework", new string[] { "net-4.6.2" }, new string[0])]
+       // We can't predict which runtimes are available on the test machine, so we don't
+        // test for any good or bad values. TODO: Create a fake list of availble runtimes.
+        [TestCase("RuntimeFramework", "framework", new string[0], new string[0])]
         [TestCase("ConfigurationFile", "configfile", new string[] { "mytest.config" }, new string[0] )]
         [TestCase("PrincipalPolicy", "set-principal-policy", new string[] { "UnauthenticatedPrincipal", "NoPrincipal", "WindowsPrincipal" }, new string[] { "JUNK" })]
 #endif

--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace NUnit.Engine
 {
@@ -78,6 +79,10 @@ namespace NUnit.Engine
             new TestCaseData(
                 new RuntimeFramework(Runtime.Mono, new Version(4,0)),
                 new RuntimeFramework(Runtime.Net, new Version(4,0)))
+                .Returns(true),
+            new TestCaseData(
+                new RuntimeFramework(Runtime.Mono, new Version(4,0)),
+                new RuntimeFramework(Runtime.Net, new Version(4,6,2)))
                 .Returns(true),
             new TestCaseData(
                 new RuntimeFramework(Runtime.Net, new Version(2,0)),

--- a/src/NUnitEngine/nunit.engine/Runtime.cs
+++ b/src/NUnitEngine/nunit.engine/Runtime.cs
@@ -99,6 +99,11 @@ namespace NUnit.Engine
             public override string DisplayName => "Mono";
 
             public override string ToString() => "Mono";
+
+            public override bool Supports(Version runtime, Version target)
+            {
+                return base.Supports(runtime, target) || runtime.Major >= 4 && target.Major == 4;
+            }
         }
 
         private class NetCoreRuntime : Runtime


### PR DESCRIPTION
Ports fix for #1130 from version 3