### PR TITLE
Fix for #1307

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
@@ -108,6 +108,8 @@ namespace NUnit.Engine.Internal
 
         private static string FindBestVersionDir(string libraryDir, Version targetVersion)
         {
+            if (targetVersion == null)
+                return null;
             Version bestVersion = new Version(0,0);
             foreach (var subdir in Directory.GetDirectories(libraryDir))
             {

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
@@ -108,7 +108,6 @@ namespace NUnit.Engine.Internal
 
         private static string FindBestVersionDir(string libraryDir, Version targetVersion)
         {
-            string target = targetVersion.ToString();
             Version bestVersion = new Version(0,0);
             foreach (var subdir in Directory.GetDirectories(libraryDir))
             {

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
@@ -77,7 +77,8 @@ namespace NUnit.Engine.Internal
                         return _loadContext.LoadFromAssemblyPath(assemblyPath);
                 }
             }
-
+            if (name.Version == null)
+                return null;
             foreach(string frameworkDirectory in AdditionalFrameworkDirectories)
             {
                 var versionDir = FindBestVersionDir(frameworkDirectory, name.Version);


### PR DESCRIPTION
Fix for #1307 : NUnit3TestAdapter integration: Exception when using NUnit.Engine 3.16.2

Removed the line that caused the nullref exception, as the resulting variable was not used in the method.