### PR TITLE
Set `AppContext.BaseDirectory` when running under .NET 8.0

### DIFF
--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -142,7 +142,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "notest-assembly", "src\Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfApp", "src\TestData\WpfApp\WpfApp.csproj", "{6B550F25-1CA5-4F3E-B631-1ECCD4CB94E4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InvalidTestNames", "src\TestData\InvalidTestNames\InvalidTestNames.csproj", "{58E18ACC-1F7E-4395-817E-E7EF943E0C77}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InvalidTestNames", "src\TestData\InvalidTestNames\InvalidTestNames.csproj", "{58E18ACC-1F7E-4395-817E-E7EF943E0C77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppContextTest", "src\TestData\AppContextTest\AppContextTest.csproj", "{E43A3E4B-B050-471B-B43C-0DF60FD44376}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -218,6 +220,10 @@ Global
 		{58E18ACC-1F7E-4395-817E-E7EF943E0C77}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58E18ACC-1F7E-4395-817E-E7EF943E0C77}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58E18ACC-1F7E-4395-817E-E7EF943E0C77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E43A3E4B-B050-471B-B43C-0DF60FD44376}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E43A3E4B-B050-471B-B43C-0DF60FD44376}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E43A3E4B-B050-471B-B43C-0DF60FD44376}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E43A3E4B-B050-471B-B43C-0DF60FD44376}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -251,6 +257,7 @@ Global
 		{81E63A90-3191-4E99-92FF-01F9B1D3E3C5} = {2ECE1CFB-9436-4149-B7E4-1FB1786FDE9F}
 		{6B550F25-1CA5-4F3E-B631-1ECCD4CB94E4} = {2ECE1CFB-9436-4149-B7E4-1FB1786FDE9F}
 		{58E18ACC-1F7E-4395-817E-E7EF943E0C77} = {2ECE1CFB-9436-4149-B7E4-1FB1786FDE9F}
+		{E43A3E4B-B050-471B-B43C-0DF60FD44376} = {2ECE1CFB-9436-4149-B7E4-1FB1786FDE9F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8E4FC26-5422-4C51-8BBC-D1AC0A578711}

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -250,7 +250,9 @@ StandardRunnerTests.Add(new PackageTest(
     MockAssemblySolutionResult,
     KnownExtensions.VSProjectLoader.SetVersion("3.9.0")));
 
-// Special Cases
+//////////////////////////////////////////////////////////////////////
+// SPECIAL CASES
+//////////////////////////////////////////////////////////////////////
 
 StandardRunnerTests.Add(new PackageTest(
     1, "InvalidTestNameTest_Net462",
@@ -286,4 +288,13 @@ AddToBothLists(new PackageTest(
         {
             new ExpectedAssemblyResult("InvalidTestNames.dll", "netcore-8.0")
         }
+    }));
+
+StandardRunnerTests.Add(new PackageTest(
+    1, "AppContextBaseDirectory_NET80",
+    "Test Setting the BaseDirectory to match test assembly location under .NET 8.0",
+    "testdata/net8.0/AppContextTest.dll",
+    new ExpectedResult("Passed")
+    {
+        Assemblies = new ExpectedAssemblyResult[] { new ExpectedAssemblyResult("AppContextTest.dll", "netcore-8.0") }
     }));

--- a/src/NUnitEngine/nunit.engine.core.tests/AppContextTest.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/AppContextTest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Core.Tests
+{
+    public class AppContextTest
+    {
+        [Test]
+        public void VerifyBasePath()
+        {
+            var thisAssembly = GetType().Assembly;
+            var expectedPath = Path.GetDirectoryName(GetType().Assembly.Location);
+
+            Assert.That(AppContext.BaseDirectory, Is.SamePath(expectedPath));
+        }
+    }
+}

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyLoadContext.cs
@@ -24,6 +24,9 @@ namespace NUnit.Engine.Internal
             _resolver = new TestAssemblyResolver(this, testAssemblyPath);
             _basePath = Path.GetDirectoryName(testAssemblyPath);
             _runtimeResolver = new AssemblyDependencyResolver(testAssemblyPath);
+#if NET8_0_OR_GREATER
+            AppContext.SetData("APP_CONTEXT_BASE_DIRECTORY", _basePath);
+#endif
         }
 
         protected override Assembly Load(AssemblyName name)
@@ -36,7 +39,6 @@ namespace NUnit.Engine.Internal
                 log.Info("Assembly {0} ({1}) is loaded using default base.Load()", name, GetAssemblyLocationInfo(loadedAssembly));
                 return loadedAssembly;
             }
-
 
             var runtimeResolverPath = _runtimeResolver.ResolveAssemblyToPath(name);
             if (string.IsNullOrEmpty(runtimeResolverPath) == false &&

--- a/src/TestData/AppContextTest/AppContextTest.cs
+++ b/src/TestData/AppContextTest/AppContextTest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.IO;
+using NUnit.Framework;
+
+namespace NUnit.Engine.Core.Tests
+{
+    public class AppContextTest
+    {
+        [Test]
+        public void VerifyBasePath()
+        {
+            var thisAssembly = GetType().Assembly;
+            var expectedPath = Path.GetDirectoryName(GetType().Assembly.Location);
+
+            Assert.That(AppContext.BaseDirectory, Is.SamePath(expectedPath));
+        }
+    }
+}

--- a/src/TestData/AppContextTest/AppContextTest.csproj
+++ b/src/TestData/AppContextTest/AppContextTest.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
+    <OutputPath>..\..\..\bin\$(Configuration)\testdata\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="nunit" Version="3.14.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
+    <PackageReference Include="nunit" Version="4.2.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #1488 at least with respect to the standard Runner. We need a .NET 8.0 runner before the same approach can be taken for .NET Core.