### PR TITLE
Move all color console display to nunit.common for reuse

### DIFF
--- a/src/NUnitCommon/nunit.common/TextDisplay/ColorConsole.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ColorConsole.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     /// <summary>
     /// Sets the console color in the constructor and resets it in the dispose

--- a/src/NUnitCommon/nunit.common/TextDisplay/ColorConsoleWriter.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ColorConsoleWriter.cs
@@ -2,7 +2,7 @@
 
 using System;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     public class ColorConsoleWriter : ExtendedTextWrapper
     {

--- a/src/NUnitCommon/nunit.common/TextDisplay/ColorStyle.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ColorStyle.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     /// <summary>
     /// ColorStyle enumerates the various styles used in the console display

--- a/src/NUnitCommon/nunit.common/TextDisplay/ExtendedTextWrapper.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ExtendedTextWrapper.cs
@@ -3,7 +3,7 @@
 using System.IO;
 using System.Text;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     /// <summary>
     /// ExtendedTextWrapper wraps a TextWriter and makes it

--- a/src/NUnitCommon/nunit.common/TextDisplay/ExtendedTextWriter.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ExtendedTextWriter.cs
@@ -2,7 +2,7 @@
 
 using System.IO;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     /// <summary>
     /// ExtendedTextWriter extends the TextWriter abstract class 

--- a/src/NUnitConsole/nunit4-console.tests/BadFileTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/BadFileTests.cs
@@ -7,6 +7,7 @@ using NUnit.Engine;
 using NUnit.Engine.Runners;
 using NUnit.Engine.Services;
 using NUnit.Framework;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-console.tests/ColorConsoleTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ColorConsoleTests.cs
@@ -3,10 +3,8 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
-    using Utilities;
-
     [TestFixture, Parallelizable(ParallelScope.None)]
     public class ColorConsoleTests
     {

--- a/src/NUnitConsole/nunit4-console.tests/ColorStyleTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ColorStyleTests.cs
@@ -3,7 +3,7 @@
 using System;
 using NUnit.Framework;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     [TestFixture]
     public class ColorStyleTests

--- a/src/NUnitConsole/nunit4-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ConsoleRunnerTests.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 using NSubstitute;
-using NUnit.ConsoleRunner;
 using NUnit.ConsoleRunner.Options;
 using NUnit.Engine;
 using NUnit.Engine.Extensibility;
 using NUnit.Engine.Services;
 using NUnit.Framework;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-console.tests/ExtendedTextWrapperTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ExtendedTextWrapperTests.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Text;
 using NUnit.Framework;
 
-namespace NUnit.ConsoleRunner
+namespace NUnit.TextDisplay
 {
     public class ExtendedTextWrapperTests
     {

--- a/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
@@ -10,6 +10,7 @@ using NUnit.Engine;
 using NUnit.Framework;
 using NUnit.Framework.Api;
 using NUnit.TestData.Assemblies;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-console.tests/TestEventHandlerTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/TestEventHandlerTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Text;
 using NUnit.Framework;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -9,6 +9,7 @@ using NUnit.ConsoleRunner.Options;
 using NUnit.Engine;
 using NUnit.Engine.Extensibility;
 using NUnit.Extensibility;
+using NUnit.TextDisplay;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/NUnitConsole/nunit4-console/ConsoleTestResult.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleTestResult.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Xml;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-console/Program.cs
+++ b/src/NUnitConsole/nunit4-console/Program.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using NUnit.Engine;
+using NUnit.TextDisplay;
 
 using NUnit.ConsoleRunner.Options;
 

--- a/src/NUnitConsole/nunit4-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit4-console/ResultReporter.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Xml;
 using NUnit.ConsoleRunner.Options;
-using NUnit.ConsoleRunner.Utilities;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit4-console/TestEventHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Xml;
 using NUnit.Engine;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-netcore-console/Program.cs
+++ b/src/NUnitConsole/nunit4-netcore-console/Program.cs
@@ -7,9 +7,9 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using NUnit.Engine;
-
 using NUnit.ConsoleRunner.Options;
+using NUnit.Engine;
+using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {

--- a/src/NUnitConsole/nunit4-netcore-console/nunit4-netcore-console.csproj
+++ b/src/NUnitConsole/nunit4-netcore-console/nunit4-netcore-console.csproj
@@ -41,14 +41,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\nunit4-console\ColorConsole.cs" Link="ColorConsole.cs" />
-    <Compile Include="..\nunit4-console\ColorConsoleWriter.cs" Link="ColorConsoleWriter.cs" />
-    <Compile Include="..\nunit4-console\ColorStyle.cs" Link="ColorStyle.cs" />
     <Compile Include="..\nunit4-console\ConsoleOptions.cs" Link="ConsoleOptions.cs" />
     <Compile Include="..\nunit4-console\ConsoleRunner.cs" Link="ConsoleRunner.cs" />
     <Compile Include="..\nunit4-console\ConsoleTestResult.cs" Link="ConsoleTestResult.cs" />
-    <Compile Include="..\nunit4-console\ExtendedTextWrapper.cs" Link="ExtendedTextWrapper.cs" />
-    <Compile Include="..\nunit4-console\ExtendedTextWriter.cs" Link="ExtendedTextWriter.cs" />
     <Compile Include="..\nunit4-console\FileSystem.cs" Link="FileSystem.cs" />
     <Compile Include="..\nunit4-console\FrameworkPackageSettings.cs" Link="FrameworkPackageSettings.cs" />
     <Compile Include="..\nunit4-console\Options\DefaultOptionsProvider.cs" Link="Options\DefaultOptionsProvider.cs" />


### PR DESCRIPTION
This will be used by pluggable agents. Moved with minimal changes: namespaces, nullability. Moved tests as well.