### PR TITLE
Switch cake to build with DotNetBuild instead of MSBuild

### DIFF
--- a/.github/workflows/NUnitConsoleAndEngine.CI.yml
+++ b/.github/workflows/NUnitConsoleAndEngine.CI.yml
@@ -1,118 +1,84 @@
 ﻿name: NUnitConsoleAndEngine.CI
 
 on:
-  push:
-    branches:
-      - main
-      - release
-      - version3x
   pull_request:
-  
+    branches-ignore:
+      - "azure-*"
+    paths-ignore:
+      - "*.txt"
+      - "*.md"
+
 env:
   DOTNET_NOLOGO: true                     # Disable the .NET logo
   DOTNET_CLI_TELEMETRY_OPTOUT: true       # Disable sending .NET CLI telemetry  
 
 jobs:
-  build-windows:
-    name: Windows Build
-    runs-on: windows-latest
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            testRunName: Windows
+          - os: ubuntu-latest
+            testRunName: Linux
+          - os: macos-14
+            testRunName: Linux
+      fail-fast: false
+
+    env:
+      MYGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
     steps:
-    - name: ⤵️ Checkout Source
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: ⤵️ Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: 🛠️ Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        # global-json-file: global.json
-        dotnet-version: |
-          2.1.x
-          3.1.x
-          5.0.x
-          8.0.100
+      - name: 🛠️ Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          # global-json-file: global.json
+          dotnet-version: |
+            2.1.x
+            3.1.x
+            6.0.x
+            8.0.100
 
-        
-    - name: 🛠️ Install dotnet tools
-      run: dotnet tool restore
+      - name: 🔧 Install dotnet tools
+        run: dotnet tool restore
 
-    - name: 🔨 Build and Test
-      run: dotnet tool run dotnet-cake --target=Test --test-run-name=Windows --configuration=Release
-      # If you need to get more verbose logging, add the following to the dotnet-cake above:  --verbosity=diagnostic
+      - name: 🍰 Run cake
+        shell: pwsh
+        # If you need to get more verbose logging, add the following to the dotnet-cake above:  --verbosity=diagnostic
+        run: dotnet cake --target=Test --test-run-name=${{ matrix.testRunName }} --configuration=Release
 
-# Wait with this until package errors (tests following packaging) are all fixed
-    # - name: 📦 Package
-    #   run: dotnet tool run dotnet-cake --target=Package
+      - name: 🪵 Upload build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: NUnitConsoleLogs
+          # This path is defined in build-settings.cake
+          path: "build/*.binlog"
+          if-no-files-found: error
 
-    # - name: 💾 Upload build artifacts
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: Package
-    #     path: package
+      # Wait with this until package errors (tests following packaging) are all fixed
+      # - name: 📦 Package
+      #   run: dotnet tool run dotnet-cake --target=Package
 
-    # - name: 💾 Upload test results
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: Test results (Windows)
-    #     path: test-results
-    #   # Use always() to always run this step to publish test results when there are test failures
-    #   if: ${{ always() }}
+      # - name: 💾 Upload build artifacts
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: Package
+      #     path: package
 
-  # build-linux:
-  #   name: Linux Build
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #   - name: ⤵️ Checkout Source
-  #     uses: actions/checkout@v4
-
-  #   - name: 🛠️ Setup .NET
-  #     uses: actions/setup-dotnet@v4
-  #     with:
-  #       global-json-file: global.json
-
-  #   - name: 🛠️ Install F#
-  #     run: sudo apt-get install fsharp
-
-  #   - name: 🛠️ Install dotnet tools
-  #     run: dotnet tool restore
-
-  #   - name: 🔨 Build and Test
-  #     run: dotnet tool run dotnet-cake --target=Test --test-run-name=Linux --configuration=Release
-
-  #   - name: 💾 Upload test results
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: Test results (Linux)
-  #       path: test-results
-  #     # Use always() to always run this step to publish test results when there are test failures
-  #     if: ${{ always() }}
-
-  # build-macos:
-  #   name: MacOS Build
-  #   runs-on: macos-14
-
-  #   steps:
-  #   - name: ⤵️ Checkout Source
-  #     uses: actions/checkout@v4
-
-  #   - name: 🛠️ Setup .NET
-  #     uses: actions/setup-dotnet@v4
-  #     with:
-  #       global-json-file: global.json
-  #       dotnet-version: 6.x
-
-  #   - name: 🛠️ Install dotnet tools
-  #     run: dotnet tool restore
-
-  #   - name: 🔨 Build and Test
-  #     run: dotnet tool run dotnet-cake --target=Test --test-run-name=Linux --configuration=Release
-
-  #   - name: 💾 Upload test results
-  #     uses: actions/upload-artifact@v4
-  #     with:
-  #       name: Test results (macOS)
-  #       path: test-results
-  #     # Use always() to always run this step to publish test results when there are test failures
-  #     if: ${{ always() }}
+      - name: 💾 Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "Test results (${{ matrix.testRunName }})"
+          path: test-results

