### PR TITLE
Don't throw an exception when encountering a .NET Standard assembly.

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -159,15 +159,19 @@ namespace NUnit.Engine.Services
                 {
                     case ".NETFramework":
                         targetRuntime = Runtime.Net;
+                        targetVersion = frameworkName.Version;
                         break;
                     case ".NETCoreApp":
                         targetRuntime = Runtime.NetCore;
+                        targetVersion = frameworkName.Version;
+                        break;
+                    case ".NETStandard":
+                        targetRuntime = Runtime.NetCore;
+                        targetVersion = new Version(3, 1);
                         break;
                     default:
                         throw new NUnitEngineException("Unsupported Target Framework: " + imageTargetFrameworkNameSetting);
                 }
-
-                targetVersion = frameworkName.Version;
             }
 
             if (!IsAvailable(new RuntimeFramework(targetRuntime, targetVersion).Id))


### PR DESCRIPTION
Porting fix for issue #1182 from version 3