### PR TITLE
Detect the 'partition' token during filter element parsing

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
@@ -126,6 +126,7 @@ namespace NUnit.Engine
                 case "name":
                 case "test":
                 case "namespace":
+                case "partition":
                     Token op = lhs.Text == "id"
                         ? Expect(EQ_OPS)
                         : Expect(REL_OPS);


### PR DESCRIPTION
This adds support for a new PartitionFilter at https://github.com/nunit/nunit/pull/4392