--- a/cake/build-settings.cake
+++ b/cake/build-settings.cake
@@ -17,9 +17,6 @@ public static class BuildSettings
         string[] validConfigurations = null,
         string githubOwner = "NUnit",
 
-		bool msbuildAllowPreviewVersion = false,
-		Verbosity msbuildVerbosity = Verbosity.Minimal,
-
         string unitTests = null, // Defaults to "**/*.tests.dll|**/*.tests.exe" (case insensitive)
         UnitTestRunner unitTestRunner = null, // If not set, NUnitLite is used
         string unitTestArguments = null
@@ -187,14 +184,21 @@ public static class BuildSettings
 
     // Building
 	public static string[] ValidConfigurations { get; set; }
-	public static bool MSBuildAllowPreviewVersion { get; set; }
-	public static Verbosity MSBuildVerbosity { get; set; }
-	public static MSBuildSettings MSBuildSettings => new MSBuildSettings {
-		Verbosity = MSBuildVerbosity,
-		Configuration = Configuration,
-		PlatformTarget = PlatformTarget.MSIL,
-		AllowPreviewVersion = MSBuildAllowPreviewVersion
-	};
+    public static DotNetBuildSettings DotNetBuildSettings => new DotNetBuildSettings
+    {
+        Configuration = Configuration,
+        NoRestore = true,
+        Verbosity = DotNetVerbosity.Minimal,
+        MSBuildSettings = new DotNetMSBuildSettings
+        {
+            BinaryLogger = new MSBuildBinaryLoggerSettings
+            {
+                Enabled = true,
+                FileName = "build/NUnitConsole.binlog",
+                Imports = MSBuildBinaryLoggerImports.Embed
+            }
+        }.WithProperty("Version", BuildSettings.PackageVersion)
+    };
 
 	// File Header Checks
 	public static bool SuppressHeaderCheck { get; private set; }

--- a/cake/task-definitions.cake
+++ b/cake/task-definitions.cake
@@ -59,7 +59,8 @@ BuildTasks.RestoreTask = Task("Restore")
 		NuGetRestore(BuildSettings.SolutionFile, new NuGetRestoreSettings() {
 		    Source = new string[]	{ 
                 "https://www.nuget.org/api/v2",
-                "https://www.myget.org/F/nunit/api/v2" }
+                "https://www.myget.org/F/nunit/api/v2" },
+            Verbosity = NuGetVerbosity.Quiet
         });
 	});
 
@@ -71,7 +72,7 @@ BuildTasks.BuildTask = Task("Build")
 	.IsDependentOn("CheckHeaders")
 	.Description("Build the solution")
 	.Does(() =>	{
-		MSBuild(BuildSettings.SolutionFile, BuildSettings.MSBuildSettings.WithProperty("Version", BuildSettings.PackageVersion));
+        DotNetBuild(BuildSettings.SolutionFile, BuildSettings.DotNetBuildSettings);
 	});
 
 BuildTasks.UnitTestTask = Task("Test")

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-    <package id="Cake" version="1.3.0" />
-</packages>


### PR DESCRIPTION
# Switch to using DotNetBuild action instead of MSBuild.
- NoRestore is specified because we have an explicit step to restore already, this should speed up builds a bit.
- Removed unused parameters from BuildSettings.Initialize (set defaults on BuildSettings directly, they can be overridden if necessary.
- Move .WithProperty("Version"...) inside BuildSettings property because it's recreating the settiings object on each call anyway, so it's unnecessary to have the caller do it.

# Enable binary logs
Binary logs contain more information and are significantly smaller than corresponding text logs.  This is especially helpful for CI builds where the reduced output makes it easier to figure out what's going on when looking at live logs, but still enables detailed debugging after the fact.
- Verbosity is set to Minimial for Build
- Verbosity is set to Quiet for Restore