### PR TITLE
Make the version3X build correctly

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -114,11 +114,6 @@ public void BuildSolution()
         .WithProperty("TargetFramework", "netstandard2.0")
         .WithProperty("PublishDir", BIN_DIR + "netstandard2.0"));
 
-    DisplayBanner("Publishing ENGINE TESTS Project for NETCOREAPP2.1");
-    MSBuild(ENGINE_TESTS_PROJECT, CreateMSBuildSettings("Publish")
-        .WithProperty("TargetFramework", "netcoreapp2.1")
-        .WithProperty("PublishDir", BIN_DIR + "netcoreapp2.1"));
-
     // TODO: May not be needed
     foreach (var framework in new[] { "netcoreapp3.1", "net5.0" })
     {
@@ -129,6 +124,7 @@ public void BuildSolution()
     }
 }
 
+// TODO: Test this on linux to see if changes are needed
 private void BuildEachProjectSeparately()
 {
     DotNetRestore(SOLUTION_FILE);
@@ -237,7 +233,7 @@ Task("TestNetStandard20EngineCore")
     .OnError(exception => { UnreportedErrors.Add(exception.Message); })
     .Does(() =>
     {
-        RunDotnetNUnitLiteTests(NETCORE_ENGINE_CORE_TESTS, "netcoreapp2.1");
+        RunDotnetNUnitLiteTests(NETCORE_ENGINE_CORE_TESTS, "netcoreapp3.1");
     });
 
 //////////////////////////////////////////////////////////////////////
@@ -302,7 +298,7 @@ Task("TestNetStandard20Engine")
     .OnError(exception => { UnreportedErrors.Add(exception.Message); })
     .Does(() =>
     {
-        RunDotnetNUnitLiteTests(NETCORE_ENGINE_TESTS, "netcoreapp2.1");
+        RunDotnetNUnitLiteTests(NETCORE_ENGINE_TESTS, "netcoreapp3.1");
     });
 
 //////////////////////////////////////////////////////////////////////

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -25,32 +25,21 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net40Test,
         Net40X86Test,
         Net35PlusNet40Test,
-        NetCore21Test,
         NetCore31Test,
         Net50Test,
         Net60Test,
-        NetCore21PlusNetCore31Test,
-        NetCore21PlusNetCore31PlusNet50PlusNet60Test,
+        Net50PlusNet60Test,
         Net40PlusNet60Test
     };
