### PR TITLE
Fix exception thrown when parsing test names

### DIFF
--- a/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Xml;
 using NUnit.Framework;
+using System;
+using System.Xml;
 
 namespace NUnit.Engine.Tests
 {
@@ -40,6 +38,7 @@ namespace NUnit.Engine.Tests
         [TestCase("test='My.Test.Fixture.Method(\"abc\\'s\")'", "<test>My.Test.Fixture.Method(&quot;abc&apos;s&quot;)</test>")]
         [TestCase("test='My.Test.Fixture.Method(\"x&y&z\")'", "<test>My.Test.Fixture.Method(&quot;x&amp;y&amp;z&quot;)</test>")]
         [TestCase("test='My.Test.Fixture.Method(\"<xyz>\")'", "<test>My.Test.Fixture.Method(&quot;&lt;xyz&gt;&quot;)</test>")]
+        [TestCase("test=='Issue1510.TestSomething(Option1,\"ABC\")'", "<test>Issue1510.TestSomething(Option1,&quot;ABC&quot;)</test>")]
         [TestCase("cat==Urgent && test=='My.Tests'", "<and><cat>Urgent</cat><test>My.Tests</test></and>")]
         [TestCase("cat==Urgent and test=='My.Tests'", "<and><cat>Urgent</cat><test>My.Tests</test></and>")]
         [TestCase("cat==Urgent || test=='My.Tests'", "<or><cat>Urgent</cat><test>My.Tests</test></or>")]

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestSelectionParserTests.cs
@@ -2,6 +2,8 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Xml;
 
 namespace NUnit.Engine.Tests
@@ -16,45 +18,17 @@ namespace NUnit.Engine.Tests
             _parser = new TestSelectionParser();
         }
 
-        [TestCase("cat=Urgent", "<cat>Urgent</cat>")]
-        [TestCase("cat==Urgent", "<cat>Urgent</cat>")]
-        [TestCase("cat!=Urgent", "<not><cat>Urgent</cat></not>")]
-        [TestCase("cat =~ Urgent", "<cat re='1'>Urgent</cat>")]
-        [TestCase("cat !~ Urgent", "<not><cat re='1'>Urgent</cat></not>")]
-        [TestCase("cat = Urgent || cat = High", "<or><cat>Urgent</cat><cat>High</cat></or>")]
-        [TestCase("Priority == High", "<prop name='Priority'>High</prop>")]
-        [TestCase("Priority != Urgent", "<not><prop name='Priority'>Urgent</prop></not>")]
-        [TestCase("Author =~ Jones", "<prop name='Author' re='1'>Jones</prop>")]
-        [TestCase("Author !~ Jones", "<not><prop name='Author' re='1'>Jones</prop></not>")]
-        [TestCase("name='SomeTest'", "<name>SomeTest</name>")]
-        [TestCase("method=TestMethod", "<method>TestMethod</method>")]
-        [TestCase("method=Test1||method=Test2||method=Test3", "<or><method>Test1</method><method>Test2</method><method>Test3</method></or>")]
-        [TestCase("namespace=Foo", "<namespace>Foo</namespace>")]
-        [TestCase("namespace=Foo.Bar", "<namespace>Foo.Bar</namespace>")]
-        [TestCase("namespace=Foo||namespace=Bar", "<or><namespace>Foo</namespace><namespace>Bar</namespace></or>")]
-        [TestCase("namespace=Foo.Bar||namespace=Bar.Baz", "<or><namespace>Foo.Bar</namespace><namespace>Bar.Baz</namespace></or>")]
-        [TestCase("test='My.Test.Fixture.Method(42)'", "<test>My.Test.Fixture.Method(42)</test>")]
-        [TestCase("test='My.Test.Fixture.Method(\"xyz\")'", "<test>My.Test.Fixture.Method(&quot;xyz&quot;)</test>")]
-        [TestCase("test='My.Test.Fixture.Method(\"abc\\'s\")'", "<test>My.Test.Fixture.Method(&quot;abc&apos;s&quot;)</test>")]
-        [TestCase("test='My.Test.Fixture.Method(\"x&y&z\")'", "<test>My.Test.Fixture.Method(&quot;x&amp;y&amp;z&quot;)</test>")]
-        [TestCase("test='My.Test.Fixture.Method(\"<xyz>\")'", "<test>My.Test.Fixture.Method(&quot;&lt;xyz&gt;&quot;)</test>")]
-        [TestCase("test=='Issue1510.TestSomething(Option1,\"ABC\")'", "<test>Issue1510.TestSomething(Option1,&quot;ABC&quot;)</test>")]
-        [TestCase("cat==Urgent && test=='My.Tests'", "<and><cat>Urgent</cat><test>My.Tests</test></and>")]
-        [TestCase("cat==Urgent and test=='My.Tests'", "<and><cat>Urgent</cat><test>My.Tests</test></and>")]
-        [TestCase("cat==Urgent || test=='My.Tests'", "<or><cat>Urgent</cat><test>My.Tests</test></or>")]
-        [TestCase("cat==Urgent or test=='My.Tests'", "<or><cat>Urgent</cat><test>My.Tests</test></or>")]
-        [TestCase("cat==Urgent || test=='My.Tests' && cat == high", "<or><cat>Urgent</cat><and><test>My.Tests</test><cat>high</cat></and></or>")]
-        [TestCase("cat==Urgent && test=='My.Tests' || cat == high", "<or><and><cat>Urgent</cat><test>My.Tests</test></and><cat>high</cat></or>")]
-        [TestCase("cat==Urgent && (test=='My.Tests' || cat == high)", "<and><cat>Urgent</cat><or><test>My.Tests</test><cat>high</cat></or></and>")]
-        [TestCase("cat==Urgent && !(test=='My.Tests' || cat == high)", "<and><cat>Urgent</cat><not><or><test>My.Tests</test><cat>high</cat></or></not></and>")]
-        [TestCase("!(test!='My.Tests')", "<not><not><test>My.Tests</test></not></not>")]
-        [TestCase("!(cat!=Urgent)", "<not><not><cat>Urgent</cat></not></not>")]
+        [TestCaseSource(nameof(UniqueOutputs))]
+        public void AllOutputsAreValidXml(string output)
+        {
+            XmlDocument doc = new XmlDocument();
+            Assert.DoesNotThrow(() => doc.LoadXml(output));
+        }
+
+        [TestCaseSource(nameof(ParserTestCases))]
         public void TestParser(string input, string output)
         {
             Assert.That(_parser.Parse(input), Is.EqualTo(output));
-
-            XmlDocument doc = new XmlDocument();
-            Assert.DoesNotThrow(() => doc.LoadXml(output));
         }
 
         [TestCase(null, typeof(ArgumentNullException))]
