### PR TITLE
.NET 8 Console and Agent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,18 @@ jobs:
   condition: not(or(startsWith(variables['Build.SourceBranchName'], 'azure-linux-'),startsWith(variables['Build.SourceBranchName'], 'azure-macOS-')))
   pool:
     vmImage: windows-2022
-  
+
   steps:
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET 8.0'
+    inputs:
+      version: 8.x
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET 7.0'
+    inputs:
+      version: 7.x
 
   - task: UseDotNet@2
     displayName: 'Install .NET 6.0'
@@ -26,7 +36,7 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       version: 3.1.x
-      
+
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'
     inputs:
@@ -70,6 +80,16 @@ jobs:
   steps:
 
   - task: UseDotNet@2
+    displayName: 'Install .NET 8.0'
+    inputs:
+      version: 8.x
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET 7.0'
+    inputs:
+      version: 7.x
+
+  - task: UseDotNet@2
     displayName: 'Install .NET 6.0'
     inputs:
       version: 6.x
@@ -83,7 +103,7 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       version: 3.1.x
-      
+
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'
     inputs:
@@ -119,6 +139,16 @@ jobs:
   steps:
 
   - task: UseDotNet@2
+    displayName: 'Install .NET 8.0'
+    inputs:
+      version: 8.x
+
+  - task: UseDotNet@2
+    displayName: 'Install .NET 7.0'
+    inputs:
+      version: 7.x
+
+  - task: UseDotNet@2
     displayName: 'Install .NET 6.0'
     inputs:
       version: 6.x
@@ -132,7 +162,7 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       version: 3.1.x
-      
+
   - task: UseDotNet@2
     displayName: 'Install .NET Core runtime 2.1'
     inputs:

--- a/build.cake
+++ b/build.cake
@@ -139,8 +139,8 @@ private void BuildEachProjectSeparately()
     BuildProject(AGENT_X86_PROJECT);
 
     BuildProject(ENGINE_TESTS_PROJECT, "net35", "netcoreapp2.1");
-    BuildProject(ENGINE_CORE_TESTS_PROJECT, "net35", "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0");
-    BuildProject(CONSOLE_TESTS_PROJECT, "net35", "net6.0");
+    BuildProject(ENGINE_CORE_TESTS_PROJECT, "net35", "netcoreapp2.1", "netcoreapp3.1", "net5.0", "net6.0", "net8.0");
+    BuildProject(CONSOLE_TESTS_PROJECT, "net35", "net6.0", "net8.0");
 
     BuildProject(MOCK_ASSEMBLY_X86_PROJECT, "net35", "net40", "netcoreapp2.1", "netcoreapp3.1");
     BuildProject(NOTEST_PROJECT, "net35", "netcoreapp2.1", "netcoreapp3.1");
@@ -317,7 +317,7 @@ Task("TestNet20Console")
     {
         RunNet20Console(CONSOLE_TESTS, "net35");
     });
-
+    
 //////////////////////////////////////////////////////////////////////
 // TEST .NET 6.0 CONSOLE
 //////////////////////////////////////////////////////////////////////
@@ -329,6 +329,19 @@ Task("TestNet60Console")
     .Does(() =>
     {
         RunNetCoreConsole(CONSOLE_TESTS, "net6.0");
+    });
+
+//////////////////////////////////////////////////////////////////////
+// TEST .NET 8.0 CONSOLE
+//////////////////////////////////////////////////////////////////////
+
+Task("TestNet80Console")
+    .Description("Tests the .NET 8.0 console runner")
+    .IsDependentOn("Build")
+    .OnError(exception => { UnreportedErrors.Add(exception.Message); })
+    .Does(() =>
+    {
+        RunNetCoreConsole(CONSOLE_TESTS, "net8.0");
     });
 
 //////////////////////////////////////////////////////////////////////

--- a/cake/constants.cake
+++ b/cake/constants.cake
@@ -39,6 +39,7 @@ var NOTEST_PROJECT = SOURCE_DIR + "NUnitEngine/notest-assembly/notest-assembly.c
 // Console Runner
 var NET20_CONSOLE = BIN_DIR + "net20/nunit3-console.exe";
 var NET60_CONSOLE = BIN_DIR + "net6.0/nunit3-console.dll";
