### PR TITLE
Ensure Loggers use late bound `TraceLevel` and `Writer`.

### DIFF
--- a/src/NUnitEngine/nunit.engine.core.tests/Internal/Logging/LoggingTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/Internal/Logging/LoggingTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.IO;
-using NUnit.Engine.Internal;
 using NUnit.Framework;
 
 namespace NUnit.Engine.Internal.Logging
@@ -16,7 +15,7 @@ namespace NUnit.Engine.Internal.Logging
             [ValueSource(nameof(LEVELS))] InternalTraceLevel msgLevel)
         {
             var writer = new StringWriter();
-            var logger = new Logger("MyLogger", logLevel, writer);
+            var logger = new Logger("MyLogger", () => logLevel, () => writer);
 
             Assert.That(logger.TraceLevel, Is.EqualTo(logLevel));
 

--- a/src/NUnitEngine/nunit.engine.core/Internal/Logging/InternalTrace.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/Logging/InternalTrace.cs
@@ -42,15 +42,12 @@ namespace NUnit.Engine.Internal
             {
                 DefaultTraceLevel = level;
 
-                if (_traceWriter == null)
-                {
-                    // We create the trace writer even if tracing is off, because
-                    // individual loggers are able to override the default level.
-                    _traceWriter = new InternalTraceWriter(logName);
+                // We create the trace writer even if tracing is off, because
+                // individual loggers are able to override the default level.
+                _traceWriter = new InternalTraceWriter(logName);
 
-                    if (DefaultTraceLevel > InternalTraceLevel.Off)
-                        _traceWriter.WriteLine("InternalTrace: Initializing at level {0}", DefaultTraceLevel);
-                }
+                if (DefaultTraceLevel > InternalTraceLevel.Off)
+                    _traceWriter.WriteLine("InternalTrace: Initializing at level {0}", DefaultTraceLevel);
 
                 Initialized = true;
             }
@@ -63,7 +60,7 @@ namespace NUnit.Engine.Internal
         /// </summary>
         public static Logger GetLogger(string name, InternalTraceLevel level)
         {
-            return new Logger(name, level, _traceWriter);
+            return new Logger(name, () => level, () => _traceWriter);
         }
 
         /// <summary>
@@ -79,7 +76,7 @@ namespace NUnit.Engine.Internal
         /// </summary>
         public static Logger GetLogger(string name)
         {
-            return new Logger(name, DefaultTraceLevel, _traceWriter);
+            return new Logger(name, () => DefaultTraceLevel, () => _traceWriter);
         }
 
         /// <summary>
@@ -87,7 +84,7 @@ namespace NUnit.Engine.Internal
         /// </summary>
         public static Logger GetLogger(Type type)
         {
-            return GetLogger(type.FullName, DefaultTraceLevel);
+            return GetLogger(type.FullName);
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.core/Internal/Logging/InternalTraceWriter.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/Logging/InternalTraceWriter.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 using System.IO;
+using NUnit.Common;
 
 namespace NUnit.Engine.Internal
 {
@@ -30,6 +31,8 @@ namespace NUnit.Engine.Internal
         /// <param name="writer"></param>
         public InternalTraceWriter(TextWriter writer)
         {
+            Guard.ArgumentNotNull(writer, nameof(writer));
+
             _writer = writer;
         }
 
@@ -62,7 +65,7 @@ namespace NUnit.Engine.Internal
         {
             lock (_myLock)
             {
-                base.Write(value);
+                _writer.Write(value);
             }
         }
 
@@ -102,8 +105,7 @@ namespace NUnit.Engine.Internal
         /// </summary>
         public override void Flush()
         {
-            if ( _writer != null )
-                _writer.Flush();
+            _writer.Flush();
         }
     }
 }


### PR DESCRIPTION
Fixes #1586