@@ -64,6 +38,85 @@ namespace NUnit.Engine.Tests
         public void TestParser_InvalidInput(string input, Type type)
         {
             Assert.That(() => _parser.Parse(input), Throws.TypeOf(type));
+        }
+
+        private static readonly TestCaseData[] ParserTestCases = new[]
+        {
+            // Category Filter
+            new TestCaseData("cat=Urgent", "<cat>Urgent</cat>"),
+            new TestCaseData("cat=/Urgent/", "<cat>Urgent</cat>"),
+            new TestCaseData("cat='Urgent'", "<cat>Urgent</cat>"),
+            new TestCaseData("cat==Urgent", "<cat>Urgent</cat>"),
+            new TestCaseData("cat!=Urgent", "<not><cat>Urgent</cat></not>"),
+            new TestCaseData("cat =~ Urgent", "<cat re='1'>Urgent</cat>"),
+            new TestCaseData("cat !~ Urgent", "<not><cat re='1'>Urgent</cat></not>"),
+            // Property Filter
+            new TestCaseData("Priority == High", "<prop name='Priority'>High</prop>"),
+            new TestCaseData("Priority != Urgent", "<not><prop name='Priority'>Urgent</prop></not>"),
+            new TestCaseData("Author =~ Jones", "<prop name='Author' re='1'>Jones</prop>"),
+            new TestCaseData("Author !~ Jones", "<not><prop name='Author' re='1'>Jones</prop></not>"),
+            // Name Filter
+            new TestCaseData("name='SomeTest'", "<name>SomeTest</name>"),
+            // Method Filter
+            new TestCaseData("method=TestMethod", "<method>TestMethod</method>"),
+            new TestCaseData("method=Test1||method=Test2||method=Test3", "<or><method>Test1</method><method>Test2</method><method>Test3</method></or>"),
+            // Namespace Filter
+            new TestCaseData("namespace=Foo", "<namespace>Foo</namespace>"),
+            new TestCaseData("namespace=Foo.Bar", "<namespace>Foo.Bar</namespace>"),
+            new TestCaseData("namespace=Foo||namespace=Bar", "<or><namespace>Foo</namespace><namespace>Bar</namespace></or>"),
+            new TestCaseData("namespace=Foo.Bar||namespace=Bar.Baz", "<or><namespace>Foo.Bar</namespace><namespace>Bar.Baz</namespace></or>"),
+            // Test Filter
+            new TestCaseData("test='My.Test.Fixture.Method(42)'", "<test>My.Test.Fixture.Method(42)</test>"),
+            new TestCaseData("test='My.Test.Fixture.Method(\"xyz\")'", "<test>My.Test.Fixture.Method(&quot;xyz&quot;)</test>"),
+            new TestCaseData("test='My.Test.Fixture.Method(\"abc\\'s\")'", "<test>My.Test.Fixture.Method(&quot;abc&apos;s&quot;)</test>"),
+            new TestCaseData("test='My.Test.Fixture.Method(\"x&y&z\")'", "<test>My.Test.Fixture.Method(&quot;x&amp;y&amp;z&quot;)</test>"),
+            new TestCaseData("test='My.Test.Fixture.Method(\"<xyz>\")'", "<test>My.Test.Fixture.Method(&quot;&lt;xyz&gt;&quot;)</test>"),
+            new TestCaseData("test=='Issue1510.TestSomething ( Option1 , \"ABC\" ) '", "<test>Issue1510.TestSomething(Option1,&quot;ABC&quot;)</test>"),
+            new TestCaseData("test=='Issue1510.TestSomething ( Option1 , \"A B C\" ) '", "<test>Issue1510.TestSomething(Option1,&quot;A B C&quot;)</test>"),
+            new TestCaseData("test=/My.Test.Fixture.Method(42)/", "<test>My.Test.Fixture.Method(42)</test>"),
+            new TestCaseData("test=/My.Test.Fixture.Method(\"xyz\")/", "<test>My.Test.Fixture.Method(&quot;xyz&quot;)</test>"),
+            new TestCaseData("test=/My.Test.Fixture.Method(\"abc\\'s\")/", "<test>My.Test.Fixture.Method(&quot;abc&apos;s&quot;)</test>"),
+            new TestCaseData("test=/My.Test.Fixture.Method(\"x&y&z\")/", "<test>My.Test.Fixture.Method(&quot;x&amp;y&amp;z&quot;)</test>"),
+            new TestCaseData("test=/My.Test.Fixture.Method(\"<xyz>\")/", "<test>My.Test.Fixture.Method(&quot;&lt;xyz&gt;&quot;)</test>"),
+            new TestCaseData("test==/Issue1510.TestSomething ( Option1 , \"ABC\" ) /", "<test>Issue1510.TestSomething(Option1,&quot;ABC&quot;)</test>"),
+            new TestCaseData("test==/Issue1510.TestSomething ( Option1 , \"A B C\" ) /", "<test>Issue1510.TestSomething(Option1,&quot;A B C&quot;)</test>"),
+            new TestCaseData("test=My.Test.Fixture.Method(42)", "<test>My.Test.Fixture.Method(42)</test>"),
+            new TestCaseData("test=My.Test.Fixture.Method(\"xyz\")", "<test>My.Test.Fixture.Method(&quot;xyz&quot;)</test>"),
+            new TestCaseData("test=My.Test.Fixture.Method(\"abc\\'s\")", "<test>My.Test.Fixture.Method(&quot;abc&apos;s&quot;)</test>"),
+            new TestCaseData("test=My.Test.Fixture.Method(\"x&y&z\")", "<test>My.Test.Fixture.Method(&quot;x&amp;y&amp;z&quot;)</test>"),
+            new TestCaseData("test=My.Test.Fixture.Method(\"<xyz>\")", "<test>My.Test.Fixture.Method(&quot;&lt;xyz&gt;&quot;)</test>"),
+            new TestCaseData("test==Issue1510.TestSomething ( Option1 , \"ABC\" ) ", "<test>Issue1510.TestSomething(Option1,&quot;ABC&quot;)</test>"),
+            new TestCaseData("test==Issue1510.TestSomething ( Option1 , \"A B C\" ) ", "<test>Issue1510.TestSomething(Option1,&quot;A B C&quot;)</test>"),
+            // And Filter
+            new TestCaseData("cat==Urgent && test=='My.Tests'", "<and><cat>Urgent</cat><test>My.Tests</test></and>"),
+            new TestCaseData("cat==Urgent and test=='My.Tests'", "<and><cat>Urgent</cat><test>My.Tests</test></and>"),
+            // Or Filter
+            new TestCaseData("cat==Urgent || test=='My.Tests'", "<or><cat>Urgent</cat><test>My.Tests</test></or>"),
+            new TestCaseData("cat==Urgent or test=='My.Tests'", "<or><cat>Urgent</cat><test>My.Tests</test></or>"),
+            // Mixed And Filter with Or Filter
+            new TestCaseData("cat = Urgent || cat = High", "<or><cat>Urgent</cat><cat>High</cat></or>"),
+            new TestCaseData("cat==Urgent || test=='My.Tests' && cat == high", "<or><cat>Urgent</cat><and><test>My.Tests</test><cat>high</cat></and></or>"),
+            new TestCaseData("cat==Urgent && test=='My.Tests' || cat == high", "<or><and><cat>Urgent</cat><test>My.Tests</test></and><cat>high</cat></or>"),
+            new TestCaseData("cat==Urgent && (test=='My.Tests' || cat == high)", "<and><cat>Urgent</cat><or><test>My.Tests</test><cat>high</cat></or></and>"),
+            new TestCaseData("cat==Urgent && !(test=='My.Tests' || cat == high)", "<and><cat>Urgent</cat><not><or><test>My.Tests</test><cat>high</cat></or></not></and>"),
+            // Not Filter
+            new TestCaseData("!(test!='My.Tests')", "<not><not><test>My.Tests</test></not></not>"),
+            new TestCaseData("!(cat!=Urgent)", "<not><not><cat>Urgent</cat></not></not>")
+        };
+
+        private static IEnumerable<string> UniqueOutputs()
+        {
+            List<string> alreadyReturned = new List<string>();
+
+            foreach (var testCase in ParserTestCases) 
+            {
+                var output = testCase.Arguments[1] as string;
+                if (!alreadyReturned.Contains(output))
+                {
+                    alreadyReturned.Add(output);
+                    yield return output;
+                }
+            }
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using NUnit.Framework;
 
 namespace NUnit.Engine.Tests
@@ -72,6 +69,19 @@ namespace NUnit.Engine.Tests
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.String, "string at start")));
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.String, "may contain \" char")));
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.String, "string at end")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Eof)));
+        }
+
+        [Test]
+        public void TestNameWithParameters()
+        {
+            var tokenizer = new Tokenizer("test==Issue1510.TestSomething(Option1,\"ABC\")");
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "test")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "==")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "Issue1510.TestSomething")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "(")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "Option1,\"ABC\"")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, ")")));
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Eof)));
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
@@ -75,13 +75,10 @@ namespace NUnit.Engine.Tests
         [Test]
         public void TestNameWithParameters()
         {
-            var tokenizer = new Tokenizer("test==Issue1510.TestSomething(Option1,\"ABC\")");
+            var tokenizer = new Tokenizer("test=='Issue1510.TestSomething(Option1,\"ABC\")'");
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "test")));
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "==")));
-            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "Issue1510.TestSomething")));
-            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "(")));
-            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "Option1,\"ABC\"")));
-            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, ")")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.String, "Issue1510.TestSomething(Option1,\"ABC\")")));
             Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Eof)));
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TokenizerTests.cs
@@ -43,6 +43,40 @@ namespace NUnit.Engine.Tests
         }
 
         [Test]
