### PR TITLE
Issue 1369

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,7 +5,7 @@ build-metadata-padding: 5
 commits-since-version-source-padding: 5
 branches:
   master:
-    regex: ^(main|version3X)$
+    regex: ^(main|version4)$
     tag: dev
   release:
     tag: pre

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -110,6 +110,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cake", "cake", "{9BCA00E2-D072-424B-A6DF-5BECF719C1FB}"
 	ProjectSection(SolutionItems) = preProject
 		cake\constants.cake = cake\constants.cake
+		cake\dotnet.cake = cake\dotnet.cake
 		cake\header-check.cake = cake\header-check.cake
 		cake\package-checks.cake = cake\package-checks.cake
 		cake\package-definitions.cake = cake\package-definitions.cake
@@ -122,6 +123,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cake", "cake", "{9BCA00E2-D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "msi", "msi", "{0C0D20CE-70CD-4CEF-BE9B-AEB8A2DE9C8A}"
 	ProjectSection(SolutionItems) = preProject
+		msi\nunit-install.sln = msi\nunit-install.sln
 		msi\resources\nunit.bundle.addins = msi\resources\nunit.bundle.addins
 	EndProjectSection
 EndProject
@@ -149,6 +151,21 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{C5B7120C-190B-4C38-95CB-83F12799598D}"
 	ProjectSection(SolutionItems) = preProject
 		.config\dotnet-tools.json = .config\dotnet-tools.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nunit", "nunit", "{93E5CAF4-D5DB-4915-AF0F-908A6043E462}"
+	ProjectSection(SolutionItems) = preProject
+		msi\nunit\addin-files.wxi = msi\nunit\addin-files.wxi
+		msi\nunit\banner.bmp = msi\nunit\banner.bmp
+		msi\nunit\console-files.wxi = msi\nunit\console-files.wxi
+		msi\nunit\dialog.bmp = msi\nunit\dialog.bmp
+		msi\nunit\engine-files.wxi = msi\nunit\engine-files.wxi
+		msi\nunit\nunit.wixproj = msi\nunit\nunit.wixproj
+		msi\nunit\nunit.wxs = msi\nunit\nunit.wxs
+		msi\nunit\runner-directories.wxi = msi\nunit\runner-directories.wxi
+		msi\nunit\runner-features.wxi = msi\nunit\runner-features.wxi
+		msi\nunit\utility-files.wxi = msi\nunit\utility-files.wxi
+		msi\nunit\variables.wxi = msi\nunit\variables.wxi
 	EndProjectSection
 EndProject
 Global
@@ -235,6 +252,7 @@ Global
 		{08F8160E-E691-4F07-9F57-EA31B9736429} = {25DA12FE-6209-4524-9A37-8E51F815E198}
 		{50371E48-BEC3-4D53-BD37-F3A6149CFD0D} = {25DA12FE-6209-4524-9A37-8E51F815E198}
 		{C5B7120C-190B-4C38-95CB-83F12799598D} = {49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}
+		{93E5CAF4-D5DB-4915-AF0F-908A6043E462} = {0C0D20CE-70CD-4CEF-BE9B-AEB8A2DE9C8A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8E4FC26-5422-4C51-8BBC-D1AC0A578711}

--- a/build.cake
+++ b/build.cake
@@ -3,6 +3,7 @@ static string Configuration; Configuration = GetArgument("configuration|c", "Rel
 static bool NoPush; NoPush = HasArgument("nopush");
 
 #load cake/constants.cake
+#load cake/dotnet.cake
 #load cake/header-check.cake
 #load cake/package-checks.cake
 #load cake/test-results.cake

--- a/cake/dotnet.cake
+++ b/cake/dotnet.cake
@@ -1,0 +1,88 @@
+public class DotnetInfo
+{
+    // Experimenting with finding dotnet installs for X64 vs x86
+    // This code will end up moved into the engine as well.
+
+    private ICakeContext _context;
+    private bool _onWindows;
+
+    public DotnetInfo(ICakeContext context)
+    {
+        _context = context;
+        _onWindows = context.IsRunningOnWindows();
+
+        InstallPath = GetDotnetInstallDirectory(false);
+        X86InstallPath = GetDotnetInstallDirectory(true);
+    }
+
+    // NOTES:
+    // * We don't need an IsInstalled property because our scripts all run under dotnet.
+
+    public bool IsX86Installed => System.IO.Directory.Exists(X86InstallPath) && System.IO.File.Exists(X86Executable);
+
+    public string InstallPath { get; }
+    public string Executable => InstallPath + "dotnet.exe";
+    public List<string> Runtimes { get; }
+
+    public string X86InstallPath { get; }
+    public string X86Executable => X86InstallPath + "dotnet.exe";
+    public List<string> X86Runtimes { get; }
+
+    public void Display()
+    {
+        _context.Information($"Install Path:      {InstallPath}");
+        _context.Information($"Executable:        {Executable}");
+        _context.Information("Runtimes:");
+        foreach (string dir in System.IO.Directory.GetDirectories(System.IO.Path.Combine(InstallPath, "shared")))
+        {
+            string runtime = System.IO.Path.GetFileName(dir);
+            foreach (string dir2 in System.IO.Directory.GetDirectories(dir))
+            {
+                string version = System.IO.Path.GetFileName(dir2);
+                _context.Information($"  {runtime} {version}");
+            }
+        }
+
+        if (IsX86Installed)
+        {
+            _context.Information($"\nX86 Install Path:  {X86InstallPath}");
+            _context.Information($"X86 Executable:    {X86Executable}");
+            _context.Information("Runtimes:");
+            foreach (var dir in System.IO.Directory.GetDirectories(System.IO.Path.Combine(X86InstallPath, "shared")))
+            {
+                string runtime = System.IO.Path.GetFileName(dir);
+                foreach (string dir2 in System.IO.Directory.GetDirectories(dir))
+                {
+                    string version = System.IO.Path.GetFileName(dir2);
+                    _context.Information($"  {runtime} {version}");
+                }
+            }
+        }
+        else
+            _context.Information("\nDotnet X86 is not installed");
+    }
+
+    private string GetDotnetInstallDirectory(bool forX86 = false)
+    {
+        if (_onWindows)
+        {
+            if (forX86)
+            {
+                Microsoft.Win32.RegistryKey key =
+                    Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\dotnet\SetUp\InstalledVersions\x86\");
+                return (string)key?.GetValue("InstallLocation");
+            }
+            else
+            {
+                Microsoft.Win32.RegistryKey key =
+                    Microsoft.Win32.Registry.LocalMachine.OpenSubKey(@"SOFTWARE\dotnet\SetUp\InstalledVersions\x64\sharedHost\");
+                return (string)key?.GetValue("Path");
+            }
+        }
+        else // Assuming linux for now
+            return "/usr/shared/dotnet/";
+    }
+}
+
+// Use this task to verify that the script understands the dotnet environment
+Task("DotnetInfo").Does(() => { new DotnetInfo(Context).Display(); });

--- a/cake/package-definitions.cake
+++ b/cake/package-definitions.cake
@@ -28,6 +28,8 @@ public void InitializePackageDefinitions(ICakeContext context)
         NetCore31Test,
         Net50Test,
         Net60Test,
+        Net70Test,
+        Net80Test,
         Net50PlusNet60Test,
         Net40PlusNet60Test
     };
@@ -41,6 +43,24 @@ public void InitializePackageDefinitions(ICakeContext context)
         Net70Test,
         Net80Test,
     };
+
+    // TODO: Remove the limitation to Windows
+    if (IsRunningOnWindows() && dotnetX86Available)
+    {
+        StandardRunnerTests.Add(Net60X86Test);
+        // TODO: Make these tests run on AppVeyor
+        if (!context.BuildSystem().IsRunningOnAppVeyor)
+        {
+            StandardRunnerTests.Add(NetCore31X86Test);
+            StandardRunnerTests.Add(Net50X86Test);
+            StandardRunnerTests.Add(Net70X86Test);
+            StandardRunnerTests.Add(Net80X86Test);
+        }
+        // Currently, NetCoreRunner runs tests in process. As a result,
+        // X86 tests will work in our environment, although uses may run
+        // it as a tool using the X86 architecture.
+    }
+
 
     AllPackages.AddRange(new PackageDefinition[] {
 

--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -48,10 +48,22 @@ static PackageTest Net80Test = new PackageTest(
     "net8.0/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
+static PackageTest Net80X86Test = new PackageTest(
+    "Net80X86Test",
+    "Run mock-assembly-x86.dll under .NET 8.0",
+    "net8.0/mock-assembly-x86.dll",
+    MockAssemblyExpectedResult(1));
+
 static PackageTest Net70Test = new PackageTest(
     "Net70Test",
     "Run mock-assembly.dll under .NET 7.0",
     "net7.0/mock-assembly.dll",
+    MockAssemblyExpectedResult(1));
+
+static PackageTest Net70X86Test = new PackageTest(
+    "Net70X86Test",
+    "Run mock-assembly-x86.dll under .NET 7.0",
+    "net7.0/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net60Test = new PackageTest(
@@ -60,16 +72,34 @@ static PackageTest Net60Test = new PackageTest(
     "net6.0/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
+static PackageTest Net60X86Test = new PackageTest(
+    "Net60X86Test",
+    "Run mock-assembly-x86.dll under .NET 6.0",
+    "net6.0/mock-assembly-x86.dll --trace:Debug",
+    MockAssemblyExpectedResult(1));
+
 static PackageTest Net50Test = new PackageTest(
     "Net50Test",
     "Run mock-assembly.dll under .NET 5.0",
     "net5.0/mock-assembly.dll",
     MockAssemblyExpectedResult(1));
 
+static PackageTest Net50X86Test = new PackageTest(
+    "Net50X86Test",
+    "Run mock-assembly-x86.dll under .NET 5.0",
+    "net5.0/mock-assembly-x86.dll",
+    MockAssemblyExpectedResult(1));
+
 static PackageTest NetCore31Test = new PackageTest(
     "NetCore31Test",
     "Run mock-assembly.dll under .NET Core 3.1",
     "netcoreapp3.1/mock-assembly.dll",
+    MockAssemblyExpectedResult(1));
+
+static PackageTest NetCore31X86Test = new PackageTest(
+    "NetCore31X86Test",
+    "Run mock-assembly-x86.dll under .NET Core 3.1",
+    "netcoreapp3.1/mock-assembly-x86.dll",
     MockAssemblyExpectedResult(1));
 
 static PackageTest Net50PlusNet60Test = new PackageTest(

--- a/msi/nunit/engine-files.wxi
+++ b/msi/nunit/engine-files.wxi
@@ -49,6 +49,8 @@
             <ComponentGroupRef Id="NETCORE31_AGENT" />
             <ComponentGroupRef Id="NET50_AGENT" />
             <ComponentGroupRef Id="NET60_AGENT" />
+            <ComponentGroupRef Id="NET70_AGENT" />
+            <ComponentGroupRef Id="NET80_AGENT" />
         </ComponentGroup>
     </Fragment>
     <Fragment>
@@ -175,24 +177,94 @@
             <Component Id="NUNIT_AGENT_NET60_ENGINE_API" Location="local" Guid="393F8699-4F44-479B-916D-34F506F089D1">
                 <File Id="nunit.agent.net60.engine.api.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/net6.0/nunit.engine.api.dll" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit.engine.api.dll" />
                 <File Id="nunit.agent.net60.engine.api.xml"
-                      Source="$(var.InstallImage)bin/net6.0/nunit.engine.api.xml" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit.engine.api.xml" />
             </Component>
             <Component Id="NUNIT_AGENT_NET60_ENGINE_CORE" Location="local" Guid="583A7D7E-9046-408C-8AA1-821EFCC2A7EA">
                 <File Id="nunit.agent.net60.engine.core.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/net6.0/nunit.engine.core.dll" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/nunit.engine.core.dll" />
             </Component>
             <Component Id="NUNIT_AGENT_NET60_ENGINE_METADATA" Location="local" Guid="8F00367C-4FFD-429D-8483-D5FA6D109627">
                 <File Id="nunit.agent.net60.engine.metadata.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/net6.0/testcentric.engine.metadata.dll" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/testcentric.engine.metadata.dll" />
             </Component>
             <Component Id="NUNIT_AGENT_NET60_DEPENDENCY_MODEL" Location="local" Guid="EFD82EAE-A38E-45E0-944B-A776F7353100">
                 <File Id="Microsoft.Extensions.DependencyModel.net60.dll"
                       ProcessorArchitecture="msil"
-                      Source="$(var.InstallImage)bin/net6.0/Microsoft.Extensions.DependencyModel.dll" />
+                      Source="$(var.InstallImage)bin/agents/net6.0/Microsoft.Extensions.DependencyModel.dll" />
+            </Component>
+        </ComponentGroup>
+        <ComponentGroup Id="NET70_AGENT" Directory="NET70_AGENT_DIR">
+            <Component Id="NUNIT_AGENT_NET70" Location="local" Guid="F1B28B46-EBAE-4D3D-AFAB-9E60B0F35EDC">
+                <File Id="nunit_agent_net70.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit-agent.dll" />
+                <File Id="nunit_agent_net70.dll.config"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit-agent.dll.config" />
+                <File Id="nunit_agent_net70.deps.json"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit-agent.deps.json" />
+                <File Id="nunit_agent_net70.runtimeconfig.json"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit-agent.runtimeconfig.json" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET70_ENGINE_API" Location="local" Guid="03667196-96FA-4AE9-8A1B-6059FA520CD9">
+                <File Id="nunit.agent.net70.engine.api.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit.engine.api.dll" />
+                <File Id="nunit.agent.net70.engine.api.xml"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit.engine.api.xml" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET70_ENGINE_CORE" Location="local" Guid="1CA60508-6E99-4FD5-AE90-023EC61C2CDB">
+                <File Id="nunit.agent.net70.engine.core.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net7.0/nunit.engine.core.dll" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET70_ENGINE_METADATA" Location="local" Guid="B2BEE75C-2BCA-4D81-BA23-64F309A5B45D">
+                <File Id="nunit.agent.net70.engine.metadata.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net7.0/testcentric.engine.metadata.dll" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET70_DEPENDENCY_MODEL" Location="local" Guid="B6C3D2CF-8441-4479-8EDE-A4E76A487F63">
+                <File Id="Microsoft.Extensions.DependencyModel.net70.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net7.0/Microsoft.Extensions.DependencyModel.dll" />
+            </Component>
+        </ComponentGroup>
+        <ComponentGroup Id="NET80_AGENT" Directory="NET80_AGENT_DIR">
+            <Component Id="NUNIT_AGENT_NET80" Location="local" Guid="D8F8C2FB-E60E-455E-9C6A-B715268F3260">
+                <File Id="nunit_agent_net80.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net8.0/nunit-agent.dll" />
+                <File Id="nunit_agent_net80.dll.config"
+                      Source="$(var.InstallImage)bin/agents/net8.0/nunit-agent.dll.config" />
+                <File Id="nunit_agent_net80.deps.json"
+                      Source="$(var.InstallImage)bin/agents/net8.0/nunit-agent.deps.json" />
+                <File Id="nunit_agent_net80.runtimeconfig.json"
+                      Source="$(var.InstallImage)bin/agents/net8.0/nunit-agent.runtimeconfig.json" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET80_ENGINE_API" Location="local" Guid="74172ECE-BEE7-4961-9A6A-DA0D06120C88">
+                <File Id="nunit.agent.net80.engine.api.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net8.0/nunit.engine.api.dll" />
+                <File Id="nunit.agent.net80.engine.api.xml"
+                      Source="$(var.InstallImage)bin/net8.0/nunit.engine.api.xml" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET80_ENGINE_CORE" Location="local" Guid="A24E77FD-350C-4E6C-B467-A7877CF9D656">
+                <File Id="nunit.agent.net80.engine.core.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net8.0/nunit.engine.core.dll" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET80_ENGINE_METADATA" Location="local" Guid="CFE58B66-97D3-434D-A929-638D07F23D94">
+                <File Id="nunit.agent.net80.engine.metadata.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net8.0/testcentric.engine.metadata.dll" />
+            </Component>
+            <Component Id="NUNIT_AGENT_NET80_DEPENDENCY_MODEL" Location="local" Guid="F3B15759-D568-430E-84A2-773CB9E9BBBA">
+                <File Id="Microsoft.Extensions.DependencyModel.net80.dll"
+                      ProcessorArchitecture="msil"
+                      Source="$(var.InstallImage)bin/agents/net8.0/Microsoft.Extensions.DependencyModel.dll" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/msi/nunit/runner-directories.wxi
+++ b/msi/nunit/runner-directories.wxi
@@ -16,6 +16,8 @@
               <Directory Id="NETCORE31_AGENT_DIR" Name="netcoreapp3.1" />
               <Directory Id="NET50_AGENT_DIR" Name="net5.0" />
               <Directory Id="NET60_AGENT_DIR" Name="net6.0" />
+              <Directory Id="NET70_AGENT_DIR" Name="net7.0" />
+              <Directory Id="NET80_AGENT_DIR" Name="net8.0" />
           </Directory>
       </Directory>
     </DirectoryRef>

--- a/src/NUnitEngine/mock-assembly-x86/mock-assembly-x86.csproj
+++ b/src/NUnitEngine/mock-assembly-x86/mock-assembly-x86.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>NUnit.Tests</RootNamespace>
-    <TargetFrameworks>net35;net40;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net35;net40;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\nunit.snk</AssemblyOriginatorKeyFile>
     <PlatformTarget>x86</PlatformTarget>

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
@@ -16,8 +16,9 @@ namespace NUnit.Engine
         /// the string passed as an argument is available.
         /// </summary>
         /// <param name="framework">A string representing a framework, like 'net-4.0'</param>
+        /// <param name="x86">A flag indicating whether the X86 architecture is needed. Defaults to false.</param>
         /// <returns>True if the framework is available, false if unavailable or nonexistent</returns>
-        bool IsAvailable(string framework);
+        bool IsAvailable(string framework, bool x86);
 
         /// <summary>
         /// Selects a target runtime framework for a TestPackage based on

--- a/src/NUnitEngine/nunit.engine.core.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/RuntimeFrameworkTests.cs
@@ -30,41 +30,42 @@ namespace NUnit.Engine.Tests
             Assert.That(RuntimeFramework.CurrentFramework.ClrVersion.Build, Is.GreaterThan(0));
         }
 
-        [Test]
-        public void CurrentFrameworkMustBeAvailable()
-        {
-            var current = RuntimeFramework.CurrentFramework;
-            Console.WriteLine("Current framework is {0} ({1})", current.DisplayName, current.Id);
-            Assert.That(current.IsAvailable, "{0} not available", current);
-        }
+        // TODO: The commented tests should be in RuntimeFrameworkService Tests
+        //[Test]
+        //public void CurrentFrameworkMustBeAvailable()
+        //{
+        //    var current = RuntimeFramework.CurrentFramework;
+        //    Console.WriteLine("Current framework is {0} ({1})", current.DisplayName, current.Id);
+        //    Assert.That(current.IsAvailable, "{0} not available", current);
+        //}
 
-        [Test]
-        public void AvailableFrameworksList()
-        {
-            RuntimeFramework[] available = RuntimeFramework.AvailableFrameworks;
-            Assert.That(RuntimeFramework.AvailableFrameworks.Length, Is.GreaterThan(0) );
-            foreach (var framework in RuntimeFramework.AvailableFrameworks)
-                Console.WriteLine("Available: {0}", framework.DisplayName);
-        }
+        //[Test]
+        //public void AvailableFrameworksList()
+        //{
+        //    RuntimeFramework[] available = RuntimeFramework.AvailableFrameworks;
+        //    Assert.That(RuntimeFramework.AvailableFrameworks.Length, Is.GreaterThan(0) );
+        //    foreach (var framework in RuntimeFramework.AvailableFrameworks)
+        //        Console.WriteLine("Available: {0}", framework.DisplayName);
+        //}
 
-        [Test]
-        public void AvailableFrameworksList_IncludesCurrentFramework()
-        {
-            foreach (var framework in RuntimeFramework.AvailableFrameworks)
-                if (RuntimeFramework.CurrentFramework.Supports(framework))
-                    return;
+        //[Test]
+        //public void AvailableFrameworksList_IncludesCurrentFramework()
+        //{
+        //    foreach (var framework in RuntimeFramework.AvailableFrameworks)
+        //        if (RuntimeFramework.CurrentFramework.Supports(framework))
+        //            return;
 
-            Assert.Fail("CurrentFramework not listed as available");
-        }
+        //    Assert.Fail("CurrentFramework not listed as available");
+        //}
 
-        [Test]
-        public void AvailableFrameworksList_ContainsNoDuplicates()
-        {
-            var names = new List<string>();
-            foreach (var framework in RuntimeFramework.AvailableFrameworks)
-                names.Add(framework.DisplayName);
-            Assert.That(names, Is.Unique);
-        }
+        //[Test]
+        //public void AvailableFrameworksList_ContainsNoDuplicates()
+        //{
+        //    var names = new List<string>();
+        //    foreach (var framework in RuntimeFramework.AvailableFrameworks)
+        //        names.Add(framework.DisplayName);
+        //    Assert.That(names, Is.Unique);
+        //}
 
         [TestCaseSource(nameof(frameworkData))]
         public void CanCreateUsingFrameworkVersion(FrameworkData data)

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
@@ -23,13 +23,17 @@ namespace NUnit.Engine.Internal
         private readonly DependencyContext _dependencyContext;
         private readonly AssemblyLoadContext _loadContext;
 
-        private static readonly string INSTALL_DIR = GetDotNetInstallDirectory();
-        private static readonly string WINDOWS_DESKTOP_DIR = Path.Combine(INSTALL_DIR, "shared", "Microsoft.WindowsDesktop.App");
-        private static readonly string ASP_NET_CORE_DIR = Path.Combine(INSTALL_DIR, "shared", "Microsoft.AspNetCore.App");
+        private static readonly string INSTALL_DIR;
+        private static readonly string WINDOWS_DESKTOP_DIR;
+        private static readonly string ASP_NET_CORE_DIR;
         private static readonly List<string> AdditionalFrameworkDirectories;
 
         static TestAssemblyResolver()
         {
+            INSTALL_DIR = GetDotNetInstallDirectory();
+            WINDOWS_DESKTOP_DIR = Path.Combine(INSTALL_DIR, "shared", "Microsoft.WindowsDesktop.App");
+            ASP_NET_CORE_DIR = Path.Combine(INSTALL_DIR, "shared", "Microsoft.AspNetCore.App");
+
             AdditionalFrameworkDirectories = new List<string>();
             if (Directory.Exists(WINDOWS_DESKTOP_DIR))
                 AdditionalFrameworkDirectories.Add(WINDOWS_DESKTOP_DIR);
@@ -169,10 +173,16 @@ namespace NUnit.Engine.Internal
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // Running on Windows so use registry
-                RegistryKey key = Environment.Is64BitProcess
-                    ? Registry.LocalMachine.OpenSubKey(@"Software\dotnet\SetUp\InstalledVersions\x64\sharedHost\")
-                    : Registry.LocalMachine.OpenSubKey(@"Software\dotnet\SetUp\InstalledVersions\x86\sharedHost\");
-                return (string)key?.GetValue("Path");
+                if (Environment.Is64BitProcess)
+                {
+                    RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\dotnet\SetUp\InstalledVersions\x64\sharedHost\");
+                    return (string)key?.GetValue("Path");
+                }
+                else
+                {
+                    RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\dotnet\SetUp\InstalledVersions\x86\");
+                    return (string)key?.GetValue("InstallLocation");
+                }
             }
             else
                 return "/usr/shared/dotnet/";

--- a/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/Fakes/FakeRuntimeService.cs
@@ -4,7 +4,7 @@ namespace NUnit.Engine.Services.Tests.Fakes
 {
     public class FakeRuntimeService : FakeService, IRuntimeFrameworkService
     {
-        bool IRuntimeFrameworkService.IsAvailable(string framework)
+        bool IRuntimeFrameworkService.IsAvailable(string framework, bool x86)
         {
             return true;
         }

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -2,11 +2,8 @@
 
 #if NETFRAMEWORK
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using NUnit.Framework;
-using NUnit.Tests;
 
 namespace NUnit.Engine.Services.Tests
 {
@@ -76,8 +73,6 @@ namespace NUnit.Engine.Services.Tests
         public void RuntimeFrameworkIsSetForSubpackages()
         {
             //Runtime Service verifies that requested frameworks are available, therefore this test can only currently be run on platforms with both CLR v2 and v4 available
-            Assume.That(new RuntimeFramework(RuntimeType.Net, new Version("2.0.50727")), Has.Property(nameof(RuntimeFramework.IsAvailable)).True);
-            Assume.That(new RuntimeFramework(RuntimeType.Net, new Version("4.0.30319")), Has.Property(nameof(RuntimeFramework.IsAvailable)).True);
 
             var topLevelPackage = new TestPackage(new [] {"a.dll", "b.dll"});
 

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -376,8 +376,10 @@ namespace NUnit.Engine.Runners
             {
                 // Check requested framework is actually available
                 var runtimeService = _services.GetService<IRuntimeFrameworkService>();
-                if (!runtimeService.IsAvailable(frameworkSetting))
-                    throw new NUnitEngineException(string.Format("The requested framework {0} is unknown or not available.", frameworkSetting));
+                if (!runtimeService.IsAvailable(frameworkSetting, runAsX86))
+                    throw new NUnitEngineException(runAsX86
+                        ? $"The requested framework {frameworkSetting} is unknown or not available for X86."
+                        : $"The requested framework {frameworkSetting} is unknown or not available.");
 
                 // If running in process, check requested framework is compatible
                 if (runningInProcess)

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/MonoRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/MonoRuntimeLocator.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#if NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace NUnit.Engine.Services.RuntimeLocators
+{
+    public static class MonoRuntimeLocator
+    {
+        public static IEnumerable<RuntimeFramework> FindRuntimes()
+        {
+            var current = RuntimeFramework.CurrentFramework;
+            if (current.Runtime == RuntimeType.Mono)
+            {
+                yield return current;
+            }
+            //else
+            //if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            //    FindBestMonoFrameworkOnWindows();
+        }
+
+        //private static void UseCurrentMonoFramework()
+        //{
+        //    Debug.Assert(CurrentFramework.Runtime == Runtime.Mono && MonoPrefix != null && MonoVersion != null);
+
+        //    // Multiple profiles are no longer supported with Mono 4.0
+        //    if (RuntimeFramework.MonoVersion.Major < 4 && FindAllMonoProfiles() > 0)
+        //        return;
+
+        //    // If Mono 4.0+ or no profiles found, just use current runtime
+        //    _availableFrameworks.Add(RuntimeFramework.CurrentFramework);
+        //}
+
+        //private static void FindBestMonoFrameworkOnWindows()
+        //{
+        //    // First, look for recent frameworks that use the Software\Mono Key
+        //    RegistryKey key = Registry.LocalMachine.OpenSubKey(@"Software\Mono");
+
+        //    if (key != null && (int)key.GetValue("Installed", 0) == 1)
+        //    {
+        //        string version = key.GetValue("Version") as string;
+        //        MonoPrefix = key.GetValue("SdkInstallRoot") as string;
+
+        //        if (version != null)
+        //        {
+        //            MonoVersion = new Version(version);
+        //            AddMonoFramework(new Version(4, 5), null);
+        //            return;
+        //        }
+        //    }
+
+        //    // Some later 3.x Mono releases didn't use the registry
+        //    // so check in standard location for them.
+        //    if (Directory.Exists(DEFAULT_WINDOWS_MONO_DIR))
+        //    {
+        //        MonoPrefix = DEFAULT_WINDOWS_MONO_DIR;
+        //        AddMonoFramework(new Version(4, 5), null);
+        //        return;
+        //    }
+
+        //    // Look in the Software\Novell key for older versions
+        //    key = Registry.LocalMachine.OpenSubKey(@"Software\Novell\Mono");
+        //    if (key != null)
+        //    {
+        //        string version = key.GetValue("DefaultCLR") as string;
+        //        if (version != null)
+        //        {
+        //            RegistryKey subKey = key.OpenSubKey(version);
+        //            if (subKey != null)
+        //            {
+        //                MonoPrefix = subKey.GetValue("SdkInstallRoot") as string;
+        //                MonoVersion = new Version(version);
+
+        //                FindAllMonoProfiles();
+        //            }
+        //        }
+        //    }
+        //}
+
+        //private static int FindAllMonoProfiles()
+        //{
+        //    int count = 0;
+
+        //    if (MonoPrefix != null)
+        //    {
+        //        if (File.Exists(Path.Combine(MonoPrefix, "lib/mono/1.0/mscorlib.dll")))
+        //        {
+        //            AddMonoFramework(new Version(1, 1, 4322), "1.0");
+        //            count++;
+        //        }
+
+        //        if (File.Exists(Path.Combine(MonoPrefix, "lib/mono/2.0/mscorlib.dll")))
+        //        {
+        //            AddMonoFramework(new Version(2, 0), "2.0");
+        //            count++;
+        //        }
+
+        //        if (Directory.Exists(Path.Combine(MonoPrefix, "lib/mono/3.5")))
+        //        {
+        //            AddMonoFramework(new Version(3, 5), "3.5");
+        //            count++;
+        //        }
+
+        //        if (File.Exists(Path.Combine(MonoPrefix, "lib/mono/4.0/mscorlib.dll")))
+        //        {
+        //            AddMonoFramework(new Version(4, 0), "4.0");
+        //            count++;
+        //        }
+
+        //        if (File.Exists(Path.Combine(MonoPrefix, "lib/mono/4.5/mscorlib.dll")))
+        //        {
+        //            AddMonoFramework(new Version(4, 5), "4.5");
+        //            count++;
+        //        }
+        //    }
+
+        //    return count;
+        //}
+
+        //private static void AddMonoFramework(Version frameworkVersion, string profile)
+        //{
+        //    var framework = new RuntimeFramework(Runtime.Mono, frameworkVersion)
+        //    {
+        //        Profile = profile,
+        //        DisplayName = MonoVersion != null
+        //            ? "Mono " + MonoVersion.ToString() + " - " + profile + " Profile"
+        //            : "Mono - " + profile + " Profile"
+        //    };
+
+        //    _availableFrameworks.Add(framework);
+        //}
+    }
+}
+#endif

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetCoreRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetCoreRuntimeLocator.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#if NETFRAMEWORK
+using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace NUnit.Engine.Services.RuntimeLocators
+{
+    public static class NetCoreRuntimeLocator
+    {
+        public static IEnumerable<RuntimeFramework> FindRuntimes()
+        {
+            List<Version> alreadyFound = new List<Version>();
+
+            foreach (string dirName in GetRuntimeDirectories())
+            {
+                Version newVersion;
+                if (TryGetVersionFromString(dirName, out newVersion) && !alreadyFound.Contains(newVersion))
+                {
+                    alreadyFound.Add(newVersion);
+                    yield return new RuntimeFramework(RuntimeType.NetCore, newVersion);
+                }
+            }
+
+            foreach (string line in GetRuntimeList())
+            {
+                Version newVersion;
+                if (TryGetVersionFromString(line, out newVersion) && !alreadyFound.Contains(newVersion))
+                {
+                    alreadyFound.Add(newVersion);
+                    yield return new RuntimeFramework(RuntimeType.NetCore, newVersion);
+                }
+            }
+        }
+
+        private static IEnumerable<string> GetRuntimeDirectories()
+        {
+            string installDir = GetDotNetInstallDirectory();
+
+            if (installDir != null && Directory.Exists(installDir) &&
+                File.Exists(Path.Combine(installDir, "dotnet.exe")))
+            {
+                string runtimeDir = Path.Combine(installDir, Path.Combine("shared", "Microsoft.NETCore.App"));
+                if (Directory.Exists(runtimeDir))
+                    foreach (var dir in new DirectoryInfo(runtimeDir).GetDirectories())
+                        yield return dir.Name;
+            }
+        }
+
+        private static IEnumerable<string> GetRuntimeList()
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    Arguments = "--list-runtimes",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true
+                }
+            };
+
+            try
+            {
+                process.Start();
+            }
+            catch (Exception)
+            {
+                // Failed to start dotnet command. Assume no versions are installed and just r eturn just return
+                yield break;
+            }
+
+            const string PREFIX = "Microsoft.NETCore.App ";
+            const int VERSION_START = 22;
+
+            while (!process.StandardOutput.EndOfStream)
+            {
+                var line = process.StandardOutput.ReadLine();
+                if (line.StartsWith(PREFIX))
+                    yield return line.Substring(VERSION_START);
+            }
+        }
+
+        private static bool TryGetVersionFromString(string text, out Version newVersion)
+        {
+            const string VERSION_CHARS = ".0123456789";
+
+            int len = 0;
+            foreach (char c in text)
+            {
+                if (VERSION_CHARS.IndexOf(c) >= 0)
+                    len++;
+                else
+                    break;
+            }
+
+            try
+            {
+                var fullVersion = new Version(text.Substring(0, len));
+                newVersion = new Version(fullVersion.Major, fullVersion.Minor);
+                return true;
+            }
+            catch
+            {
+                newVersion = new Version();
+                return false;
+            }
+        }
+
+        internal static string GetDotNetInstallDirectory()
+        {
+            if (Path.DirectorySeparatorChar == '\\')
+            {
+                RegistryKey key =
+                    Registry.LocalMachine.OpenSubKey(@"Software\dotnet\SetUp\InstalledVersions\x64\sharedHost\");
+                return (string)key?.GetValue("Path");
+            }
+            else
+                return "/usr/shared/dotnet/";
+        }
+    }
+}
+#endif

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetCoreRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetCoreRuntimeLocator.cs
@@ -11,11 +11,11 @@ namespace NUnit.Engine.Services.RuntimeLocators
 {
     public static class NetCoreRuntimeLocator
     {
-        public static IEnumerable<RuntimeFramework> FindRuntimes()
+        public static IEnumerable<RuntimeFramework> FindRuntimes(bool x86)
         {
             List<Version> alreadyFound = new List<Version>();
 
-            foreach (string dirName in GetRuntimeDirectories())
+            foreach (string dirName in GetRuntimeDirectories(x86))
             {
                 Version newVersion;
                 if (TryGetVersionFromString(dirName, out newVersion) && !alreadyFound.Contains(newVersion))
@@ -36,9 +36,9 @@ namespace NUnit.Engine.Services.RuntimeLocators
             }
         }
 
-        private static IEnumerable<string> GetRuntimeDirectories()
+        private static IEnumerable<string> GetRuntimeDirectories(bool x86)
         {
-            string installDir = GetDotNetInstallDirectory();
+            string installDir = GetDotNetInstallDirectory(x86);
 
             if (installDir != null && Directory.Exists(installDir) &&
                 File.Exists(Path.Combine(installDir, "dotnet.exe")))
@@ -111,13 +111,22 @@ namespace NUnit.Engine.Services.RuntimeLocators
             }
         }
 
-        internal static string GetDotNetInstallDirectory()
+        internal static string GetDotNetInstallDirectory(bool x86)
         {
             if (Path.DirectorySeparatorChar == '\\')
             {
-                RegistryKey key =
-                    Registry.LocalMachine.OpenSubKey(@"Software\dotnet\SetUp\InstalledVersions\x64\sharedHost\");
-                return (string)key?.GetValue("Path");
+                if (x86)
+                {
+                    RegistryKey key =
+                        Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\dotnet\SetUp\InstalledVersions\x86\");
+                    return (string)key?.GetValue("InstallLocation");
+                }
+                else
+                {
+                    RegistryKey key =
+                        Registry.LocalMachine.OpenSubKey(@"SOFTWARE\dotnet\SetUp\InstalledVersions\x64\sharedHost\");
+                    return (string)key?.GetValue("Path");
+                }
             }
             else
                 return "/usr/shared/dotnet/";

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetFxRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetFxRuntimeLocator.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#if NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using Microsoft.Win32;
+
+namespace NUnit.Engine.Services.RuntimeLocators
+{
+    public static class NetFxRuntimeLocator
+    {
+        // Note: this method cannot be generalized past V4, because (a)  it has
+        // specific code for detecting .NET 4.5 and (b) we don't know what
+        // microsoft will do in the future
+        public static IEnumerable<RuntimeFramework> FindRuntimes()
+        {
+            // Handle Version 1.0, using a different registry key
+            foreach (var framework in FindExtremelyOldDotNetFrameworkVersions())
+                yield return framework;
+
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\NET Framework Setup\NDP");
+            if (key != null)
+            {
+                foreach (string name in key.GetSubKeyNames())
+                {
+                    if (name.StartsWith("v") && name != "v4.0") // v4.0 is a duplicate, legacy key
+                    {
+                        var versionKey = key.OpenSubKey(name);
+                        if (versionKey == null) continue;
+
+                        if (name.StartsWith("v4", StringComparison.Ordinal))
+                        {
+                            // Version 4 and 4.5
+                            foreach (var framework in FindDotNetFourFrameworkVersions(versionKey))
+                            {
+                                yield return framework;
+                            }
+                        }
+                        else if (CheckInstallDword(versionKey))
+                        {
+                            // Versions 1.1, 2.0, 3.0 and 3.5 are possible here
+                            yield return new RuntimeFramework(RuntimeType.Net, new Version(name.Substring(1, 3)));
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<RuntimeFramework> FindExtremelyOldDotNetFrameworkVersions()
+        {
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\.NETFramework\policy\v1.0");
+            if (key == null)
+                yield break;
+
+            foreach (var build in key.GetValueNames())
+                yield return new RuntimeFramework(RuntimeType.Net, new Version("1.0." + build));
+        }
+
+        private struct MinimumRelease
+        {
+            public readonly int Release;
+            public readonly Version Version;
+
+            public MinimumRelease(int release, Version version)
+            {
+                Release = release;
+                Version = version;
+            }
+        }
+
+        private static readonly MinimumRelease[] ReleaseTable = new MinimumRelease[]
+        {
+            new MinimumRelease(378389, new Version(4, 5)),
+            new MinimumRelease(378675, new Version(4, 5, 1)),
+            new MinimumRelease(379893, new Version(4, 5, 2)),
+            new MinimumRelease(393295, new Version(4, 6)),
+            new MinimumRelease(394254, new Version(4, 6, 1)),
+            new MinimumRelease(394802, new Version(4, 6, 2)),
+            new MinimumRelease(460798, new Version(4, 7)),
+            new MinimumRelease(461308, new Version(4, 7, 1)),
+            new MinimumRelease(461808, new Version(4, 7, 2)),
+            new MinimumRelease(528040, new Version(4, 8))
+        };
+
+        private static IEnumerable<RuntimeFramework> FindDotNetFourFrameworkVersions(RegistryKey versionKey)
+        {
+            foreach (string profile in new string[] { "Full", "Client" })
+            {
+                var profileKey = versionKey.OpenSubKey(profile);
+                if (profileKey == null) continue;
+
+                if (CheckInstallDword(profileKey))
+                {
+                    yield return new RuntimeFramework(RuntimeType.Net, new Version(4, 0), profile);
+
+                    var release = (int)profileKey.GetValue("Release", 0);
+                    foreach (var entry in ReleaseTable)
+                        if (release >= entry.Release)
+                            yield return new RuntimeFramework(RuntimeType.Net, entry.Version);
+
+
+                    yield break;     //If full profile found don't check for client profile
+                }
+            }
+        }
+
+        private static bool CheckInstallDword(RegistryKey key)
+        {
+            return ((int)key.GetValue("Install", 0) == 1);
+        }
+    }
+}
+#endif

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -55,15 +55,18 @@ namespace NUnit.Engine.Services
             // Target Runtime must be specified by this point
             string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");
             Guard.OperationValid(runtimeSetting.Length > 0, "LaunchAgentProcess called with no runtime specified");
+            bool runAsX86 = package.GetSetting(EnginePackageSettings.RunAsX86, false);
 
             // If target runtime is not available, something went wrong earlier.
             // We list all available frameworks to use in debugging.
             var targetRuntime = RuntimeFramework.Parse(runtimeSetting);
-            if (!_runtimeService.IsAvailable(targetRuntime.Id))
+            if (!_runtimeService.IsAvailable(targetRuntime.Id, runAsX86))
             {
-                string msg = $"The {targetRuntime} framework is not available.\r\nAvailable frameworks:";
+                string msg = $"The {targetRuntime} framework is not available for X86={runAsX86}.\r\nAvailable frameworks:";
                 // HACK
-                foreach (var runtime in ((RuntimeFrameworkService)_runtimeService).AvailableRuntimes)
+                var service = _runtimeService as RuntimeFrameworkService;
+                var availableRuntimes = runAsX86 ? service.AvailableX86Runtimes : service.AvailableRuntimes;
+                foreach (var runtime in availableRuntimes)
                     msg += $" {runtime}";
                 throw new ArgumentException(msg);
             }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -62,7 +62,8 @@ namespace NUnit.Engine.Services
             if (!_runtimeService.IsAvailable(targetRuntime.Id))
             {
                 string msg = $"The {targetRuntime} framework is not available.\r\nAvailable frameworks:";
-                foreach (var runtime in RuntimeFramework.AvailableFrameworks)
+                // HACK
+                foreach (var runtime in ((RuntimeFrameworkService)_runtimeService).AvailableRuntimes)
                     msg += $" {runtime}";
                 throw new ArgumentException(msg);
             }


### PR DESCRIPTION
Fixes https://github.com/nunit/nunit-console/issues/1369 in main branch (already fixed in version4 branch)

Includes a preliminary refactoring to move logic to determine available runtimes from the RuntimeFramework class to the RuntimeFrameworkService class.

The fix applies to all packages containing the standard console runner but not to the NetCore runner. That runner currently only executes tests in process so it must be run under an X86 version of dotnet in order to run X86 tests.