+var NET80_CONSOLE = BIN_DIR + "net8.0/nunit3-console.dll";
 // Unit Tests
 var NETFX_ENGINE_CORE_TESTS = "nunit.engine.core.tests.exe";
 var NETCORE_ENGINE_CORE_TESTS = "nunit.engine.core.tests.dll";

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -5,6 +5,7 @@
 PackageDefinition NUnitConsoleNuGetPackage;
 PackageDefinition NUnitConsoleRunnerNuGetPackage;
 PackageDefinition NUnitConsoleRunnerNet60Package;
+PackageDefinition NUnitConsoleRunnerNet80Package;
 PackageDefinition NUnitEnginePackage;
 PackageDefinition NUnitEngineApiPackage;
 PackageDefinition NUnitConsoleRunnerChocolateyPackage;
@@ -46,6 +47,8 @@ public void InitializePackageDefinitions(ICakeContext context)
         NetCore31Test,
         Net50Test,
         Net60Test,
+        Net70Test,
+        Net80Test,
         NetCore21PlusNetCore31Test,
         NetCore21PlusNetCore31PlusNet50PlusNet60Test
     };
@@ -71,7 +74,9 @@ public void InitializePackageDefinitions(ICakeContext context)
                 HasDirectory("tools/agents/net40").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins"),
                 HasDirectory("tools/agents/netcoreapp3.1").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
                 HasDirectory("tools/agents/net5.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
-                HasDirectory("tools/agents/net6.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins")
+                HasDirectory("tools/agents/net6.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
+                HasDirectory("tools/agents/net7.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
+                HasDirectory("tools/agents/net8.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins")
             },
             symbols: new PackageCheck[] {
                 HasDirectory("tools").WithFiles(ENGINE_PDB_FILES).AndFile("nunit3-console.pdb"),
@@ -79,10 +84,27 @@ public void InitializePackageDefinitions(ICakeContext context)
                 HasDirectory("tools/agents/net40").WithFiles(AGENT_PDB_FILES),
                 HasDirectory("tools/agents/netcoreapp3.1").WithFiles(AGENT_PDB_FILES_NETCORE),
                 HasDirectory("tools/agents/net5.0").WithFiles(AGENT_PDB_FILES_NETCORE),
-                HasDirectory("tools/agents/net6.0").WithFiles(AGENT_PDB_FILES_NETCORE)
+                HasDirectory("tools/agents/net6.0").WithFiles(AGENT_PDB_FILES_NETCORE),
+                HasDirectory("tools/agents/net7.0").WithFiles(AGENT_PDB_FILES_NETCORE),
+                HasDirectory("tools/agents/net8.0").WithFiles(AGENT_PDB_FILES_NETCORE)
             },
             executable: "tools/nunit3-console.exe",
             tests: StandardRunnerTests),
+
+        NUnitConsoleRunnerNet80Package = new NuGetPackage(
+            context: context,
+            id: "NUnit.ConsoleRunner.NetCore",
+            version: ProductVersion,
+            source: NUGET_DIR + "runners/nunit.console-runner.netcore.nuspec",
+            checks: new PackageCheck[] {
+                HasFiles("LICENSE.txt", "NOTICES.txt"),
+                HasDirectory("tools/net8.0/any").WithFiles(CONSOLE_FILES_NETCORE).AndFiles(ENGINE_FILES).AndFile("nunit.console.nuget.addins")
+            },
+            symbols: new PackageCheck[] {
+                HasDirectory("tools/net8.0/any").WithFile("nunit3-console.pdb").AndFiles(ENGINE_PDB_FILES)
+            },
+            executable: "tools/net8.0/any/nunit3-console.exe",
+            tests: NetCoreRunnerTests),
 
         NUnitConsoleRunnerNet60Package = new NuGetPackage(
             context: context,
@@ -110,7 +132,9 @@ public void InitializePackageDefinitions(ICakeContext context)
                 HasDirectory("tools/agents/net40").WithFiles(AGENT_FILES).AndFile("nunit.agent.addins"),
                 HasDirectory("tools/agents/netcoreapp3.1").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
                 HasDirectory("tools/agents/net5.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
-                HasDirectory("tools/agents/net6.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins")
+                HasDirectory("tools/agents/net6.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
+                HasDirectory("tools/agents/net7.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins"),
+                HasDirectory("tools/agents/net8.0").WithFiles(AGENT_FILES_NETCORE).AndFile("nunit.agent.addins")
             },
             executable: "tools/nunit3-console.exe",
             tests: StandardRunnerTests),
@@ -144,7 +168,9 @@ public void InitializePackageDefinitions(ICakeContext context)
                 HasDirectory("bin/agents/net20").WithFiles(AGENT_FILES).AndFiles(AGENT_PDB_FILES),
                 HasDirectory("bin/agents/net40").WithFiles(AGENT_FILES).AndFiles(AGENT_PDB_FILES),
                 HasDirectory("bin/agents/net5.0").WithFiles(AGENT_FILES_NETCORE).AndFiles(AGENT_PDB_FILES_NETCORE),
-                HasDirectory("bin/agents/net6.0").WithFiles(AGENT_FILES_NETCORE).AndFiles(AGENT_PDB_FILES_NETCORE)
+                HasDirectory("bin/agents/net6.0").WithFiles(AGENT_FILES_NETCORE).AndFiles(AGENT_PDB_FILES_NETCORE),
+                HasDirectory("bin/agents/net7.0").WithFiles(AGENT_FILES_NETCORE).AndFiles(AGENT_PDB_FILES_NETCORE),
+                HasDirectory("bin/agents/net8.0").WithFiles(AGENT_FILES_NETCORE).AndFiles(AGENT_PDB_FILES_NETCORE)
             },
             executable: "bin/net20/nunit3-console.exe",
             tests: StandardRunnerTests.Concat(new[] { NUnitProjectTest })),

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -42,6 +42,18 @@ static PackageTest Net35PlusNet40Test = new PackageTest(
     "net35/mock-assembly.dll net40/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
 
+static PackageTest Net80Test = new PackageTest(
+    "Net80Test",
+    "Run mock-assembly.dll under .NET 8.0",
+    "net8.0/mock-assembly.dll",
+    MockAssemblyExpectedResult(1));
+
+static PackageTest Net70Test = new PackageTest(
+    "Net70Test",
+    "Run mock-assembly.dll under .NET 7.0",
+    "net7.0/mock-assembly.dll",
+    MockAssemblyExpectedResult(1));
+
 static PackageTest Net60Test = new PackageTest(
     "Net60Test",
     "Run mock-assembly.dll under .NET 6.0",
@@ -87,7 +99,7 @@ static PackageTest NetCore21PlusNetCore31Test = new PackageTest(
 static PackageTest NetCore21PlusNetCore31PlusNet50PlusNet60Test = new PackageTest(
     "NetCore21PlusNetCore31PlusNet50PlusNet60Test",
     "Run four copies of mock-assembly together",
-    "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll net5.0/mock-assembly.dll net6.0/mock-assembly.dll",
+    "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll net5.0/mock-assembly.dll net6.0/mock-assembly.dll net7.0/mock-assembly.dll net8.0/mock-assembly.dll",
     MockAssemblyExpectedResult(4));
 
 static PackageTest Net40PlusNet60Test = new PackageTest(

--- a/cake/utilities.cake
+++ b/cake/utilities.cake
@@ -180,7 +180,7 @@ void RunNetCoreConsole(string testAssembly, string targetRuntime)
         "dotnet",
         new ProcessSettings
         {
-            Arguments = $"\"{NET60_CONSOLE}\" \"{assemblyPath}\" --result:{resultPath}",
+            Arguments = $"\"{NET80_CONSOLE}\" \"{assemblyPath}\" --result:{resultPath}",
             WorkingDirectory = workingDir
         });
 

--- a/choco/nunit-console-runner.nuspec
+++ b/choco/nunit-console-runner.nuspec
@@ -92,5 +92,25 @@
     <file src = "$BIN_DIR$agents/net6.0/nunit.engine.core.dll" target="tools/agents/net6.0" />
     <file src = "$BIN_DIR$agents/net6.0/testcentric.engine.metadata.dll" target="tools/agents/net6.0" />
     <file src = "nunit.agent.addins" target = "tools/agents/net6.0" />
+
+    <file src = "$BIN_DIR$agents/net7.0/nunit-agent.dll" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/nunit-agent.dll.config" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/nunit-agent.deps.json" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/nunit-agent.runtimeconfig.json" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/nunit.engine.api.dll" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/nunit.engine.api.xml" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/nunit.engine.core.dll" target="tools/agents/net7.0" />
+    <file src = "$BIN_DIR$agents/net7.0/testcentric.engine.metadata.dll" target="tools/agents/net7.0" />
+    <file src = "nunit.agent.addins" target = "tools/agents/net7.0" />
+
+    <file src = "$BIN_DIR$agents/net8.0/nunit-agent.dll" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/nunit-agent.dll.config" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/nunit-agent.deps.json" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/nunit-agent.runtimeconfig.json" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/nunit.engine.api.dll" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/nunit.engine.api.xml" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/nunit.engine.core.dll" target="tools/agents/net8.0" />
+    <file src = "$BIN_DIR$agents/net8.0/testcentric.engine.metadata.dll" target="tools/agents/net8.0" />
+    <file src = "nunit.agent.addins" target = "tools/agents/net8.0" />
   </files>
 </package>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.101",
+    "version": "8.0.100",
     "rollForward": "feature"
   }
 }

--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -93,6 +93,32 @@
     <file src="agents/net6.0/testcentric.engine.metadata.dll" target="tools/agents/net6.0" />
     <file src="../../nuget/engine/nunit.agent.addins" target="tools/agents/net6.0"/>
 
+    <file src="agents/net7.0/nunit-agent.dll" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit-agent.pdb" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit-agent.dll.config" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit-agent.deps.json" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit-agent.runtimeconfig.json" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit.engine.api.dll" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit.engine.api.pdb" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit.engine.api.xml" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit.engine.core.dll" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/nunit.engine.core.pdb" target="tools/agents/net7.0" />
+    <file src="agents/net7.0/testcentric.engine.metadata.dll" target="tools/agents/net7.0" />
+    <file src="../../nuget/engine/nunit.agent.addins" target="tools/agents/net7.0"/>
+
+    <file src="agents/net8.0/nunit-agent.dll" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit-agent.pdb" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit-agent.dll.config" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit-agent.deps.json" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit-agent.runtimeconfig.json" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit.engine.api.dll" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit.engine.api.pdb" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit.engine.api.xml" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit.engine.core.dll" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/nunit.engine.core.pdb" target="tools/agents/net8.0" />
+    <file src="agents/net8.0/testcentric.engine.metadata.dll" target="tools/agents/net8.0" />
+    <file src="../../nuget/engine/nunit.agent.addins" target="tools/agents/net8.0"/>
+
     <file src="net20/nunit3-console.exe" target="tools" />
     <file src="net20/nunit3-console.pdb" target="tools" />
     <file src="net20/nunit3-console.exe.config" target="tools" />

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RootNamespace>NUnit.ConsoleRunner.Tests</RootNamespace>
-    <TargetFrameworks>net35;net6.0</TargetFrameworks>
+    <TargetFrameworks>net35;net6.0;net8.0</TargetFrameworks>
     <NoWarn>1685</NoWarn>
     <DebugType>Full</DebugType>
   </PropertyGroup>

--- a/src/NUnitConsole/nunit3-console/OptionsUtils/Options.cs
+++ b/src/NUnitConsole/nunit3-console/OptionsUtils/Options.cs
@@ -771,7 +771,7 @@ namespace NUnit.Options
             this.option = optionName;
         }
 