+        public void WordsWithSpecialCharacters()
+        {
+            var tokenizer = new Tokenizer("word_with_underscores word-with-dashes word.with.dots");
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "word_with_underscores")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "word-with-dashes")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "word.with.dots")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Eof)));
+        }
+
+        private const string WORD_BREAK_CHARS = "=!()&| \t,";
+        [Test]
+        public void WordBreakCharacters()
+        {
+            var tokenizer = new Tokenizer("word1==word2!=word3 func(arg1, arg2) this&&that||both");
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "word1")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "==")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "word2")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "!=")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "word3")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "func")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "(")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "arg1")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, ",")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "arg2")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, ")")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "this")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "&&")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "that")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Symbol, "||")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Word, "both")));
+            Assert.That(tokenizer.NextToken(), Is.EqualTo(new Token(TokenKind.Eof)));
+        }
+
+        [Test]
         public void StringWithDoubleQuotes()
         {
             var tokenizer = new Tokenizer("\"string at start\" \"may contain ' char\" \"string at end\"");

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -83,7 +83,7 @@ namespace NUnit.Engine
         private int _index;
 
         private const char EOF_CHAR = '\0';
-        private const string WORD_BREAK_CHARS = "=!()&|";
+        private const string WORD_BREAK_CHARS = "=!()&| \t,";
         private readonly string[] DOUBLE_CHAR_SYMBOLS = new string[] { "==", "=~", "!=", "!~", "&&", "||" };
 
         private Token _lookahead;
@@ -130,6 +130,7 @@ namespace NUnit.Engine
                 // Single char symbols
                 case '(':
                 case ')':
+                case ',':
                     GetChar();
                     return new Token(TokenKind.Symbol, ch) { Pos = pos };
 


### PR DESCRIPTION
Fixes #1510 Replaces PR #1513

@stevenaw @mikkelbu @OsirisTerje 
I'd appreciate if one of you who commented on the issue would review this. Thanks to @stevenaw for the tests.

This is a somewhat adhoc change but one we will have to live with for a while unless we want to make substantial changes to how we process arguments. I suggest reading my comments on #1504.

Absent a rewrite, I've added fixups to deal with two situations:
1. Quoted test names using `'` or `/`, which needed fixing so that blanks are ignored outside of quotes.
2. Unquoted test names, including those quoted using `"`, which is removed by `cmd.exe`. In this case, I combined a series of tokens to create a new one.

The new code is no longer sensitive to white space outside of quoted argument strings.