### PR TITLE
Fix path for Microsoft.Extensions.DependencyModel in nuspec

### DIFF
--- a/nuget/runners/nunit.console-runner.netcore.nuspec
+++ b/nuget/runners/nunit.console-runner.netcore.nuspec
@@ -23,7 +23,7 @@
     <tags>nunit test testing tdd runner</tags>
     <copyright>Copyright (c) 2021 Charlie Poole, Rob Prouse</copyright>
     <packageTypes>
-        <packageType name="DotnetTool" />
+      <packageType name="DotnetTool" />
     </packageTypes>
   </metadata>
   <files>
@@ -43,7 +43,7 @@
     <file src="net6.0/nunit.engine.api.pdb" target="tools/net6.0/any" />
     <file src="net6.0/nunit.engine.api.xml" target="tools/net6.0/any" />
     <file src="net6.0/testcentric.engine.metadata.dll" target="tools/net6.0/any" />
-    <file src="Microsoft.Extensions.DependencyModel.dll" target="tools/net6.0/any" />
+    <file src="net6.0/Microsoft.Extensions.DependencyModel.dll" target="tools/net6.0/any" />
     <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools/net6.0/any"/>
     <file src="../../nuget/runners/DotnetToolSettings.xml" target="tools/net6.0/any"/>
 
@@ -63,7 +63,7 @@
     <file src="net8.0/testcentric.engine.metadata.dll" target="tools/net8.0/any" />
     <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools/net8.0/any"/>
     <file src="../../nuget/runners/DotnetToolSettings.xml" target="tools/net8.0/any"/>
-    
+
     <file src="../../nunit_256.png" target="images"/>
   </files>
 </package>


### PR DESCRIPTION
As part of PR #1376, 3f854b20e4ea7e42ba7ae0d7bf81af902a6bc8fd was integrated into the `version3X` branch.  The `main` branch only includes net6.0 in the package so it copies all dependencies into the root folder and references them from there (including Microsoft.Extensions.DependencyModel.dll).

In `version3X` the package includes both net6.0 and net8.0 dependencies so the binaries are referenced from sub-folders, so when the change was merged, it was referencing `Microsoft.Extensions.DependencyModel.dll` when it should have been looking in `net6.0/Microsoft.Extensions.DependencyModel.dll`.

> This also includes two whitespace changes that were automatically fixed by VSCode when I saved the file.  They're harmless and match the style of the rest of the file, so I figured I'd just keep them.