### PR TITLE
Enable BinaryFormatter for nunit-agent

### DIFF
--- a/src/NUnitEngine/nunit-agent/nunit-agent.csproj
+++ b/src/NUnitEngine/nunit-agent/nunit-agent.csproj
@@ -9,6 +9,7 @@
     <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
     <OutputPath>..\..\..\bin\$(Configuration)\agents\</OutputPath>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Sets the [BinaryFormatter compatibility flag](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/binaryformatter-apis-produce-errors) to prevent crash of the agent process.