### PR TITLE
Upgrade to use C# 11

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputPath>..\..\..\bin\$(Configuration)\</OutputPath>  
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>7</LangVersion>
+    <LangVersion>11</LangVersion>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
     <Company>NUnit Software</Company>
     <Copyright>Copyright (c) 2022 Charlie Poole, Rob Prouse</Copyright>

--- a/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
+++ b/src/NUnitConsole/nunit3-console.tests/nunit3-console.tests.csproj
@@ -23,8 +23,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)'!='net462'">
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
-    <!--<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />-->
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Fixes #1479 by upgrading the C# language level to 11 without making use of any new features yet.