### PR TITLE
Reorganize assembly resolution; fix error loading WindowsBase.dll

### DIFF
--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyLoadContext.cs
@@ -15,14 +15,12 @@ namespace NUnit.Engine.Internal
     {
         private static readonly Logger log = InternalTrace.GetLogger(typeof(TestAssemblyLoadContext));
 
-        private readonly string _testAssemblyPath;
         private readonly string _basePath;
         private readonly TestAssemblyResolver _resolver;
         private readonly System.Runtime.Loader.AssemblyDependencyResolver _runtimeResolver;
 
         public TestAssemblyLoadContext(string testAssemblyPath)
         {
-            _testAssemblyPath = testAssemblyPath;
             _resolver = new TestAssemblyResolver(this, testAssemblyPath);
             _basePath = Path.GetDirectoryName(testAssemblyPath);
             _runtimeResolver = new AssemblyDependencyResolver(testAssemblyPath);

--- a/src/TestData/wpf-test/WpfTest.cs
+++ b/src/TestData/wpf-test/WpfTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
+using System.Windows;
 using System.Windows.Controls;
 using NUnit.Framework;
 
@@ -8,19 +9,24 @@ using NUnit.Framework;
 namespace Test1
 {
     [TestFixture]
-    public class WPFTest
+    public class WPFTest : IWeakEventListener
     {
         [Test]
-        public void WithoutFramework()
+        public void AssertPass()
         {
             Assert.Pass();
         }
 
-        [Test]
-        public void WithFramework()
+        [Test, Apartment(System.Threading.ApartmentState.STA)]
+        public void CreateCheckBox()
         {
-            //CheckBox checkbox;
+            CheckBox checkbox;
+            checkbox = new CheckBox();
+        }
 
+        public bool ReceiveWeakEvent(Type managerType, object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
This PR fixes #1466, which is caused by loading the wrong copy of `WindowsBase.dll`, the copy that's part of `Microsoft.NetCore.App` rather than the one from `Microsoft.WindowsDesktop.App`.

In order to resolve it, I did a great deal of refactoring in `TestAssemblyResolver`. We were using four main strategies to locate assemblies in a fixed order. I've now changed the structure as follows:

1. The strategies are now formal, using the Strategy pattern.
2. I added some heuristics to decide on the order to apply the strategies to each test assembly. For example, if the test assembly directly references either a Windows Forms or a WPF assembly, we check the `Microsoft.WindowsDesktop.App` directory first. 

I view this as a start. In the future, we may want to get self-diagnostic reporting of how often each strategy is used. We may  want to subdivide the strategies further or add new ones. We'll almost certainly want to look at efficiency.

So I'd like to get comments on this PR about the usefulness of the new structure for those future purposes in addition to the normal review of the bug fix. I've asked @veleek to do the primary review as he has worked in this area but anyone on the @nunit team is welcome to review as well.