-
-    if (dotnetX86Available)
-    {
-        StandardRunnerTests.Add(NetCore21X86Test);
-        StandardRunnerTests.Add(NetCore31X86Test);
-    }
 
     // Tests run for the NETCORE runner package
     var NetCoreRunnerTests = new List<PackageTest>
     {
-        NetCore21Test,
         NetCore31Test,
         Net50Test,
         Net60Test,
         Net70Test,
         Net80Test,
-        NetCore21PlusNetCore31Test,
-        NetCore21PlusNetCore31PlusNet50PlusNet60Test
     };
 
     AllPackages.AddRange(new PackageDefinition[] {

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -151,7 +151,6 @@ public void InitializePackageDefinitions(ICakeContext context)
                 HasDirectory("bin/net20").WithFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit3-console.pdb").AndFiles(ENGINE_PDB_FILES),
                 HasDirectory("bin/net35").WithFiles(CONSOLE_FILES).AndFiles(ENGINE_FILES).AndFile("nunit3-console.pdb").AndFiles(ENGINE_PDB_FILES),
                 HasDirectory("bin/netstandard2.0").WithFiles(ENGINE_FILES).AndFiles(ENGINE_PDB_FILES),
-                HasDirectory("bin/netcoreapp2.1").WithFiles(ENGINE_FILES).AndFiles(ENGINE_PDB_FILES),
                 HasDirectory("bin/netcoreapp3.1").WithFiles(ENGINE_CORE_FILES).AndFiles(ENGINE_CORE_PDB_FILES),
                 //HasDirectory("bin/net5.0").WithFiles(ENGINE_FILES).AndFiles(ENGINE_PDB_FILES),
                 HasDirectory("bin/agents/net20").WithFiles(AGENT_FILES).AndFiles(AGENT_PDB_FILES),

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -72,35 +72,35 @@ static PackageTest NetCore31Test = new PackageTest(
     "netcoreapp3.1/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
-static PackageTest NetCore31X86Test = new PackageTest(
-    "NetCore31X86Test",
-    "Run mock-assembly-x86.dll under .NET Core 3.1",
-    "netcoreapp3.1/mock-assembly-x86.dll",
-    MockAssemblyExpectedResult(1));
+//static PackageTest NetCore31X86Test = new PackageTest(
+//    "NetCore31X86Test",
+//    "Run mock-assembly-x86.dll under .NET Core 3.1",
+//    "netcoreapp3.1/mock-assembly-x86.dll",
+//    MockAssemblyExpectedResult(1));
 
-static PackageTest NetCore21Test = new PackageTest(
-    "NetCore21Test",
-    "Run mock-assembly.dll targeting .NET Core 2.1",
-    "netcoreapp2.1/mock-assembly.dll",
-    MockAssemblyExpectedResult(1));
+//static PackageTest NetCore21Test = new PackageTest(
+//    "NetCore21Test",
+//    "Run mock-assembly.dll targeting .NET Core 2.1",
+//    "netcoreapp2.1/mock-assembly.dll",
+//    MockAssemblyExpectedResult(1));
 
-static PackageTest NetCore21X86Test = new PackageTest(
-    "NetCore21X86Test",
-    "Run mock-assembly-x86.dll under .NET Core 2.1",
-    "netcoreapp2.1/mock-assembly-x86.dll",
-    MockAssemblyExpectedResult(1));
+//static PackageTest NetCore21X86Test = new PackageTest(
+//    "NetCore21X86Test",
+//    "Run mock-assembly-x86.dll under .NET Core 2.1",
+//    "netcoreapp2.1/mock-assembly-x86.dll",
+//    MockAssemblyExpectedResult(1));
 
-static PackageTest NetCore21PlusNetCore31Test = new PackageTest(
-    "NetCore21PlusNetCore31Test",
-    "Run two copies of mock-assembly together",
-    "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll",
-    MockAssemblyExpectedResult(2));
+//static PackageTest NetCore21PlusNetCore31Test = new PackageTest(
+//    "NetCore21PlusNetCore31Test",
+//    "Run two copies of mock-assembly together",
+//    "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll",
+//    MockAssemblyExpectedResult(2));
 
-static PackageTest NetCore21PlusNetCore31PlusNet50PlusNet60Test = new PackageTest(
-    "NetCore21PlusNetCore31PlusNet50PlusNet60Test",
+static PackageTest Net50PlusNet60Test = new PackageTest(
+    "Net50PlusNet60Test",
     "Run four copies of mock-assembly together",
-    "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll net5.0/mock-assembly.dll net6.0/mock-assembly.dll net7.0/mock-assembly.dll net8.0/mock-assembly.dll",
-    MockAssemblyExpectedResult(4));
+    "net5.0/mock-assembly.dll net6.0/mock-assembly.dll",//" net7.0/mock-assembly.dll net8.0/mock-assembly.dll",
+    MockAssemblyExpectedResult(2));
 
 static PackageTest Net40PlusNet60Test = new PackageTest(
     "Net40PlusNet60Test",

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -72,33 +72,9 @@ static PackageTest NetCore31Test = new PackageTest(
     "netcoreapp3.1/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
-//static PackageTest NetCore31X86Test = new PackageTest(
-//    "NetCore31X86Test",
-//    "Run mock-assembly-x86.dll under .NET Core 3.1",
-//    "netcoreapp3.1/mock-assembly-x86.dll",
-//    MockAssemblyExpectedResult(1));
-
-//static PackageTest NetCore21Test = new PackageTest(
-//    "NetCore21Test",
-//    "Run mock-assembly.dll targeting .NET Core 2.1",
-//    "netcoreapp2.1/mock-assembly.dll",
-//    MockAssemblyExpectedResult(1));
-
-//static PackageTest NetCore21X86Test = new PackageTest(
-//    "NetCore21X86Test",
-//    "Run mock-assembly-x86.dll under .NET Core 2.1",
-//    "netcoreapp2.1/mock-assembly-x86.dll",
-//    MockAssemblyExpectedResult(1));
-
-//static PackageTest NetCore21PlusNetCore31Test = new PackageTest(
-//    "NetCore21PlusNetCore31Test",
-//    "Run two copies of mock-assembly together",
-//    "netcoreapp2.1/mock-assembly.dll netcoreapp3.1/mock-assembly.dll",
-//    MockAssemblyExpectedResult(2));
-
 static PackageTest Net50PlusNet60Test = new PackageTest(
     "Net50PlusNet60Test",
-    "Run four copies of mock-assembly together",
+    "Run mock-assembly under .NET 5.0 and 6.0 together",
     "net5.0/mock-assembly.dll net6.0/mock-assembly.dll",//" net7.0/mock-assembly.dll net8.0/mock-assembly.dll",
     MockAssemblyExpectedResult(2));
 

--- a/msi/nunit/engine-files.wxi
+++ b/msi/nunit/engine-files.wxi
@@ -94,9 +94,9 @@
             <Component Id="NUNIT_AGENT_NETCORE31" Location="local" Guid="21E39B4C-07E4-4C38-8F91-7030516127E2">
                 <File Id="nunit_agent_netcore31.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/agents/netcoreapp3.1/nunit-agent-netcore31.dll" />
+                      Source="$(var.InstallImage)bin/agents/netcoreapp3.1/nunit-agent.dll" />
                 <File Id="nunit_agent_netcore31.dll.config"
-                      Source="$(var.InstallImage)bin/agents/netcoreapp3.1/nunit-agent-netcore31.dll.config" />
+                      Source="$(var.InstallImage)bin/agents/netcoreapp3.1/nunit-agent.dll.config" />
                 <File Id="nunit_agent_netcore31.deps.json"
                       Source="$(var.InstallImage)bin/agents/netcoreapp3.1/nunit-agent.deps.json" />
                 <File Id="nunit_agent_netcore31.runtimeconfig.json"
@@ -122,16 +122,16 @@
             <Component Id="NUNIT_AGENT_NETCORE31_DEPENDENCY_MODEL" Location="local" Guid="6A33A615-BCD2-411C-B3A8-95BF5829C8CA">
                 <File Id="Microsoft.Extensions.DependencyModel.netcore31.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)agents/nunit-agent-netcore31/Microsoft.Extensions.DependencyModel.dll" />
+                      Source="$(var.InstallImage)bin/agents/netcoreapp3.1/Microsoft.Extensions.DependencyModel.dll" />
             </Component>
         </ComponentGroup>
         <ComponentGroup Id="NET50_AGENT" Directory="NET50_AGENT_DIR">
             <Component Id="NUNIT_AGENT_NET50" Location="local" Guid="6B5C423E-5EDB-4DD4-8B7F-626C8F4EAF06">
                 <File Id="nunit_agent_net50.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/agents/net5.0/nunit-agent-net50.dll" />
+                      Source="$(var.InstallImage)bin/agents/net5.0/nunit-agent.dll" />
                 <File Id="nunit_agent_net50.dll.config"
-                      Source="$(var.InstallImage)bin/agents/net5.0/nunit-agent-net50.dll.config" />
+                      Source="$(var.InstallImage)bin/agents/net5.0/nunit-agent.dll.config" />
                 <File Id="nunit_agent_net50.deps.json"
                       Source="$(var.InstallImage)bin/agents/net5.0/nunit-agent.deps.json" />
                 <File Id="nunit_agent_net50.runtimeconfig.json"
@@ -164,13 +164,13 @@
             <Component Id="NUNIT_AGENT_NET60" Location="local" Guid="8AFA7F03-96EA-4F80-8B79-7AFB59B67786">
                 <File Id="nunit_agent_net60.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/net6.0/nunit-agent-net60.dll" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit-agent.dll" />
                 <File Id="nunit_agent_net60.dll.config"
-                      Source="$(var.InstallImage)bin/net6.0/nunit-agent-net60.dll.config" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit-agent.dll.config" />
                 <File Id="nunit_agent_net60.deps.json"
-                      Source="$(var.InstallImage)bin/net6.0/nunit-agent.deps.json" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit-agent.deps.json" />
                 <File Id="nunit_agent_net60.runtimeconfig.json"
-                      Source="$(var.InstallImage)bin/net6.0/nunit-agent.runtimeconfig.json" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit-agent.runtimeconfig.json" />
             </Component>
             <Component Id="NUNIT_AGENT_NET60_ENGINE_API" Location="local" Guid="393F8699-4F44-479B-916D-34F506F089D1">
                 <File Id="nunit.agent.net60.engine.api.dll"

--- a/nuget/runners/nunit.console-runner.netcore.nuspec
+++ b/nuget/runners/nunit.console-runner.netcore.nuspec
@@ -43,7 +43,7 @@
     <file src="net6.0/nunit.engine.api.pdb" target="tools/net6.0/any" />
     <file src="net6.0/nunit.engine.api.xml" target="tools/net6.0/any" />
     <file src="net6.0/testcentric.engine.metadata.dll" target="tools/net6.0/any" />
-    <file src="Microsoft.Extensions.DependencyModel.dll" target="tools/net6.0/any" />
+    <file src="net6.0/Microsoft.Extensions.DependencyModel.dll" target="tools/net6.0/any" />
     <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools/net6.0/any"/>
     <file src="../../nuget/runners/DotnetToolSettings.xml" target="tools/net6.0/any"/>
 
@@ -61,6 +61,7 @@
     <file src="net8.0/nunit.engine.api.pdb" target="tools/net8.0/any" />
     <file src="net8.0/nunit.engine.api.xml" target="tools/net8.0/any" />
     <file src="net8.0/testcentric.engine.metadata.dll" target="tools/net8.0/any" />
+    <file src="net8.0/Microsoft.Extensions.DependencyModel.dll" target="tools/net8.0/any" />
     <file src="../../nuget/runners/nunit.console.nuget.addins" target="tools/net8.0/any"/>
     <file src="../../nuget/runners/DotnetToolSettings.xml" target="tools/net8.0/any"/>
     

--- a/src/NUnitEngine/nunit.engine.core.tests/Services/ExtensionManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/Services/ExtensionManagerTests.cs
@@ -153,7 +153,7 @@ namespace NUnit.Engine.Services.Tests
             var assemblyName = Path.Combine(GetSiblingDirectory("net35"), "nunit.engine.core.tests.exe");
 #else
             // Attempt to load the .NET Core 2.1 version of the extensions from the .NET 3.5 tests
-            var assemblyName = Path.Combine(GetSiblingDirectory("netcoreapp2.1"), "nunit.engine.core.tests.dll");
+            var assemblyName = Path.Combine(GetSiblingDirectory("netcoreapp3.1"), "nunit.engine.core.tests.dll");
 #endif
             Assert.That(assemblyName, Does.Exist);
             Console.WriteLine($"{assemblyName} does exist");
@@ -242,7 +242,7 @@ namespace NUnit.Engine.Services.Tests
             Assembly netFramework = typeof(ExtensionService).Assembly;
 
             var extNetStandard = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("netstandard2.0"), "nunit.engine.dll"), false);
-            var extNetCore = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("netcoreapp2.1"), "nunit.engine.tests.dll"), false);
+            var extNetCore = new ExtensionAssembly(Path.Combine(GetSiblingDirectory("netcoreapp3.1"), "nunit.engine.tests.dll"), false);
 
             yield return new TestCaseData(new FrameworkCombo(netFramework, extNetCore)).SetName("InvalidCombo(.NET Framework, .NET Core)");
 #endif

--- a/src/NUnitEngine/nunit.engine.core.tests/nunit.engine.core.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.core.tests/nunit.engine.core.tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Core.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp3.1;net5.0;net6.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>

--- a/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
+++ b/src/NUnitEngine/nunit.engine.core/nunit.engine.core.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
+++ b/src/NUnitEngine/nunit.engine.tests/nunit.engine.tests.csproj
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RootNamespace>NUnit.Engine.Tests</RootNamespace>
-    <TargetFrameworks>net35;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net35;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
@@ -29,7 +29,7 @@
     <Reference Include="System.Web" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   


### PR DESCRIPTION
As with PR #1405, which applies to branch main, this PR merely does what is needed so that the branch builds correctly in CI. As part of this, all .NET Core 2.1 builds have been removed. 