-#if !PCL
+#if !PCL && !NET8_0_OR_GREATER
         protected OptionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
@@ -784,7 +784,7 @@ namespace NUnit.Options
             get { return this.option; }
         }
 
-#if !PCL
+#if !PCL && !NET8_0_OR_GREATER
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             base.GetObjectData(info, context);

--- a/src/NUnitConsole/nunit3-console/nunit3-console.csproj
+++ b/src/NUnitConsole/nunit3-console/nunit3-console.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>NUnit.ConsoleRunner</RootNamespace>
     <AssemblyName>nunit3-console</AssemblyName>
-    <TargetFrameworks>net20;net6.0</TargetFrameworks>
+    <TargetFrameworks>net20;net6.0;net8.0</TargetFrameworks>
     <RollForward>Major</RollForward>
   </PropertyGroup>
 

--- a/src/NUnitEngine/mock-assembly-x86/mock-assembly-x86.csproj
+++ b/src/NUnitEngine/mock-assembly-x86/mock-assembly-x86.csproj
@@ -7,6 +7,7 @@
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <PlatformTarget>x86</PlatformTarget>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <NuGetAudit Condition="'$(TargetFramework)'=='netcoreapp2.1'">false</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitEngine/mock-assembly/mock-assembly.csproj
+++ b/src/NUnitEngine/mock-assembly/mock-assembly.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;net40;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <NuGetAudit Condition="'$(TargetFramework)'=='netcoreapp2.1'">false</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitEngine/notest-assembly/notest-assembly.csproj
+++ b/src/NUnitEngine/notest-assembly/notest-assembly.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>notest_assembly</RootNamespace>
     <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <NuGetAudit Condition="'$(TargetFramework)'=='netcoreapp2.1'">false</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitEngine/nunit-agent/Program.cs
+++ b/src/NUnitEngine/nunit-agent/Program.cs
@@ -3,7 +3,9 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security;
 using NUnit.Common;
 using NUnit.Engine;
@@ -71,7 +73,9 @@ namespace NUnit.Agent
 
             LocateAgencyProcess(agencyPid);
 
-#if NETCOREAPP3_1
+#if NET5_0_OR_GREATER
+            log.Info($"Running {typeof(NUnitTestAgent).Assembly.GetCustomAttribute<TargetFrameworkAttribute>().FrameworkDisplayName} agent under {RuntimeInformation.FrameworkDescription}");
+#elif NETCOREAPP3_1
             log.Info($"Running .NET Core 3.1 agent under {RuntimeInformation.FrameworkDescription}");
 #elif NET40
             log.Info($"Running .NET 4.0 agent under {RuntimeFramework.CurrentFramework.DisplayName}");

--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>nunit.agent</RootNamespace>
-    <TargetFrameworks>net20;net40;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net20;net40;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>..\..\..\nunit.ico</ApplicationIcon>
     <GenerateSupportedRuntime>false</GenerateSupportedRuntime>

--- a/src/NUnitEngine/nunit.engine.core.tests/nunit.engine.core.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.core.tests/nunit.engine.core.tests.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DebugType>Full</DebugType>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <NuGetAudit Condition="'$(TargetFramework)'=='netcoreapp2.1'">false</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitEngine/nunit.engine.core.tests/nunit.engine.core.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.core.tests/nunit.engine.core.tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Core.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
+++ b/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RootNamespace>NUnit.Engine</RootNamespace>
-    <TargetFrameworks>net20;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net20;netstandard2.0;netcoreapp3.1;net5.0;net6.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);SYSLIB0011;SYSLIB0012</NoWarn><!-- TODO: Get rid of obsolete stuff -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DebugType>Full</DebugType>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <NuGetAudit Condition="'$(TargetFramework)'=='netcoreapp2.1'">false</NuGetAudit>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -127,7 +127,7 @@ namespace NUnit.Engine.Services
                     agentExtension = ".exe";
                     break;
                 case RuntimeType.NetCore:
-                    runtimeDir = major >= 6 ? "net6.0" : major == 5 ? "net5.0" : "netcoreapp3.1";
+                    runtimeDir = major >= 8 ? "net8.0" : major == 7 ? "net7.0" : major == 6 ? "net6.0" : major == 5 ? "net5.0" : "netcoreapp3.1";
                     agentName = "nunit-agent";
                     agentExtension = ".dll";
                     break;


### PR DESCRIPTION
- Use .NET 8 SDK in global.json
- Add .NET 8 target to nunit-console and nunit-engine-core
- Add .NET 8 and 7 target to nunit-agent
- Selectively disable NuGet audit to suppress errors when building for .NET Core 2.1
- Adjusted cake scripts

See #1374