### PR TITLE
CSharp is null analyzer 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,17 @@ indent_size = 4
 [*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml,yml}]
 indent_style = space
 indent_size = 2
+
+##########################################################################################
+# Analysis settings
+
+[*.cs]
+# CSharpIsNull Analyzers
+
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+
+# CSIsNull001: Use `is null` for null checks
+dotnet_diagnostic.CSIsNull001.severity = warning
+
+# CSIsNull002: Use `is object` for non-null checks
+dotnet_diagnostic.CSIsNull002.severity = warning

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -43,6 +43,7 @@
     <ItemGroup>
         <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" PrivateAssets="all" />
         <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)/StyleCop.Analyzers.globalconfig" />
+        <PackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/src/NUnitCommon/nunit.agent.core.tests/Drivers/NotRunnableFrameworkDriverTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Drivers/NotRunnableFrameworkDriverTests.cs
@@ -100,7 +100,7 @@ namespace NUnit.Engine.Drivers
         private static string? GetSkipReason(XmlNode result)
         {
             var propNode = result.SelectSingleNode(string.Format("properties/property[@name='{0}']", PropertyNames.SkipReason));
-            return propNode == null ? null : propNode.GetAttribute("value");
+            return propNode is null ? null : propNode.GetAttribute("value");
         }
 
         private class NullListener : ITestEventListener

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/DomainManagerStaticTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/DomainManagerStaticTests.cs
@@ -93,7 +93,7 @@ namespace NUnit.Engine.Runners
             expected = TestPath(expected);
 
             var package = new TestPackage(filePath);
-            if (appBase != null)
+            if (appBase is not null)
                 package.Settings["BasePath"] = appBase;
 
             Assert.That(DomainManager.GetApplicationBase(package), Is.SamePath(expected));
@@ -124,7 +124,7 @@ namespace NUnit.Engine.Runners
             expected = TestPath(expected);
 
             var package = new TestPackage(filePath);
-            if (configSetting != null)
+            if (configSetting is not null)
                 package.Settings["ConfigurationFile"] = configSetting;
 
             Assert.That(DomainManager.GetConfigFile(appBase, package), Is.EqualTo(expected));
@@ -138,7 +138,7 @@ namespace NUnit.Engine.Runners
         [return: NotNullIfNotNull(nameof(path))]
         private static string? TestPath(string? path)
         {
-            if (path != null && Path.DirectorySeparatorChar != '/')
+            if (path is not null && Path.DirectorySeparatorChar != '/')
             {
                 path = path.Replace('/', Path.DirectorySeparatorChar);
                 if (path[0] == Path.DirectorySeparatorChar)

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerTests.cs
@@ -35,7 +35,7 @@ namespace NUnit.Engine.Runners
         [TearDown]
         public void Cleanup()
         {
-            if (_runner != null)
+            if (_runner is not null)
                 _runner.Dispose();
         }
 

--- a/src/NUnitCommon/nunit.agent.core/AgentOptions.cs
+++ b/src/NUnitCommon/nunit.agent.core/AgentOptions.cs
@@ -55,10 +55,10 @@ namespace NUnit.Agents
 
                     if (optionTakesValue)
                     {
-                        if (val == null && index + 1 < args.Length)
+                        if (val is null && index + 1 < args.Length)
                             val = args[++index];
 
-                        if (val == null)
+                        if (val is null)
                             throw new Exception($"Option requires a value: {arg}");
                     }
                     else if (delim > 0)

--- a/src/NUnitCommon/nunit.agent.core/Agents/RemoteTestAgent.cs
+++ b/src/NUnitCommon/nunit.agent.core/Agents/RemoteTestAgent.cs
@@ -32,13 +32,13 @@ namespace NUnit.Engine.Agents
 
         public override bool Start()
         {
-            Guard.OperationValid(Transport != null, "Transport must be set before calling Start().");
+            Guard.OperationValid(Transport is not null, "Transport must be set before calling Start().");
             return Transport.Start();
         }
 
         public override void Stop()
         {
-            Guard.OperationValid(Transport != null, "Transport must be set before calling Stop().");
+            Guard.OperationValid(Transport is not null, "Transport must be set before calling Stop().");
             Transport.Stop();
         }
 

--- a/src/NUnitCommon/nunit.agent.core/Communication/Transports/Remoting/TestAgentRemotingTransport.cs
+++ b/src/NUnitCommon/nunit.agent.core/Communication/Transports/Remoting/TestAgentRemotingTransport.cs
@@ -70,7 +70,7 @@ namespace NUnit.Engine.Communication.Transports.Remoting
 
         public void Stop()
         {
-            Guard.OperationValid(_channel != null, "Channel is not open");
+            Guard.OperationValid(_channel is not null, "Channel is not open");
 
             log.Info("Stopping");
 

--- a/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
@@ -56,7 +56,7 @@ namespace NUnit.Engine.Drivers
             if (!PathUtils.IsAssemblyFileType(assemblyPath))
                 return new InvalidAssemblyFrameworkDriver(assemblyPath, package.ID, "File type is not supported");
 
-            if (targetFramework != null)
+            if (targetFramework is not null)
             {
                 // This takes care of an issue with Roslyn. It may get fixed, but we still
                 // have to deal with assemblies having this setting. I'm assuming that

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
@@ -72,7 +72,7 @@ namespace NUnit.Engine.Drivers
                         null,
                         null).ShouldNotBeNull();
                 }
-                catch (BadImageFormatException ex) when (requestedRuntime != null)
+                catch (BadImageFormatException ex) when (requestedRuntime is not null)
                 {
                     throw new NUnitEngineException($"Requested runtime {requestedRuntime} is not suitable for use with test assembly {_testAssemblyPath}", ex);
                 }
@@ -113,7 +113,7 @@ namespace NUnit.Engine.Drivers
 
             private void CheckLoadWasCalled()
             {
-                if (_frameworkController == null)
+                if (_frameworkController is null)
                     throw new InvalidOperationException(LOAD_MESSAGE);
             }
 

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
@@ -96,7 +96,7 @@ namespace NUnit.Engine.Drivers
             _frameworkAssembly = LoadAssembly(_nunitRef);
 
             _frameworkController = CreateInstance(CONTROLLER_TYPE, testAssembly, idPrefix, settings);
-            if (_frameworkController == null)
+            if (_frameworkController is null)
             {
                 log.Error(INVALID_FRAMEWORK_MESSAGE);
                 throw new NUnitEngineException(INVALID_FRAMEWORK_MESSAGE);
@@ -114,14 +114,14 @@ namespace NUnit.Engine.Drivers
         {
             CheckLoadWasCalled();
             object? count = ExecuteMethod(COUNT_METHOD, filter);
-            return count != null ? (int)count : 0;
+            return count is not null ? (int)count : 0;
         }
 
         public string Run(ITestEventListener? listener, string filter)
         {
             CheckLoadWasCalled();
             log.Info("Running {0} - see separate log file", Path.GetFileName(_testAssemblyPath.ShouldNotBeNull()));
-            Action<string>? callback = listener != null ? listener.OnTestEvent : null;
+            Action<string>? callback = listener is not null ? listener.OnTestEvent : null;
             return (string)ExecuteMethod(RUN_METHOD, [typeof(Action<string>), typeof(string)], callback, filter);
         }
 
@@ -146,7 +146,7 @@ namespace NUnit.Engine.Drivers
 
         private void CheckLoadWasCalled()
         {
-            if (_frameworkController == null)
+            if (_frameworkController is null)
                 throw new InvalidOperationException(LOAD_MESSAGE);
         }
 
@@ -164,7 +164,7 @@ namespace NUnit.Engine.Drivers
             try
             {
                 assembly = _assemblyLoadContext?.LoadFromAssemblyPath(assemblyPath)!;
-                if (assembly == null)
+                if (assembly is null)
                     throw new Exception("LoadFromAssemblyPath returned null");
             }
             catch (Exception e)
@@ -185,7 +185,7 @@ namespace NUnit.Engine.Drivers
             try
             {
                 assembly = _assemblyLoadContext?.LoadFromAssemblyName(assemblyName)!;
-                if (assembly == null)
+                if (assembly is null)
                     throw new Exception("LoadFromAssemblyName returned null");
             }
             catch (Exception e)
@@ -227,7 +227,7 @@ namespace NUnit.Engine.Drivers
 
         private object ExecuteMethod(MethodInfo? method, params object?[] args)
         {
-            if (method == null)
+            if (method is null)
                 throw new NUnitEngineException(INVALID_FRAMEWORK_MESSAGE);
 
             log.Debug($"Executing {method.DeclaringType}.{method.Name}");

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
@@ -133,7 +133,7 @@ namespace NUnit.Engine.Drivers
         /// <returns>An Xml string representing the result</returns>
         public string Run(ITestEventListener? listener, string filter)
         {
-            return _api.Run(listener != null ? new EventInterceptor(listener) : null, filter);
+            return _api.Run(listener is not null ? new EventInterceptor(listener) : null, filter);
         }
 
         /// <summary>

--- a/src/NUnitCommon/nunit.agent.core/Runners/DomainDetailsBuilder.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/DomainDetailsBuilder.cs
@@ -23,7 +23,7 @@ namespace NUnit.Engine
         public static string DetailsFor(AppDomain domain, string? errMsg = null)
         {
             var sb = new StringBuilder();
-            if (errMsg != null)
+            if (errMsg is not null)
                 sb.AppendLine(errMsg);
 
             try

--- a/src/NUnitCommon/nunit.agent.core/Runners/DomainManager.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/DomainManager.cs
@@ -34,7 +34,7 @@ namespace NUnit.Engine.Runners
             AppDomainSetup setup = CreateAppDomainSetup(package);
 
             string hashCode = string.Empty;
-            if (package.Name != null)
+            if (package.Name is not null)
             {
                 hashCode = package.Name.GetHashCode().ToString("x") + "-";
             }
@@ -80,7 +80,7 @@ namespace NUnit.Engine.Runners
                 // .NET versions greater than v4.0 report as v4.0, so look at
                 // the TargetFrameworkAttribute on the assembly if it exists
                 // If property is null, .NET 4.5+ is not installed, so there is no need
-                if (TargetFrameworkNameProperty != null)
+                if (TargetFrameworkNameProperty is not null)
                 {
                     var frameworkName = package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty);
                     if (frameworkName != string.Empty)
@@ -133,7 +133,7 @@ namespace NUnit.Engine.Runners
                     throw new NUnitEngineUnloadException(msg);
                 }
 
-                if (_unloadException != null)
+                if (_unloadException is not null)
                     throw new NUnitEngineUnloadException("Exception encountered unloading application domain", _unloadException);
             }
 
@@ -231,7 +231,7 @@ namespace NUnit.Engine.Runners
             var assemblies = new List<string>();
 
             // All subpackages have full names, but this is a public method in a public class so we have no control.
-            foreach (var package in packages.Where(p => p.FullName != null))
+            foreach (var package in packages.Where(p => p.FullName is not null))
                 assemblies.Add(package.FullName!);
 
             return GetCommonAppBase(assemblies);
@@ -244,10 +244,10 @@ namespace NUnit.Engine.Runners
             foreach (string assembly in assemblies)
             {
                 string? dir = Path.GetDirectoryName(Path.GetFullPath(assembly))!;
-                if (commonBase == null)
+                if (commonBase is null)
                     commonBase = dir;
                 else
-                    while (commonBase != null && !PathUtils.SamePathOrUnder(commonBase, dir))
+                    while (commonBase is not null && !PathUtils.SamePathOrUnder(commonBase, dir))
                         commonBase = Path.GetDirectoryName(commonBase)!;
             }
 
@@ -266,7 +266,7 @@ namespace NUnit.Engine.Runners
             if (package.GetSetting(EnginePackageSettings.AutoBinPath, binPath == string.Empty))
                 binPath = package.SubPackages.Count > 0
                     ? GetPrivateBinPath(appBase, package.SubPackages)
-                    : package.FullName != null
+                    : package.FullName is not null
                         ? GetPrivateBinPath(appBase, package.FullName)
                         : null;
 
@@ -276,7 +276,7 @@ namespace NUnit.Engine.Runners
         public static string? GetPrivateBinPath(string basePath, IList<TestPackage> packages)
         {
             var assemblies = new List<string>();
-            foreach (var package in packages.Where(p => p.FullName != null))
+            foreach (var package in packages.Where(p => p.FullName is not null))
                 assemblies.Add(package.FullName!);
 
             return GetPrivateBinPath(basePath, assemblies);
@@ -292,7 +292,7 @@ namespace NUnit.Engine.Runners
                 string? dir = PathUtils.RelativePath(
                     Path.GetFullPath(basePath),
                     Path.GetDirectoryName(Path.GetFullPath(assembly))!);
-                if (dir != null && dir != string.Empty && dir != "." && !dirList.Contains(dir))
+                if (dir is not null && dir != string.Empty && dir != "." && !dirList.Contains(dir))
                 {
                     dirList.Add(dir);
                     if (sb.Length > 0)

--- a/src/NUnitCommon/nunit.agent.core/Runners/TestAgentRunner.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/TestAgentRunner.cs
@@ -42,7 +42,7 @@ namespace NUnit.Engine.Runners
         /// </summary>
         public bool IsPackageLoaded
         {
-            get { return LoadResult != null; }
+            get { return LoadResult is not null; }
         }
 
         public TestAgentRunner(TestPackage package)
@@ -89,7 +89,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         public virtual TestEngineResult Load()
         {
-            Guard.OperationValid(TestDomain != null, "TestDomain is not set");
+            Guard.OperationValid(TestDomain is not null, "TestDomain is not set");
 
             var result = new TestEngineResult();
 
@@ -97,7 +97,7 @@ namespace NUnit.Engine.Runners
             // only a single assembly.
             var assemblyPackage = TestPackage.Select(p => !p.HasSubPackages()).First();
 
-            if (DriverService == null)
+            if (DriverService is null)
                 DriverService = new DriverService();
 
             var testFile = assemblyPackage.FullName!; // We know it's an assembly
@@ -105,7 +105,7 @@ namespace NUnit.Engine.Runners
             string? targetFramework = assemblyPackage.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, (string?)null);
             bool skipNonTestAssemblies = assemblyPackage.GetSetting(EnginePackageSettings.SkipNonTestAssemblies, false);
 
-            if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain()
+            if (_assemblyResolver is not null && !TestDomain.IsDefaultAppDomain()
                 && assemblyPackage.GetSetting(EnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
             {
                 // It's OK to do this in the loop because the Add method

--- a/src/NUnitCommon/nunit.agent.core/Runners/TestDomainRunner.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/TestDomainRunner.cs
@@ -28,7 +28,7 @@ namespace NUnit.Engine.Runners
         /// </summary>
         public override void Unload()
         {
-            if (this.TestDomain != null)
+            if (this.TestDomain is not null)
             {
                 _domainManager.Unload(this.TestDomain);
                 this.TestDomain = null;

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyLoadContext.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyLoadContext.cs
@@ -34,7 +34,7 @@ namespace NUnit.Engine.Internal
             log.Debug("Loading {0} assembly", name);
 
             var loadedAssembly = base.Load(name);
-            if (loadedAssembly != null)
+            if (loadedAssembly is not null)
             {
                 log.Info("Assembly {0} ({1}) is loaded using default base.Load()", name, GetAssemblyLocationInfo(loadedAssembly));
                 return loadedAssembly;
@@ -47,14 +47,14 @@ namespace NUnit.Engine.Internal
                 loadedAssembly = LoadFromAssemblyPath(runtimeResolverPath);
             }
 
-            if (loadedAssembly != null)
+            if (loadedAssembly is not null)
             {
                 log.Info("Assembly {0} ({1}) is loaded using the deps.json info", name, GetAssemblyLocationInfo(loadedAssembly));
                 return loadedAssembly;
             }
 
             loadedAssembly = _resolver.Resolve(this, name);
-            if (loadedAssembly != null)
+            if (loadedAssembly is not null)
             {
                 log.Info("Assembly {0} ({1}) is loaded using the TestAssembliesResolver", name, GetAssemblyLocationInfo(loadedAssembly));
 
@@ -71,7 +71,7 @@ namespace NUnit.Engine.Internal
                 loadedAssembly = LoadFromAssemblyPath(assemblyPath);
             }
 
-            if (loadedAssembly != null)
+            if (loadedAssembly is not null)
             {
                 log.Info("Assembly {0} ({1}) is loaded using base path", name, GetAssemblyLocationInfo(loadedAssembly));
                 return loadedAssembly;

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
@@ -91,7 +91,7 @@ namespace NUnit.Engine.Internal
 
         private Assembly? OnResolving(AssemblyLoadContext loadContext, AssemblyName assemblyName)
         {
-            if (loadContext == null)
+            if (loadContext is null)
                 throw new ArgumentNullException("context");
 
             Assembly? loadedAssembly;
@@ -170,7 +170,7 @@ namespace NUnit.Engine.Internal
             public override bool TryToResolve(
                 AssemblyLoadContext loadContext, AssemblyName assemblyName, [NotNullWhen(true)] out Assembly? loadedAssembly)
             {
-                if (_dependencyContext == null)
+                if (_dependencyContext is null)
                 {
                     // TODO: Is this the intended behavior?
                     loadedAssembly = null;
@@ -224,12 +224,12 @@ namespace NUnit.Engine.Internal
                 AssemblyLoadContext loadContext, AssemblyName assemblyName, [NotNullWhen(true)] out Assembly? loadedAssembly)
             {
                 loadedAssembly = null;
-                if (assemblyName.Version == null)
+                if (assemblyName.Version is null)
                     return false;
 
                 var versionDir = FindBestVersionDir(_frameworkDirectory, assemblyName.Version);
 
-                if (versionDir != null)
+                if (versionDir is not null)
                 {
                     string candidate = Path.Combine(_frameworkDirectory, versionDir, assemblyName.Name + ".dll");
                     if (File.Exists(candidate))

--- a/src/NUnitCommon/nunit.common/AssemblyHelper.cs
+++ b/src/NUnitCommon/nunit.common/AssemblyHelper.cs
@@ -37,7 +37,7 @@ namespace NUnit
             // To get the location before the file has been shadow-copied, use the CodeBase property.
             string? codeBase = assembly.CodeBase;
 
-            if (codeBase != null && IsFileUri(codeBase))
+            if (codeBase is not null && IsFileUri(codeBase))
                 return GetAssemblyPathFromCodeBase(codeBase);
 #endif
 

--- a/src/NUnitCommon/nunit.common/Communitcation/Transports/Tcp/SocketReader.cs
+++ b/src/NUnitCommon/nunit.common/Communitcation/Transports/Tcp/SocketReader.cs
@@ -62,7 +62,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
             var receivedMessage = GetNextMessage();
             var expectedMessage = receivedMessage as TMessage;
 
-            if (expectedMessage == null)
+            if (expectedMessage is null)
                 throw new InvalidOperationException($"Expected a {typeof(TMessage)} but received a {receivedMessage.GetType()}");
 
             return expectedMessage;

--- a/src/NUnitCommon/nunit.common/DotNet.cs
+++ b/src/NUnitCommon/nunit.common/DotNet.cs
@@ -18,10 +18,10 @@ namespace NUnit.Engine
         private static string? _x64InstallDirectory;
         public static string? GetX64InstallDirectory()
         {
-            if (_x64InstallDirectory == null)
+            if (_x64InstallDirectory is null)
                 _x64InstallDirectory = Environment.GetEnvironmentVariable("DOTNET_ROOT");
 
-            if (_x64InstallDirectory == null)
+            if (_x64InstallDirectory is null)
             {
 #if NETFRAMEWORK
                 if (Path.DirectorySeparatorChar == '\\')
@@ -42,10 +42,10 @@ namespace NUnit.Engine
         private static string? _x86InstallDirectory;
         public static string? GetX86InstallDirectory()
         {
-            if (_x86InstallDirectory == null)
+            if (_x86InstallDirectory is null)
                 _x86InstallDirectory = Environment.GetEnvironmentVariable("DOTNET_ROOT_X86");
 
-            if (_x86InstallDirectory == null)
+            if (_x86InstallDirectory is null)
             {
 #if NETFRAMEWORK
                 if (Path.DirectorySeparatorChar == '\\')

--- a/src/NUnitCommon/nunit.common/ExceptionHelper.cs
+++ b/src/NUnitCommon/nunit.common/ExceptionHelper.cs
@@ -85,7 +85,7 @@ namespace NUnit
             var result = new List<Exception>();
 
             var unloadException = exception as NUnitEngineUnloadException;
-            if (unloadException?.AggregatedExceptions != null)
+            if (unloadException?.AggregatedExceptions is not null)
             {
                 result.AddRange(unloadException.AggregatedExceptions);
 
@@ -94,7 +94,7 @@ namespace NUnit
             }
 
             var reflectionException = exception as ReflectionTypeLoadException;
-            if (reflectionException != null && reflectionException.LoaderExceptions != null)
+            if (reflectionException is not null && reflectionException.LoaderExceptions is not null)
             {
                 result.AddRange(reflectionException.LoaderExceptions.WhereNotNull());
 
@@ -102,7 +102,7 @@ namespace NUnit
                     result.AddRange(FlattenExceptionHierarchy(innerException));
             }
 
-            if (exception.InnerException != null)
+            if (exception.InnerException is not null)
             {
                 result.Add(exception.InnerException);
                 result.AddRange(FlattenExceptionHierarchy(exception.InnerException));
@@ -117,7 +117,7 @@ namespace NUnit
             {
                 // Special handling for Mono 5.0, which returns an empty message
                 var fnfEx = ex as System.IO.FileNotFoundException;
-                return fnfEx != null
+                return fnfEx is not null
                     ? "Could not load assembly. File not found: " + fnfEx.FileName
                     : "No message provided";
             }

--- a/src/NUnitCommon/nunit.common/FileSystemAccess/Directory.cs
+++ b/src/NUnitCommon/nunit.common/FileSystemAccess/Directory.cs
@@ -23,7 +23,7 @@ namespace NUnit.FileSystemAccess
         /// <exception cref="SIO.PathTooLongException"><paramref name="path"/> exceeds the system-defined maximum length.</exception>
         public Directory(string path)
         {
-            if (path == null)
+            if (path is null)
             {
                 throw new ArgumentNullException(nameof(path));
             }
@@ -35,7 +35,7 @@ namespace NUnit.FileSystemAccess
 
             this.directory = new SIO.DirectoryInfo(path);
 
-            this.Parent = this.directory.Parent == null ? null : new Directory(directory.Parent.FullName);
+            this.Parent = this.directory.Parent is null ? null : new Directory(directory.Parent.FullName);
         }
 
         /// <inheritdoc/>

--- a/src/NUnitCommon/nunit.common/FileSystemAccess/DirectoryFinder.cs
+++ b/src/NUnitCommon/nunit.common/FileSystemAccess/DirectoryFinder.cs
@@ -93,7 +93,7 @@ namespace NUnit.FileSystemAccess
                     newList.Add(dir);
                 else if (pattern == "..")
                 {
-                    if (dir.Parent != null)
+                    if (dir.Parent is not null)
                         newList.Add(dir.Parent);
                 }
                 else if (pattern == "**")

--- a/src/NUnitCommon/nunit.common/FileSystemAccess/File.cs
+++ b/src/NUnitCommon/nunit.common/FileSystemAccess/File.cs
@@ -21,7 +21,7 @@ namespace NUnit.FileSystemAccess
         /// <exception cref="System.IO.PathTooLongException">The specified path exceeds the system-defined maximum length.</exception>
         public File(string path)
         {
-            if (path == null)
+            if (path is null)
             {
                 throw new ArgumentNullException(nameof(path));
             }

--- a/src/NUnitCommon/nunit.common/FileSystemAccess/FileSystem.cs
+++ b/src/NUnitCommon/nunit.common/FileSystemAccess/FileSystem.cs
@@ -13,7 +13,7 @@ namespace NUnit.FileSystemAccess
         /// <inheritdoc/>
         public bool Exists(IDirectory directory)
         {
-            if (directory == null)
+            if (directory is null)
             {
                 throw new ArgumentNullException(nameof(directory));
             }
@@ -24,7 +24,7 @@ namespace NUnit.FileSystemAccess
         /// <inheritdoc/>
         public bool Exists(IFile file)
         {
-            if (file == null)
+            if (file is null)
             {
                 throw new ArgumentNullException(nameof(file));
             }

--- a/src/NUnitCommon/nunit.common/Guard.cs
+++ b/src/NUnitCommon/nunit.common/Guard.cs
@@ -19,7 +19,7 @@ namespace NUnit
         /// <param name="name">The name of the argument</param>
         public static void ArgumentNotNull(object value, string name)
         {
-            if (value == null)
+            if (value is null)
                 throw new ArgumentNullException("Argument " + name + " must not be null", name);
         }
 
@@ -34,7 +34,7 @@ namespace NUnit
         public static T ShouldNotBeNull<T>(this T? result, [CallerArgumentExpression(nameof(result))] string expression = "")
             where T : class
         {
-            if (result == null)
+            if (result is null)
                 throw new InvalidOperationException($"Result {expression} must not be null");
 
             return result;

--- a/src/NUnitCommon/nunit.common/Logging/InternalTraceWriter.cs
+++ b/src/NUnitCommon/nunit.common/Logging/InternalTraceWriter.cs
@@ -88,7 +88,7 @@ namespace NUnit
         {
             lock (_myLock)
             {
-                if (disposing && _writer != null)
+                if (disposing && _writer is not null)
                 {
                     _writer.Flush();
                     _writer.Dispose();

--- a/src/NUnitCommon/nunit.common/PathUtils.cs
+++ b/src/NUnitCommon/nunit.common/PathUtils.cs
@@ -40,16 +40,16 @@ namespace NUnit
         /// </summary>
         public static string? RelativePath(string from, string to)
         {
-            if (from == null)
+            if (from is null)
                 throw new ArgumentNullException(from);
-            if (to == null)
+            if (to is null)
                 throw new ArgumentNullException(to);
 
             string? toPathRoot = Path.GetPathRoot(to);
-            if (toPathRoot == null || toPathRoot == string.Empty)
+            if (toPathRoot is null || toPathRoot == string.Empty)
                 return to;
             string? fromPathRoot = Path.GetPathRoot(from);
-            if (fromPathRoot == null || fromPathRoot == string.Empty)
+            if (fromPathRoot is null || fromPathRoot == string.Empty)
                 return null;
 
             if (!PathsEqual(toPathRoot, fromPathRoot))
@@ -189,7 +189,7 @@ namespace NUnit
         /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
         public static bool IsFullyQualifiedWindowsPath(string path)
         {
-            if (path == null)
+            if (path is null)
             {
                 throw new ArgumentNullException(nameof(path));
             }
@@ -213,7 +213,7 @@ namespace NUnit
         /// <exception cref="ArgumentNullException"><paramref name="path"/></exception>
         public static bool IsFullyQualifiedUnixPath(string path)
         {
-            if (path == null)
+            if (path is null)
             {
                 throw new ArgumentNullException(nameof(path));
             }

--- a/src/NUnitCommon/nunit.common/ResultHelper.cs
+++ b/src/NUnitCommon/nunit.common/ResultHelper.cs
@@ -113,12 +113,12 @@ namespace NUnit.Engine
         public static XmlNode Aggregate(string elementName, string? testType, string id, string? name, string? fullName, IList<XmlNode> resultNodes)
         {
             XmlNode combinedNode = XmlHelper.CreateTopLevelElement(elementName);
-            if (testType != null)
+            if (testType is not null)
                 combinedNode.AddAttribute("type", testType);
             combinedNode.AddAttribute("id", id);
-            if (name != null && name != string.Empty)
+            if (name is not null && name != string.Empty)
                 combinedNode.AddAttribute("name", name);
-            if (fullName != null && fullName != string.Empty)
+            if (fullName is not null && fullName != string.Empty)
                 combinedNode.AddAttribute("fullname", fullName);
             combinedNode.AddAttribute("runstate", "Runnable"); // If not, we would not have gotten this far
 
@@ -143,7 +143,7 @@ namespace NUnit.Engine
                 testcasecount += node.GetAttribute("testcasecount", 0);
 
                 XmlAttribute? resultAttribute = node.Attributes?["result"];
-                if (resultAttribute != null)
+                if (resultAttribute is not null)
                 {
                     isTestRunResult = true;
 
@@ -183,7 +183,7 @@ namespace NUnit.Engine
                     asserts += node.GetAttribute("asserts", 0);
                 }
 
-                if (combinedNode.OwnerDocument != null)
+                if (combinedNode.OwnerDocument is not null)
                 {
                     XmlNode import = combinedNode.OwnerDocument.ImportNode(node, true);
                     combinedNode.AppendChild(import);
@@ -195,9 +195,9 @@ namespace NUnit.Engine
             if (isTestRunResult)
             {
                 combinedNode.AddAttribute("result", aggregateResult);
-                if (aggregateLabel != null)
+                if (aggregateLabel is not null)
                     combinedNode.AddAttribute("label", aggregateLabel);
-                if (aggregateSite != null)
+                if (aggregateSite is not null)
                     combinedNode.AddAttribute("site", aggregateSite);
 
                 //combinedNode.AddAttribute("duration", totalDuration.ToString("0.000000", NumberFormatInfo.InvariantInfo));

--- a/src/NUnitCommon/nunit.common/RuntimeInformation.cs
+++ b/src/NUnitCommon/nunit.common/RuntimeInformation.cs
@@ -15,7 +15,7 @@ namespace NUnit.Engine.Internal.Backports
     {
         static RuntimeInformation()
         {
-            bool isMono = Type.GetType("Mono.Runtime", false) != null;
+            bool isMono = Type.GetType("Mono.Runtime", false) is not null;
 
             Version version = new Version(Environment.Version.Major, Environment.Version.Minor);
             if (isMono)
@@ -41,10 +41,10 @@ namespace NUnit.Engine.Internal.Backports
                 {
                     case 2:
                         key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\.NETFramework");
-                        if (key != null)
+                        if (key is not null)
                         {
                             string? installRoot = key.GetValue("InstallRoot") as string;
-                            if (installRoot != null)
+                            if (installRoot is not null)
                             {
                                 if (Directory.Exists(System.IO.Path.Combine(installRoot, "v3.5")))
                                 {
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Internal.Backports
                         break;
                     case 4:
                         key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full");
-                        if (key != null)
+                        if (key is not null)
                         {
                             version = new Version(4, 5);
                             int release = (int)key.GetValue("Release", 0);

--- a/src/NUnitCommon/nunit.common/TcpChannelUtils.ObservableServerChannelSinkProvider.cs
+++ b/src/NUnitCommon/nunit.common/TcpChannelUtils.ObservableServerChannelSinkProvider.cs
@@ -17,7 +17,7 @@ namespace NUnit.Engine
 
             public ObservableServerChannelSinkProvider(CurrentMessageCounter currentMessageCounter)
             {
-                if (currentMessageCounter == null)
+                if (currentMessageCounter is null)
                     throw new ArgumentNullException(nameof(currentMessageCounter));
                 _currentMessageCounter = currentMessageCounter;
             }
@@ -28,7 +28,7 @@ namespace NUnit.Engine
 
             public IServerChannelSink CreateSink(IChannelReceiver channel)
             {
-                if (Next == null)
+                if (Next is null)
                     throw new InvalidOperationException("Cannot create a sink without setting the next provider.");
                 return new ObservableServerChannelSink(_currentMessageCounter, Next.CreateSink(channel));
             }
@@ -42,7 +42,7 @@ namespace NUnit.Engine
 
                 public ObservableServerChannelSink(CurrentMessageCounter currentMessageCounter, IServerChannelSink next)
                 {
-                    if (next == null)
+                    if (next is null)
                         throw new ArgumentNullException(nameof(next));
                     _currentMessageCounter = currentMessageCounter;
                     _next = next;

--- a/src/NUnitCommon/nunit.common/TcpChannelUtils.cs
+++ b/src/NUnitCommon/nunit.common/TcpChannelUtils.cs
@@ -49,7 +49,7 @@ namespace NUnit.Engine
             return new TcpChannel(
                 props,
                 clientProvider,
-                currentMessageCounter != null
+                currentMessageCounter is not null
                     ? new ObservableServerChannelSinkProvider(currentMessageCounter) { Next = serverProvider }
                     : (IServerChannelSinkProvider)serverProvider);
         }
@@ -91,7 +91,7 @@ namespace NUnit.Engine
         public static TcpChannel? GetTcpChannel(string name, int port, int limit, CurrentMessageCounter? currentMessageCounter = null)
         {
             var existingChannel = ChannelServices.GetChannel(name) as TcpChannel;
-            if (existingChannel != null)
+            if (existingChannel is not null)
                 return existingChannel;
 
             // NOTE: Retries are normally only needed when rapidly creating

--- a/src/NUnitCommon/nunit.common/TestPackageExtensions.cs
+++ b/src/NUnitCommon/nunit.common/TestPackageExtensions.cs
@@ -14,7 +14,7 @@ namespace NUnit.Engine
     {
         public static bool IsAssemblyPackage(this TestPackage package)
         {
-            return package.FullName != null && PathUtils.IsAssemblyFileType(package.FullName);
+            return package.FullName is not null && PathUtils.IsAssemblyFileType(package.FullName);
         }
 
         public static bool HasSubPackages(this TestPackage package)

--- a/src/NUnitCommon/nunit.common/XmlHelper.cs
+++ b/src/NUnitCommon/nunit.common/XmlHelper.cs
@@ -91,7 +91,7 @@ namespace NUnit
         {
             XmlAttribute? attr = result.Attributes?[name];
 
-            return attr == null ? null : attr.Value;
+            return attr is null ? null : attr.Value;
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace NUnit
         {
             XmlAttribute? attr = result.Attributes?[name];
 
-            return attr == null
+            return attr is null
                 ? defaultValue
                 : int.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
         }
@@ -121,7 +121,7 @@ namespace NUnit
         {
             XmlAttribute? attr = result.Attributes?[name];
 
-            return attr == null
+            return attr is null
                 ? defaultValue
                 : double.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
         }
@@ -136,7 +136,7 @@ namespace NUnit
         public static DateTime GetAttribute(this XmlNode result, string name, DateTime defaultValue)
         {
             string? dateStr = GetAttribute(result, name);
-            if (dateStr == null)
+            if (dateStr is null)
                 return defaultValue;
 
             DateTime date;

--- a/src/NUnitCommon/nunit.extensibility/AddinsFile.cs
+++ b/src/NUnitCommon/nunit.extensibility/AddinsFile.cs
@@ -15,7 +15,7 @@ namespace NUnit.Extensibility
     {
         public static AddinsFile Read(IFile file)
         {
-            if (file == null)
+            if (file is null)
                 throw new ArgumentNullException(nameof(file));
 
             using (var stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
@@ -39,7 +39,7 @@ namespace NUnit.Extensibility
 
                 int lineNumber = 0;
                 string? line;
-                while ((line = reader.ReadLine()) != null)
+                while ((line = reader.ReadLine()) is not null)
                 {
                     var entry = new AddinsFileEntry(++lineNumber, line);
                     if (entry.Text != string.Empty && !entry.IsValid)
@@ -70,7 +70,7 @@ namespace NUnit.Extensibility
         public override bool Equals(object? obj)
         {
             var other = obj as AddinsFile;
-            if (other == null)
+            if (other is null)
                 return false;
 
             if (Count != other.Count)

--- a/src/NUnitCommon/nunit.extensibility/AddinsFileEntry.cs
+++ b/src/NUnitCommon/nunit.extensibility/AddinsFileEntry.cs
@@ -37,7 +37,7 @@ namespace NUnit.Extensibility
         public override bool Equals(object? obj)
         {
             var other = obj as AddinsFileEntry;
-            if (other == null)
+            if (other is null)
                 return false;
 
             return LineNumber == other.LineNumber && RawText == other.RawText;

--- a/src/NUnitCommon/nunit.extensibility/ExtensionAssembly.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionAssembly.cs
@@ -50,7 +50,7 @@ namespace NUnit.Extensibility
             get
             {
                 var framework = Assembly.GetFrameworkName();
-                if (framework != null)
+                if (framework is not null)
                     return new FrameworkName(framework);
 
                 // No TargetFrameworkAttribute - Assume .NET Framework

--- a/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
@@ -169,7 +169,7 @@ namespace NUnit.Extensibility
 
             IDirectory? startDir = _fileSystem.GetDirectory(AssemblyHelper.GetDirectoryName(hostAssembly));
 
-            while (startDir != null)
+            while (startDir is not null)
             {
                 foreach (var pattern in extensionPatterns)
                     foreach (var dir in _directoryFinder.GetDirectories(startDir, pattern))
@@ -204,7 +204,7 @@ namespace NUnit.Extensibility
             EnsureExtensionsAreLoaded();
 
             var ep = GetExtensionPoint(path);
-            if (ep != null)
+            if (ep is not null)
                 foreach (var node in ep.Extensions)
                     yield return node;
         }
@@ -221,7 +221,7 @@ namespace NUnit.Extensibility
             // TODO: Remove need for the cast
             var ep = GetExtensionPoint(path) as ExtensionPoint;
 
-            return ep != null && ep.Extensions.Count > 0 ? ep.Extensions[0] : null;
+            return ep is not null && ep.Extensions.Count > 0 ? ep.Extensions[0] : null;
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace NUnit.Extensibility
             EnsureExtensionsAreLoaded();
 
             var ep = GetExtensionPoint(typeof(T));
-            if (ep != null)
+            if (ep is not null)
                 foreach (var node in ep.Extensions)
                     if (includeDisabled || node.Enabled)
                         yield return node;
@@ -285,7 +285,7 @@ namespace NUnit.Extensibility
         private ExtensionPoint? DeduceExtensionPointFromType(TypeReference typeRef)
         {
             var ep = GetExtensionPoint(typeRef);
-            if (ep != null)
+            if (ep is not null)
                 return ep;
 
             TypeDefinition typeDef = typeRef.Resolve();
@@ -293,12 +293,12 @@ namespace NUnit.Extensibility
             foreach (InterfaceImplementation iface in typeDef.Interfaces)
             {
                 ep = DeduceExtensionPointFromType(iface.InterfaceType);
-                if (ep != null)
+                if (ep is not null)
                     return ep;
             }
 
             TypeReference? baseType = typeDef.BaseType;
-            return baseType != null && baseType.FullName != "System.Object"
+            return baseType is not null && baseType.FullName != "System.Object"
                 ? DeduceExtensionPointFromType(baseType)
                 : null;
         }
@@ -495,20 +495,20 @@ namespace NUnit.Extensibility
             {
                 bool isV3Extension = false;
                 CustomAttribute extensionAttr = extensionType.GetAttribute(EXTENSION_ATTRIBUTE);
-                if (extensionAttr == null)
+                if (extensionAttr is null)
                 {
                     extensionAttr = extensionType.GetAttribute(V3_EXTENSION_ATTRIBUTE);
                     isV3Extension = true;
                 }
 
-                if (extensionAttr == null)
+                if (extensionAttr is null)
                     continue;
 
                 // TODO: This is a remnant of older code. In principle, this should be generalized
                 // to something like "HostVersion". However, this can safely remain until
                 // we separate ExtensionManager into its own assembly.
                 string? versionArg = extensionAttr.GetNamedArgument(nameof(ExtensionAttribute.EngineVersion)) as string;
-                if (versionArg != null)
+                if (versionArg is not null)
                 {
                     if (new Version(versionArg) > CURRENT_ENGINE_VERSION)
                     {
@@ -525,7 +525,7 @@ namespace NUnit.Extensibility
                 };
 
                 object? enabledArg = extensionAttr.GetNamedArgument(nameof(ExtensionAttribute.Enabled));
-                node.Enabled = enabledArg == null || (bool)enabledArg;
+                node.Enabled = enabledArg is null || (bool)enabledArg;
 
                 log.Info("  Found ExtensionAttribute on Type " + extensionType.Name);
 
@@ -538,7 +538,7 @@ namespace NUnit.Extensibility
                     string? name = attr.ConstructorArguments[0].Value as string;
                     string? value = attr.ConstructorArguments[1].Value as string;
 
-                    if (name != null && value != null)
+                    if (name is not null && value is not null)
                     {
                         node.AddProperty(name, value);
                         log.Info("        ExtensionProperty {0} = {1}", name, value);
@@ -548,10 +548,10 @@ namespace NUnit.Extensibility
                 _extensions.Add(node);
 
                 ExtensionPoint? ep;
-                if (extensionAttrPath == null)
+                if (extensionAttrPath is null)
                 {
                     ep = DeduceExtensionPointFromType(extensionType);
-                    if (ep == null)
+                    if (ep is null)
                         throw new NUnitExtensibilityException($"Unable to deduce ExtensionPoint for Type {extensionType.FullName}. Specify Path on ExtensionAttribute to resolve.");
 
                     node.Path = ep.Path;
@@ -562,7 +562,7 @@ namespace NUnit.Extensibility
 
                     // TODO: Remove need for the cast
                     ep = GetExtensionPoint(node.Path) as ExtensionPoint;
-                    if (ep == null)
+                    if (ep is null)
                         throw new NUnitExtensibilityException($"Unable to locate ExtensionPoint for Type {extensionType.FullName}. The Path {node.Path} cannot be found.");
                 }
 
@@ -582,7 +582,7 @@ namespace NUnit.Extensibility
         /// <param name="extensionAsm">The extension we are attempting to load</param>
         public bool CanLoadTargetFramework(Assembly? runnerAsm, ExtensionAssembly extensionAsm)
         {
-            if (runnerAsm == null)
+            if (runnerAsm is null)
                 return true;
 
             var runnerFrameworkName = GetTargetRuntime(runnerAsm.Location);

--- a/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
@@ -105,7 +105,7 @@ namespace NUnit.Extensibility
         {
             get
             {
-                if (_extensionObject == null)
+                if (_extensionObject is null)
                 {
                     object obj = CreateExtensionObject();
 

--- a/src/NUnitCommon/nunit.extensibility/ExtensionWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionWrapper.cs
@@ -83,7 +83,7 @@ namespace NUnit.Extensibility
                 return method;
 
             method = _wrappedType.GetMethod(methodName, argTypes);
-            if (method == null)
+            if (method is null)
                 throw new MissingMethodException(methodName);
 
             return _methods[sig] = method;
@@ -94,7 +94,7 @@ namespace NUnit.Extensibility
             if (_properties.TryGetValue(propertyName, out PropertyInfo? property))
                 return property;
             property = _wrappedType.GetProperty(propertyName);
-            if (property == null)
+            if (property is null)
                 throw new MissingMemberException(propertyName);
             return _properties[propertyName] = property;
         }

--- a/src/NUnitCommon/nunit.extensibility/Wrappers/ProjectLoaderWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/Wrappers/ProjectLoaderWrapper.cs
@@ -80,7 +80,7 @@ namespace NUnit.Extensibility.Wrappers
 
             public T GetSetting<T>(string name, T defaultValue)
             {
-                if (defaultValue == null)
+                if (defaultValue is null)
                     throw new ArgumentNullException(nameof(defaultValue));
                 return Invoke<T>(nameof(GetSetting), name, defaultValue);
             }

--- a/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
@@ -200,7 +200,7 @@ namespace NUnit.ConsoleRunner
 
             string? line;
             var lines = new List<string>();
-            while ((line = rdr.ReadLine()) != null)
+            while ((line = rdr.ReadLine()) is not null)
                 lines.Add(line);
 
             return lines;

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -30,7 +30,7 @@ namespace NUnit.ConsoleRunner
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
 
             ConfigureOptions();
-            if (args != null)
+            if (args is not null)
                 Parse(args);
         }
 
@@ -63,7 +63,7 @@ namespace NUnit.ConsoleRunner
         [MemberNotNullWhen(true, nameof(WhereClause))]
         public bool WhereClauseSpecified
         {
-            get { return WhereClause != null; }
+            get { return WhereClause is not null; }
         }
 
         public int DefaultTestCaseTimeout { get; private set; } = -1;
@@ -102,7 +102,7 @@ namespace NUnit.ConsoleRunner
         [MemberNotNullWhen(true, nameof(OutFile))]
         public bool OutFileSpecified
         {
-            get { return OutFile != null; }
+            get { return OutFile is not null; }
         }
 
         public string? DisplayTestLabels { get; private set; }
@@ -114,7 +114,7 @@ namespace NUnit.ConsoleRunner
         }
         public bool WorkDirectorySpecified
         {
-            get { return workDirectory != null; }
+            get { return workDirectory is not null; }
         }
 
         public string? InternalTraceLevel { get; private set; }
@@ -122,7 +122,7 @@ namespace NUnit.ConsoleRunner
         [MemberNotNullWhen(true, nameof(InternalTraceLevel))]
         public bool InternalTraceLevelSpecified
         {
-            get { return InternalTraceLevel != null; }
+            get { return InternalTraceLevel is not null; }
         }
 
         private readonly List<OutputSpecification> resultOutputSpecifications = new List<OutputSpecification>();
@@ -150,7 +150,7 @@ namespace NUnit.ConsoleRunner
         [MemberNotNullWhen(true, nameof(ActiveConfig))]
         public bool ActiveConfigSpecified
         {
-            get { return ActiveConfig != null; }
+            get { return ActiveConfig is not null; }
         }
 
         // How to Run Tests
@@ -160,7 +160,7 @@ namespace NUnit.ConsoleRunner
         [MemberNotNullWhen(true, nameof(RuntimeFramework))]
         public bool RuntimeFrameworkSpecified
         {
-            get { return RuntimeFramework != null; }
+            get { return RuntimeFramework is not null; }
         }
 
         public string? ConfigurationFile { get; private set; }
@@ -277,7 +277,7 @@ namespace NUnit.ConsoleRunner
                 v =>
                 {
                     var spec = parser.ResolveOutputSpecification(parser.RequiredValue(v, "--resultxml"), resultOutputSpecifications, _fileSystem, CURRENT_DIRECTORY_ON_ENTRY);
-                    if (spec != null)
+                    if (spec is not null)
                         resultOutputSpecifications.Add(spec);
                 });
 
@@ -285,7 +285,7 @@ namespace NUnit.ConsoleRunner
             {
                 Explore = true;
                 var spec = parser.ResolveOutputSpecification(v, ExploreOutputSpecifications, _fileSystem, CURRENT_DIRECTORY_ON_ENTRY);
-                if (spec != null)
+                if (spec is not null)
                     ExploreOutputSpecifications.Add(spec);
             });
 
@@ -423,7 +423,7 @@ namespace NUnit.ConsoleRunner
 
         public IEnumerable<string> PreParse(IEnumerable<string> args)
         {
-            if (args == null)
+            if (args is null)
                 throw new ArgumentNullException("args");
 
             if (++_nesting > 3)
@@ -500,7 +500,7 @@ namespace NUnit.ConsoleRunner
 
         private string? ExpandToFullPath(string path)
         {
-            if (path == null)
+            if (path is null)
                 return null;
 
             return Path.GetFullPath(path);

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -63,16 +63,16 @@ namespace NUnit.ConsoleRunner
 
             // NOTE: Accessing Services triggers the engine to initialize all services
             _resultService = _engine.Services.GetService<IResultService>();
-            Guard.OperationValid(_resultService != null, "Internal Error: ResultService was not found");
+            Guard.OperationValid(_resultService is not null, "Internal Error: ResultService was not found");
 
             _filterService = _engine.Services.GetService<ITestFilterService>();
-            Guard.OperationValid(_filterService != null, "Internal Error: TestFilterService was not found");
+            Guard.OperationValid(_filterService is not null, "Internal Error: TestFilterService was not found");
 
             _extensionService = _engine.Services.GetService<IExtensionService>();
-            Guard.OperationValid(_extensionService != null, "Internal Error: ExtensionService was not found");
+            Guard.OperationValid(_extensionService is not null, "Internal Error: ExtensionService was not found");
 
             _extensionService = _engine.Services.GetService<IExtensionService>();
-            Guard.OperationValid(_extensionService != null, "Internal Error: ExtensionService was not found");
+            Guard.OperationValid(_extensionService is not null, "Internal Error: ExtensionService was not found");
 
             var extensionPath = Environment.GetEnvironmentVariable(NUNIT_EXTENSION_DIRECTORIES);
             if (!string.IsNullOrEmpty(extensionPath))
@@ -239,7 +239,7 @@ namespace NUnit.ConsoleRunner
                 }
             }
 
-            var labels = _options.DisplayTestLabels != null
+            var labels = _options.DisplayTestLabels is not null
                 ? _options.DisplayTestLabels.ToUpperInvariant()
                 : "ON";
 
@@ -267,7 +267,7 @@ namespace NUnit.ConsoleRunner
                 engineException = ex;
             }
 
-            if (result != null)
+            if (result is not null)
             {
                 var reporter = new ResultReporter(result, writer, _options);
                 reporter.ReportResults();
@@ -279,13 +279,13 @@ namespace NUnit.ConsoleRunner
                     writer.WriteLine("Results ({0}) saved as {1}", spec.Format, spec.OutputPath);
                 }
 
-                if (engineException != null)
+                if (engineException is not null)
                 {
                     writer.WriteLine(ColorStyle.Error, Environment.NewLine + ExceptionHelper.BuildMessage(engineException));
                     return ConsoleRunner.UNEXPECTED_ERROR;
                 }
 
-                if (unloadException != null)
+                if (unloadException is not null)
                 {
                     writer.WriteLine(ColorStyle.Warning, Environment.NewLine + ExceptionHelper.BuildMessage(unloadException));
                 }
@@ -304,7 +304,7 @@ namespace NUnit.ConsoleRunner
             }
 
             // If we got here, it's because we had an exception, but check anyway
-            if (engineException != null)
+            if (engineException is not null)
             {
                 writer.WriteLine(ColorStyle.Error, ExceptionHelper.BuildMessage(engineException));
                 writer.WriteLine();
@@ -489,7 +489,7 @@ namespace NUnit.ConsoleRunner
             if (options.PauseBeforeRun)
                 package.AddSetting(FrameworkPackageSettings.PauseBeforeRun, true);
 
-            if (options.PrincipalPolicy != null)
+            if (options.PrincipalPolicy is not null)
                 package.AddSetting(EnginePackageSettings.PrincipalPolicy, options.PrincipalPolicy);
 
 #if DEBUG
@@ -501,13 +501,13 @@ namespace NUnit.ConsoleRunner
             //        throw new Exception(string.Format("Package setting {0} is not a valid type", entry.Key));
 #endif
 
-            if (options.DefaultTestNamePattern != null)
+            if (options.DefaultTestNamePattern is not null)
                 package.AddSetting(FrameworkPackageSettings.DefaultTestNamePattern, options.DefaultTestNamePattern);
 
             if (options.TestParameters.Count != 0)
                 AddTestParametersSetting(package, options.TestParameters);
 
-            if (options.ConfigurationFile != null)
+            if (options.ConfigurationFile is not null)
                 package.AddSetting(EnginePackageSettings.ConfigurationFile, options.ConfigurationFile);
 
             return package;

--- a/src/NUnitConsole/nunit4-console/ConsoleTestResult.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleTestResult.cs
@@ -67,7 +67,7 @@ namespace NUnit.ConsoleRunner
         {
             get
             {
-                if (_assertions == null)
+                if (_assertions is null)
                 {
                     _assertions = new List<AssertionResult>();
                     XmlNodeList? assertions = _resultNode.SelectNodes("assertions/assertion");
@@ -131,7 +131,7 @@ namespace NUnit.ConsoleRunner
             // In order to control the format, we trim any line-end chars
             // from end of the strings we write and supply them via calls
             // to WriteLine(). Newlines within the strings are retained.
-            return node != null
+            return node is not null
                 ? node.InnerText.TrimEnd(EOL_CHARS)
                 : null;
         }

--- a/src/NUnitConsole/nunit4-console/FileSystem.cs
+++ b/src/NUnitConsole/nunit4-console/FileSystem.cs
@@ -10,7 +10,7 @@ namespace NUnit.ConsoleRunner
     {
         public bool FileExists(string fileName)
         {
-            if (fileName == null)
+            if (fileName is null)
                 throw new ArgumentNullException("fileName");
 
             return File.Exists(fileName);
@@ -18,13 +18,13 @@ namespace NUnit.ConsoleRunner
 
         public IEnumerable<string> ReadLines(string fileName)
         {
-            if (fileName == null)
+            if (fileName is null)
                 throw new ArgumentNullException("fileName");
 
             using (var file = File.OpenText(fileName))
             {
                 string? line;
-                while ((line = file.ReadLine()) != null)
+                while ((line = file.ReadLine()) is not null)
                 {
                     yield return line;
                 }

--- a/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
@@ -25,7 +25,7 @@ namespace NUnit.ConsoleRunner.Options
 
             bool isValid = true;
 
-            if (validValues != null && validValues.Length > 0)
+            if (validValues is not null && validValues.Length > 0)
             {
                 isValid = false;
 
@@ -96,7 +96,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public OutputSpecification? ResolveOutputSpecification(string value, IList<OutputSpecification> outputSpecifications, IFileSystem fileSystem, string currentDir)
         {
-            if (value == null)
+            if (value is null)
                 return null;
 
             OutputSpecification spec;
@@ -111,7 +111,7 @@ namespace NUnit.ConsoleRunner.Options
                 return null;
             }
 
-            if (spec.Transform != null)
+            if (spec.Transform is not null)
             {
                 if (!fileSystem.FileExists(spec.Transform))
                 {

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -194,7 +194,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public static IEnumerable<string> WrappedLines(string self, IEnumerable<int> widths)
         {
-            if (widths == null)
+            if (widths is null)
                 throw new ArgumentNullException("widths");
             return CreateWrappedLinesIterator(self, widths);
         }
@@ -394,7 +394,7 @@ namespace NUnit.ConsoleRunner.Options
 
         private void AssertValid(int index)
         {
-            if (c.Option == null)
+            if (c.Option is null)
                 throw new InvalidOperationException("OptionContext.Option is null.");
             if (index >= c.Option.MaxValueCount)
                 throw new ArgumentOutOfRangeException("index");
@@ -508,7 +508,7 @@ namespace NUnit.ConsoleRunner.Options
 
         protected Option(string prototype, string? description, int maxValueCount, bool hidden)
         {
-            if (prototype == null)
+            if (prototype is null)
                 throw new ArgumentNullException("prototype");
             if (prototype.Length == 0)
                 throw new ArgumentException("Cannot be the empty string.", "prototype");
@@ -575,7 +575,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public string[] GetValueSeparators()
         {
-            if (separators == null)
+            if (separators is null)
                 return Array.Empty<string>();
             return (string[])separators.Clone();
         }
@@ -601,7 +601,7 @@ namespace NUnit.ConsoleRunner.Options
             T t = default(T)!;
             try
             {
-                if (value != null)
+                if (value is not null)
                 {
 #if PCL
                     if (targetType.GetTypeInfo ().IsEnum)
@@ -765,7 +765,7 @@ namespace NUnit.ConsoleRunner.Options
                 StringBuilder arg = new StringBuilder();
 
                 string? line;
-                while ((line = reader.ReadLine()) != null)
+                while ((line = reader.ReadLine()) is not null)
                 {
                     int t = line.Length;
 
@@ -929,9 +929,9 @@ namespace NUnit.ConsoleRunner.Options
 
         protected override string GetKeyForItem(Option item)
         {
-            if (item == null)
+            if (item is null)
                 throw new ArgumentNullException("option");
-            if (item.Names != null && item.Names.Length > 0)
+            if (item.Names is not null && item.Names.Length > 0)
                 return item.Names[0];
             // This should never happen, as it's invalid for Option to be
             // constructed w/o any names.
@@ -941,7 +941,7 @@ namespace NUnit.ConsoleRunner.Options
         [Obsolete("Use KeyedCollection.this[string]")]
         protected Option? GetOptionForName(string option)
         {
-            if (option == null)
+            if (option is null)
                 throw new ArgumentNullException("option");
             try
             {
@@ -978,7 +978,7 @@ namespace NUnit.ConsoleRunner.Options
 
         private void AddImpl(Option option)
         {
-            if (option == null)
+            if (option is null)
                 throw new ArgumentNullException("option");
             List<string> added = new List<string>(option.Names.Length);
             try
@@ -1000,7 +1000,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(string header)
         {
-            if (header == null)
+            if (header is null)
                 throw new ArgumentNullException("header");
             Add(new Category(header));
             return this;
@@ -1040,7 +1040,7 @@ namespace NUnit.ConsoleRunner.Options
             public ActionOption(string prototype, string? description, int count, Action<OptionValueCollection> action, bool hidden)
                 : base(prototype, description, count, hidden)
             {
-                if (action == null)
+                if (action is null)
                     throw new ArgumentNullException("action");
                 this.action = action;
             }
@@ -1063,7 +1063,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(string prototype, string? description, Action<string> action, bool hidden)
         {
-            if (action == null)
+            if (action is null)
                 throw new ArgumentNullException("action");
             Option p = new ActionOption(prototype, description, 1,
                     delegate(OptionValueCollection v) { action(v[0]); }, hidden);
@@ -1083,7 +1083,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(string prototype, string? description, OptionAction<string, string> action, bool hidden)
         {
-            if (action == null)
+            if (action is null)
                 throw new ArgumentNullException("action");
             Option p = new ActionOption(prototype, description, 2,
                     delegate(OptionValueCollection v) { action(v[0], v[1]); }, hidden);
@@ -1098,7 +1098,7 @@ namespace NUnit.ConsoleRunner.Options
             public ActionOption(string prototype, string? description, Action<T> action)
                 : base(prototype, description, 1)
             {
-                if (action == null)
+                if (action is null)
                     throw new ArgumentNullException("action");
                 this.action = action;
             }
@@ -1116,7 +1116,7 @@ namespace NUnit.ConsoleRunner.Options
             public ActionOption(string prototype, string? description, OptionAction<TKey, TValue> action)
                 : base(prototype, description, 2)
             {
-                if (action == null)
+                if (action is null)
                     throw new ArgumentNullException("action");
                 this.action = action;
             }
@@ -1151,7 +1151,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(ArgumentSource source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException("source");
             sources.Add(source);
             return this;
@@ -1164,7 +1164,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public List<string> Parse(IEnumerable<string> arguments)
         {
-            if (arguments == null)
+            if (arguments is null)
                 throw new ArgumentNullException("arguments");
             OptionContext c = CreateOptionContext();
             c.OptionIndex = -1;
@@ -1190,7 +1190,7 @@ namespace NUnit.ConsoleRunner.Options
                 if (!Parse(argument, c))
                     Unprocessed(unprocessed, def, c, argument);
             }
-            if (c.Option != null)
+            if (c.Option is not null)
                 c.Option.Invoke(c);
             return unprocessed;
         }
@@ -1246,7 +1246,7 @@ namespace NUnit.ConsoleRunner.Options
 
         private static bool Unprocessed(ICollection<string> extra, Option? def, OptionContext c, string argument)
         {
-            if (def == null)
+            if (def is null)
             {
                 extra.Add(argument);
                 return false;
@@ -1262,7 +1262,7 @@ namespace NUnit.ConsoleRunner.Options
 
         protected bool GetOptionParts(string argument, [NotNullWhen(true)] out string? flag, [NotNullWhen(true)] out string? name, out string? sep, out string? value)
         {
-            if (argument == null)
+            if (argument is null)
                 throw new ArgumentNullException("argument");
 
             flag = name = sep = value = null;
@@ -1283,7 +1283,7 @@ namespace NUnit.ConsoleRunner.Options
 
         protected virtual bool Parse(string argument, OptionContext c)
         {
-            if (c.Option != null)
+            if (c.Option is not null)
             {
                 ParseValue(argument, c);
                 return true;
@@ -1324,10 +1324,10 @@ namespace NUnit.ConsoleRunner.Options
 
         private void ParseValue(string? option, OptionContext c)
         {
-            Guard.OperationValid(c.Option != null, "OptionContext.Option != null");
+            Guard.OperationValid(c.Option is not null, "OptionContext.Option != null");
 
-            if (option != null)
-                foreach (string o in c.Option.ValueSeparators != null
+            if (option is not null)
+                foreach (string o in c.Option.ValueSeparators is not null
                         ? option.Split(c.Option.ValueSeparators, c.Option.MaxValueCount - c.OptionValues.Count, StringSplitOptions.None)
                         : new string[] { option })
                 {
@@ -1426,13 +1426,13 @@ namespace NUnit.ConsoleRunner.Options
                     continue;
 
                 Category? c = p as Category;
-                if (c != null)
+                if (c is not null)
                 {
                     WriteDescription(o, p.Description, string.Empty, 80, 80);
                     continue;
                 }
                 CommandOption? co = p as CommandOption;
-                if (co != null)
+                if (co is not null)
                 {
                     WriteCommandDescription(o, co.Command, co.CommandName);
                     continue;
@@ -1456,7 +1456,7 @@ namespace NUnit.ConsoleRunner.Options
             foreach (ArgumentSource s in sources)
             {
                 string[] names = s.GetNames();
-                if (names == null || names.Length == 0)
+                if (names is null || names.Length == 0)
                     continue;
 
                 int written = 0;
@@ -1543,7 +1543,7 @@ namespace NUnit.ConsoleRunner.Options
                     Write(o, ref written, localizer("["));
                 }
                 Write(o, ref written, localizer("=" + GetArgumentName(0, p.MaxValueCount, p.Description)));
-                string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0
+                string sep = p.ValueSeparators is not null && p.ValueSeparators.Length > 0
                     ? p.ValueSeparators[0]
                     : " ";
                 for (int c = 1; c < p.MaxValueCount; ++c)
@@ -1602,7 +1602,7 @@ namespace NUnit.ConsoleRunner.Options
 
         private static string GetDescription(string? description)
         {
-            if (description == null)
+            if (description is null)
                 return string.Empty;
             StringBuilder sb = new StringBuilder(description.Length);
             int start = -1;
@@ -1713,7 +1713,7 @@ namespace NUnit.ConsoleRunner.Options
         public CommandOption(Command command, string? commandName = null, bool hidden = false)
             : base("=:Command:= " + (commandName ?? command?.Name), (commandName ?? command?.Name), maxValueCount: 0, hidden: hidden)
         {
-            if (command == null)
+            if (command is null)
                 throw new ArgumentNullException(nameof(command));
             Command = command;
             CommandName = commandName ?? command.Name;
@@ -1767,10 +1767,10 @@ namespace NUnit.ConsoleRunner.Options
 
         private bool ShouldWrapOption(Option item)
         {
-            if (item == null)
+            if (item is null)
                 return false;
             var help = item as HelpOption;
-            if (help != null)
+            if (help is not null)
                 return false;
             foreach (var n in item.Names)
             {
@@ -1816,11 +1816,11 @@ namespace NUnit.ConsoleRunner.Options
 
         public CommandSet(string suite, TextWriter output, TextWriter error, MessageLocalizerConverter? localizer = null)
         {
-            if (suite == null)
+            if (suite is null)
                 throw new ArgumentNullException(nameof(suite));
-            if (output == null)
+            if (output is null)
                 throw new ArgumentNullException(nameof(output));
-            if (error == null)
+            if (error is null)
                 throw new ArgumentNullException(nameof(error));
 
             this.suite = suite;
@@ -1841,7 +1841,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public new CommandSet Add(Command value)
         {
-            if (value == null)
+            if (value is null)
                 throw new ArgumentNullException(nameof(value));
             AddCommand(value);
             options.Add(new CommandOption(value));
@@ -1850,12 +1850,12 @@ namespace NUnit.ConsoleRunner.Options
 
         private void AddCommand(Command value)
         {
-            if (value.CommandSet != null && value.CommandSet != this)
+            if (value.CommandSet is not null && value.CommandSet != this)
             {
                 throw new ArgumentException("Command instances can only be added to a single CommandSet.", nameof(value));
             }
             value.CommandSet = this;
-            if (value.Options != null)
+            if (value.Options is not null)
             {
                 value.Options.MessageLocalizer = options.MessageLocalizer;
             }
@@ -1945,10 +1945,10 @@ namespace NUnit.ConsoleRunner.Options
 
         public CommandSet Add(CommandSet nestedCommands)
         {
-            if (nestedCommands == null)
+            if (nestedCommands is null)
                 throw new ArgumentNullException(nameof(nestedCommands));
 
-            if (NestedCommandSets == null)
+            if (NestedCommandSets is null)
             {
                 NestedCommandSets = new List<CommandSet>();
             }
@@ -1980,7 +1980,7 @@ namespace NUnit.ConsoleRunner.Options
         {
             if (value == this)
                 return true;
-            if (NestedCommandSets == null)
+            if (NestedCommandSets is null)
                 return false;
             foreach (var nc in NestedCommandSets)
             {
@@ -2003,7 +2003,7 @@ namespace NUnit.ConsoleRunner.Options
                 }
             }
 
-            if (NestedCommandSets == null)
+            if (NestedCommandSets is null)
                 yield break;
 
             foreach (var subset in NestedCommandSets)
@@ -2047,16 +2047,16 @@ namespace NUnit.ConsoleRunner.Options
 
         public int Run(IEnumerable<string> arguments)
         {
-            if (arguments == null)
+            if (arguments is null)
                 throw new ArgumentNullException(nameof(arguments));
 
             this.showHelp = false;
-            if (help == null)
+            if (help is null)
             {
                 help = new HelpCommand();
                 AddCommand(help);
             }
-            Action<string> setHelp = v => showHelp = v != null;
+            Action<string> setHelp = v => showHelp = v is not null;
             if (!options.Contains("help"))
             {
                 options.Add("help", string.Empty, setHelp, hidden: true);
@@ -2076,7 +2076,7 @@ namespace NUnit.ConsoleRunner.Options
                 return 1;
             }
             var command = GetCommand(extra);
-            if (command == null)
+            if (command is null)
             {
                 help.WriteUnknownCommand(extra[0]);
                 return 1;
@@ -2120,11 +2120,11 @@ namespace NUnit.ConsoleRunner.Options
 
         private Command? TryGetNestedCommand(List<string> extra)
         {
-            if (NestedCommandSets == null)
+            if (NestedCommandSets is null)
                 return null;
 
             var nestedCommands = NestedCommandSets.Find(c => c.Suite == extra[0]);
-            if (nestedCommands == null)
+            if (nestedCommands is null)
                 return null;
 
             var extraCopy = new List<string>(extra);
@@ -2133,7 +2133,7 @@ namespace NUnit.ConsoleRunner.Options
                 return null;
 
             var command = nestedCommands.GetCommand(extraCopy);
-            if (command != null)
+            if (command is not null)
             {
                 extra.Clear();
                 extra.AddRange(extraCopy);
@@ -2177,16 +2177,16 @@ namespace NUnit.ConsoleRunner.Options
                     }
                     CommandSet.Options.WriteCommandDescription(CommandSet.Out, c.Value, c.Key);
                 }
-                if (CommandSet.help != null)
+                if (CommandSet.help is not null)
                     CommandSet.Options.WriteCommandDescription(CommandSet.Out, CommandSet.help, "help");
                 return 0;
             }
-            if (command == null)
+            if (command is null)
             {
                 WriteUnknownCommand(extra[0]);
                 return 1;
             }
-            if (command.Options != null)
+            if (command.Options is not null)
             {
                 command.Options.WriteOptionDescriptions(CommandSet.Out);
                 return 0;
@@ -2205,7 +2205,7 @@ namespace NUnit.ConsoleRunner.Options
                 commands.Add(new KeyValuePair<string, Command>(c.Name, c));
             }
 
-            if (commandSet.NestedCommandSets == null)
+            if (commandSet.NestedCommandSets is null)
                 return commands;
 
             foreach (var nc in commandSet.NestedCommandSets)
@@ -2222,7 +2222,7 @@ namespace NUnit.ConsoleRunner.Options
             {
                 commands.Add(new KeyValuePair<string, Command>($"{outer}{value.Suite} {v.Name}", v));
             }
-            if (value.NestedCommandSets == null)
+            if (value.NestedCommandSets is null)
                 return;
             foreach (var nc in value.NestedCommandSets)
             {

--- a/src/NUnitConsole/nunit4-console/Options/OutputSpecification.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OutputSpecification.cs
@@ -19,7 +19,7 @@ namespace NUnit.ConsoleRunner.Options
         /// <param name="transformFolder">The folder containing the transform.</param>
         public OutputSpecification(string spec, string? transformFolder)
         {
-            if (spec == null)
+            if (spec is null)
                 throw new ArgumentNullException(nameof(spec), "Output spec may not be null");
 
             string[] parts = spec.Split(';');
@@ -37,7 +37,7 @@ namespace NUnit.ConsoleRunner.Options
                     case "format":
                         string fmt = opt[1].Trim();
 
-                        if (this.Format != null && this.Format != fmt)
+                        if (this.Format is not null && this.Format != fmt)
                             throw new ArgumentException(
                                 string.Format("Conflicting format options: {0}", spec));
 
@@ -47,11 +47,11 @@ namespace NUnit.ConsoleRunner.Options
                     case "transform":
                         string val = opt[1].Trim();
 
-                        if (this.Transform != null && this.Transform != val)
+                        if (this.Transform is not null && this.Transform != val)
                             throw new ArgumentException(
                                 string.Format("Conflicting transform options: {0}", spec));
 
-                        if (this.Format != null && this.Format != "user")
+                        if (this.Format is not null && this.Format != "user")
                             throw new ArgumentException(
                                 string.Format("Conflicting format options: {0}", spec));
 
@@ -61,7 +61,7 @@ namespace NUnit.ConsoleRunner.Options
                 }
             }
 
-            if (Format == null)
+            if (Format is null)
                 Format = "nunit3";
         }
 
@@ -83,9 +83,9 @@ namespace NUnit.ConsoleRunner.Options
         public override string ToString()
         {
             var sb = new StringBuilder($"OutputPath: {OutputPath}");
-            if (Format != null)
+            if (Format is not null)
                 sb.Append($", Format: {Format}");
-            if (Transform != null)
+            if (Transform is not null)
                 sb.Append($", Transform: {Transform}");
             return sb.ToString();
         }

--- a/src/NUnitConsole/nunit4-console/Options/TestNameParser.cs
+++ b/src/NUnitConsole/nunit4-console/Options/TestNameParser.cs
@@ -23,7 +23,7 @@ namespace NUnit.ConsoleRunner.Options
             while (index < argument.Length)
             {
                 string name = GetTestName(argument, ref index);
-                if (name != null && name != string.Empty)
+                if (name is not null && name != string.Empty)
                     list.Add(name);
             }
 

--- a/src/NUnitConsole/nunit4-console/Program.cs
+++ b/src/NUnitConsole/nunit4-console/Program.cs
@@ -28,7 +28,7 @@ namespace NUnit.ConsoleRunner
         {
             get
             {
-                if (_outWriter == null)
+                if (_outWriter is null)
                     _outWriter = new ColorConsoleWriter(!Options.NoColor);
 
                 return _outWriter;
@@ -101,7 +101,7 @@ namespace NUnit.ConsoleRunner
                     if (Options.RuntimeFrameworkSpecified)
                     {
                         var availableRuntimeService = engine.Services.GetService<IAvailableRuntimes>();
-                        if (availableRuntimeService == null)
+                        if (availableRuntimeService is null)
                         {
                             WriteErrorMessage("Unable to acquire AvailableRuntimeService from engine");
                             return ConsoleRunner.UNEXPECTED_ERROR;
@@ -119,10 +119,10 @@ namespace NUnit.ConsoleRunner
                             WriteErrorMessage("Unavailable runtime framework requested: " + Options.RuntimeFramework);
                     }
 
-                    if (Options.WorkDirectory != null)
+                    if (Options.WorkDirectory is not null)
                         engine.WorkDirectory = Options.WorkDirectory;
 
-                    engine.InternalTraceLevel = Options.InternalTraceLevel != null
+                    engine.InternalTraceLevel = Options.InternalTraceLevel is not null
                         ? (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), Options.InternalTraceLevel)
                         : InternalTraceLevel.Off;
 

--- a/src/NUnitConsole/nunit4-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit4-console/ResultReporter.cs
@@ -20,7 +20,7 @@ namespace NUnit.ConsoleRunner
             string? overallResult = resultNode.GetAttribute("result");
             if (overallResult == "Skipped")
                 OverallResult = "Warning";
-            if (overallResult == null)
+            if (overallResult is null)
                 OverallResult = "Unknown";
             else
                 OverallResult = overallResult;
@@ -56,7 +56,7 @@ namespace NUnit.ConsoleRunner
         internal void WriteRunSettingsReport()
         {
             var firstSuite = ResultNode.SelectSingleNode("test-suite");
-            if (firstSuite != null)
+            if (firstSuite is not null)
             {
                 var settings = firstSuite.SelectNodes("settings/setting");
 
@@ -190,7 +190,7 @@ namespace NUnit.ConsoleRunner
 
                             // Correct a problem in some framework versions, whereby warnings and some failures
                             // are promulgated to the containing suite without setting the FailureSite.
-                            if (site == null)
+                            if (site is null)
                             {
                                 if (resultNode.SelectSingleNode("reason/message")?.InnerText == "One or more child tests had warnings" ||
                                     resultNode.SelectSingleNode("failure/message")?.InnerText == "One or more child tests had errors")

--- a/src/NUnitConsole/nunit4-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit4-console/ResultSummary.cs
@@ -158,7 +158,7 @@ namespace NUnit.ConsoleRunner
                         case "Failed":
                             if (failedInFixtureTearDown)
                                 ErrorCount++;
-                            else if (label == null)
+                            else if (label is null)
                                 FailureCount++;
                             else if (label == "Invalid")
                                 InvalidCount++;

--- a/src/NUnitConsole/nunit4-console/SafeAttributeAccess.cs
+++ b/src/NUnitConsole/nunit4-console/SafeAttributeAccess.cs
@@ -29,7 +29,7 @@ namespace NUnit.ConsoleRunner
         {
             XmlAttribute? attr = result.Attributes?[name];
 
-            return attr == null ? null : attr.Value;
+            return attr is null ? null : attr.Value;
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace NUnit.ConsoleRunner
         {
             XmlAttribute? attr = result.Attributes?[name];
 
-            return attr == null
+            return attr is null
                 ? defaultValue
                 : double.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
         }
@@ -58,7 +58,7 @@ namespace NUnit.ConsoleRunner
         public static DateTime GetAttribute(this XmlNode result, string name, DateTime defaultValue)
         {
             string? dateStr = GetAttribute(result, name);
-            if (dateStr == null)
+            if (dateStr is null)
                 return defaultValue;
 
             DateTime date;

--- a/src/NUnitConsole/nunit4-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit4-console/TestEventHandler.cs
@@ -38,7 +38,7 @@ namespace NUnit.ConsoleRunner
             doc.LoadXml(report);
 
             var testEvent = doc.FirstChild;
-            if (testEvent == null)
+            if (testEvent is null)
                 return;
 
             switch (testEvent.Name)
@@ -65,7 +65,7 @@ namespace NUnit.ConsoleRunner
         {
             var testName = testResult.Attributes?["fullname"]?.Value;
 
-            if (_displayBeforeTest && testName != null)
+            if (_displayBeforeTest && testName is not null)
                 WriteLabelLine(testName);
         }
 
@@ -73,13 +73,13 @@ namespace NUnit.ConsoleRunner
         {
             var testName = testResult.Attributes?["fullname"]?.Value;
 
-            if (testName == null)
+            if (testName is null)
                 return;
 
             var status = testResult.GetAttribute("label") ?? testResult.GetAttribute("result") ?? "Unknown";
             var outputNode = testResult.SelectSingleNode("output");
 
-            if (outputNode != null)
+            if (outputNode is not null)
             {
                 if (_displayBeforeOutput)
                     WriteLabelLine(testName);
@@ -97,7 +97,7 @@ namespace NUnit.ConsoleRunner
             var suiteName = testResult.Attributes?["fullname"]?.Value;
             var outputNode = testResult.SelectSingleNode("output");
 
-            if (suiteName != null && outputNode != null)
+            if (suiteName is not null && outputNode is not null)
             {
                 if (_displayBeforeOutput)
                     WriteLabelLine(suiteName);
@@ -111,7 +111,7 @@ namespace NUnit.ConsoleRunner
         {
             var testName = outputNode.GetAttribute("testname");
 
-            if (testName != null)
+            if (testName is not null)
             {
                 if (_displayBeforeOutput)
                     WriteLabelLine(testName);
@@ -141,7 +141,7 @@ namespace NUnit.ConsoleRunner
             FlushNewLineIfNeeded();
             _lastTestOutput = label;
 
-            if (status != null)
+            if (status is not null)
             {
                 _outWriter.Write(GetColorForResultStatus(status), $"{status} ");
             }

--- a/src/NUnitConsole/nunit4-netcore-console/Program.cs
+++ b/src/NUnitConsole/nunit4-netcore-console/Program.cs
@@ -27,7 +27,7 @@ namespace NUnit.ConsoleRunner
         {
             get
             {
-                if (_outWriter == null)
+                if (_outWriter is null)
                     _outWriter = new ColorConsoleWriter(!Options.NoColor);
 
                 return _outWriter;
@@ -97,10 +97,10 @@ namespace NUnit.ConsoleRunner
                         return ConsoleRunner.INVALID_ARG;
                     }
 
-                    if (Options.WorkDirectory != null)
+                    if (Options.WorkDirectory is not null)
                         engine.WorkDirectory = Options.WorkDirectory;
 
-                    engine.InternalTraceLevel = Options.InternalTraceLevel != null
+                    engine.InternalTraceLevel = Options.InternalTraceLevel is not null
                         ? (InternalTraceLevel)Enum.Parse(typeof(InternalTraceLevel), Options.InternalTraceLevel)
                         : InternalTraceLevel.Off;
 

--- a/src/NUnitEngine/nunit.engine.api/AsyncTestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine.api/AsyncTestEngineResult.cs
@@ -23,7 +23,7 @@ namespace NUnit.Engine
         {
             get
             {
-                if (_result == null)
+                if (_result is null)
                     throw new InvalidOperationException("Cannot retrieve Result from an incomplete or cancelled TestRun.");
 
                 return _result;
@@ -44,9 +44,9 @@ namespace NUnit.Engine
         /// <param name="result"></param>
         public void SetResult(TestEngineResult result)
         {
-            if (result == null)
+            if (result is null)
                 throw new ArgumentNullException(nameof(result));
-            if (_result != null)
+            if (_result is not null)
                 throw new InvalidOperationException("Cannot set the Result of an TestRun more than once");
 
             _result = result;
@@ -69,7 +69,7 @@ namespace NUnit.Engine
         /// </summary>
         public bool IsComplete
         {
-            get { return _result != null; }
+            get { return _result is not null; }
         }
 
         XmlNode ITestRun.Result

--- a/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineActivator.cs
@@ -22,7 +22,7 @@ namespace NUnit.Engine
         {
             var apiLocation = typeof(TestEngineActivator).Assembly.Location;
             var directoryName = Path.GetDirectoryName(apiLocation);
-            var enginePath = directoryName == null ? DEFAULT_ENGINE_ASSEMBLY : Path.Combine(directoryName, DEFAULT_ENGINE_ASSEMBLY);
+            var enginePath = directoryName is null ? DEFAULT_ENGINE_ASSEMBLY : Path.Combine(directoryName, DEFAULT_ENGINE_ASSEMBLY);
             var assembly = Assembly.LoadFrom(enginePath);
             var engineType = assembly.GetType(DEFAULT_ENGINE_TYPE, throwOnError: true)!;
             return (ITestEngine)Activator.CreateInstance(engineType)!;

--- a/src/NUnitEngine/nunit.engine.api/TestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineResult.cs
@@ -76,7 +76,7 @@ namespace NUnit.Engine
             get
             {
                 // xmlNodes might be null after deserialization
-                if (_xmlNodes == null)
+                if (_xmlNodes is null)
                     _xmlNodes = new List<XmlNode>();
 
                 for (int i = _xmlNodes.Count; i < _xmlText.Count; i++)
@@ -84,7 +84,7 @@ namespace NUnit.Engine
                     XmlDocument doc = new XmlDocument();
                     doc.LoadXml(_xmlText[i]);
                     // TODO: Should we throw if first child is null?
-                    if (doc.FirstChild != null)
+                    if (doc.FirstChild is not null)
                         _xmlNodes.Add(doc.FirstChild);
                 }
 

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -78,7 +78,7 @@ namespace NUnit.Engine
         /// </summary>
         public string? Name
         {
-            get { return FullName == null ? null : Path.GetFileName(FullName); }
+            get { return FullName is null ? null : Path.GetFileName(FullName); }
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/ProcessTester.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/ProcessTester.cs
@@ -24,7 +24,7 @@ namespace NUnit.Engine.TestHelpers
 
                 process.OutputDataReceived += (sender, e) =>
                 {
-                    if (e.Data == null)
+                    if (e.Data is null)
                         return;
                     if (currentDataIsError)
                     {
@@ -37,7 +37,7 @@ namespace NUnit.Engine.TestHelpers
                 };
                 process.ErrorDataReceived += (sender, e) =>
                 {
-                    if (e.Data == null)
+                    if (e.Data is null)
                         return;
                     if (!currentDataIsError)
                     {

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/StackEnumerator.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/StackEnumerator.cs
@@ -36,14 +36,14 @@ namespace NUnit.Engine.TestHelpers
 
         public void Recurse(IEnumerator<T> newCurrent)
         {
-            if (newCurrent == null)
+            if (newCurrent is null)
                 return;
             stack.Push(current);
             current = newCurrent;
         }
         public void Recurse(IEnumerable<T> newCurrent)
         {
-            if (newCurrent == null)
+            if (newCurrent is null)
                 return;
             Recurse(newCurrent.GetEnumerator());
         }

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MultipleTestProcessRunnerTests.cs
@@ -42,14 +42,14 @@ namespace NUnit.Engine.Runners
         [TestCase(20, 8, 8)]
         public void CheckLevelOfParallelism_ListOfAssemblies(int assemblyCount, int? maxAgents, int expected)
         {
-            if (maxAgents == null)
+            if (maxAgents is null)
                 expected = Math.Min(assemblyCount, _processorCount);
 
             var assemblies = new List<string>();
             for (int i = 1; i <= assemblyCount; i++)
                 assemblies.Add($"test{i}.dll");
             var package = new TestPackage(assemblies);
-            if (maxAgents != null)
+            if (maxAgents is not null)
                 package.Settings[EnginePackageSettings.MaxAgents] = maxAgents;
             var runner = new MultipleTestProcessRunner(_serviceContext, package, _processorCount);
             Assert.That(runner.LevelOfParallelism, Is.EqualTo(expected));
@@ -76,7 +76,7 @@ namespace NUnit.Engine.Runners
             var package = new TestPackage(new string[] { "proj.nunit" });
             for (int i = 1; i <= assemblyCount; i++)
                 package.SubPackages[0].AddSubPackage(new TestPackage($"test{i}.dll"));
-            if (maxAgents != null)
+            if (maxAgents is not null)
                 package.Settings[EnginePackageSettings.MaxAgents] = maxAgents;
             var runner = new MultipleTestProcessRunner(_serviceContext, package);
             Assert.That(runner.LevelOfParallelism, Is.EqualTo(expected));

--- a/src/NUnitEngine/nunit.engine.tests/Services/FakeProjectService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/FakeProjectService.cs
@@ -24,7 +24,7 @@ namespace NUnit.Engine.Services
 
         void IProjectService.ExpandProjectPackage(TestPackage package)
         {
-            if (package.Name == null)
+            if (package.Name is null)
             {
                 throw new ArgumentException("Package must have a name", nameof(package));
             }

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -15,7 +15,7 @@ namespace NUnit.Engine.Services
 
         // We can do this because we currently only build under NETFRAMEWORK
         private static Runtime _currentRuntime =
-            Type.GetType("Mono.Runtime", false) != null
+            Type.GetType("Mono.Runtime", false) is not null
                 ? Runtime.Mono
                 : Runtime.Net;
 

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Remoting/TestAgencyRemotingTransport.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Remoting/TestAgencyRemotingTransport.cs
@@ -55,7 +55,7 @@ namespace NUnit.Engine.Communication.Transports.Remoting
             if (_port == 0)
             {
                 ChannelDataStore? store = _channel!.ChannelData as ChannelDataStore;
-                if (store != null)
+                if (store is not null)
                 {
                     string channelUri = store.ChannelUris[0];
                     _port = int.Parse(channelUri.Substring(channelUri.LastIndexOf(':') + 1));
@@ -76,7 +76,7 @@ namespace NUnit.Engine.Communication.Transports.Remoting
                     this._isMarshalled = false;
                 }
 
-                if (this._channel != null)
+                if (this._channel is not null)
                 {
                     try
                     {

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgentTcpProxy.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgentTcpProxy.cs
@@ -117,11 +117,11 @@ namespace NUnit.Engine.Communication.Transports.Tcp
                 var receivedType = receivedMessage.GetType();
 
                 var returnMessage = receivedMessage as CommandReturnMessage;
-                if (returnMessage != null)
+                if (returnMessage is not null)
                     return (TestEngineResult)returnMessage.ReturnValue;
 
                 var progressMessage = receivedMessage as ProgressMessage;
-                if (progressMessage == null)
+                if (progressMessage is null)
                     throw new InvalidOperationException($"Expected either a ProgressMessage or a CommandReturnMessage but received a {receivedType}");
 
                 listener.OnTestEvent(progressMessage.Report);

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -49,7 +49,7 @@ namespace NUnit.Engine.Runners
         {
             get
             {
-                if (_runners == null)
+                if (_runners is null)
                 {
                     _runners = new List<ITestEngineRunner>();
                     foreach (var subPackage in TestPackage.Select(p => !p.HasSubPackages()))
@@ -64,7 +64,7 @@ namespace NUnit.Engine.Runners
 
         public AggregatingTestRunner(IServiceLocator services, TestPackage package) : base(services, package)
         {
-            Guard.ArgumentValid(TestRunnerFactory != null, "TestRunnerFactory service not available", nameof(services));
+            Guard.ArgumentValid(TestRunnerFactory is not null, "TestRunnerFactory service not available", nameof(services));
         }
 
         /// <summary>
@@ -229,12 +229,12 @@ namespace NUnit.Engine.Runners
         private static void LogResultsFromTask(TestExecutionTask task, List<TestEngineResult> results, List<Exception> unloadExceptions)
         {
             var result = task.Result;
-            if (result != null)
+            if (result is not null)
             {
                 results.Add(result);
             }
 
-            if (task.UnloadException != null)
+            if (task.UnloadException is not null)
             {
                 unloadExceptions.Add(task.UnloadException);
             }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -48,9 +48,9 @@ namespace NUnit.Engine.Runners
 
         public MasterTestRunner(IServiceLocator services, TestPackage package)
         {
-            if (services == null)
+            if (services is null)
                 throw new ArgumentNullException("services");
-            if (package == null)
+            if (package is null)
                 throw new ArgumentNullException("package");
 
             _services = services;
@@ -85,7 +85,7 @@ namespace NUnit.Engine.Runners
         /// </summary>
         protected bool IsPackageLoaded
         {
-            get { return LoadResult != null; }
+            get { return LoadResult is not null; }
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace NUnit.Engine.Runners
         {
             if (!_disposed)
             {
-                if (disposing && _engineRunner != null)
+                if (disposing && _engineRunner is not null)
                     _engineRunner.Dispose();
 
                 _disposed = true;
@@ -243,7 +243,7 @@ namespace NUnit.Engine.Runners
         //Exposed for testing
         internal ITestEngineRunner GetEngineRunner()
         {
-            if (_engineRunner == null)
+            if (_engineRunner is null)
             {
                 // Some files in the top level package may be projects.
                 // Expand them so that they contain subprojects for
@@ -270,7 +270,7 @@ namespace NUnit.Engine.Runners
         // allows the lower-level runners to be completely ignorant of projects
         private TestEngineResult PrepareResult(TestEngineResult result)
         {
-            if (result == null)
+            if (result is null)
                 throw new ArgumentNullException("result");
 
             // See if we have any projects to deal with. At this point,
@@ -332,7 +332,7 @@ namespace NUnit.Engine.Runners
 
         private void EnsurePackagesAreExpanded(TestPackage package)
         {
-            if (package == null)
+            if (package is null)
                 throw new ArgumentNullException("package");
 
             foreach (var subPackage in package.SubPackages)
@@ -348,11 +348,11 @@ namespace NUnit.Engine.Runners
 
         private bool IsProjectPackage(TestPackage package)
         {
-            if (package == null)
+            if (package is null)
                 throw new ArgumentNullException("package");
 
             return
-                _projectService != null
+                _projectService is not null
                 && !string.IsNullOrEmpty(package.FullName)
                 && _projectService.CanLoadFrom(package.FullName);
         }
@@ -423,7 +423,7 @@ namespace NUnit.Engine.Runners
             _eventDispatcher.Listeners.Clear();
             _eventDispatcher.Listeners.Add(_workItemTracker);
 
-            if (listener != null)
+            if (listener is not null)
                 _eventDispatcher.Listeners.Add(listener);
 
             foreach (var extension in _extensionService.GetExtensions<ITestEventListener>())
@@ -493,7 +493,7 @@ namespace NUnit.Engine.Runners
         {
             var doc = resultNode.OwnerDocument;
 
-            if (doc == null)
+            if (doc is null)
             {
                 return;
             }
@@ -517,7 +517,7 @@ namespace NUnit.Engine.Runners
             }
 
             var doc = resultNode.OwnerDocument;
-            if (doc == null)
+            if (doc is null)
             {
                 return;
             }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -57,7 +57,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         protected override TestEngineResult LoadPackage()
         {
-            Guard.OperationValid(TestPackage != null, "Calling LoadPackage with null TestPackage");
+            Guard.OperationValid(TestPackage is not null, "Calling LoadPackage with null TestPackage");
 
             log.Info("Loading " + TestPackage.Name);
             Unload();
@@ -85,7 +85,7 @@ namespace NUnit.Engine.Runners
         {
             try
             {
-                if (_remoteRunner != null)
+                if (_remoteRunner is not null)
                 {
                     log.Info("Unloading " + TestPackage.Name);
                     _remoteRunner.Unload();
@@ -179,7 +179,7 @@ namespace NUnit.Engine.Runners
         /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
         public override void StopRun(bool force)
         {
-            if (_remoteRunner != null)
+            if (_remoteRunner is not null)
             {
                 try
                 {
@@ -216,14 +216,14 @@ namespace NUnit.Engine.Runners
                     log.Error(ExceptionHelper.BuildMessageAndStackTrace(ex));
                 }
 
-                if (_agent != null && _agency.IsAgentProcessActive(_agent.Id, out _))
+                if (_agent is not null && _agency.IsAgentProcessActive(_agent.Id, out _))
                 {
                     try
                     {
                         log.Debug("Stopping remote agent");
                         _agent.Stop();
                     }
-                    catch (NUnitEngineUnloadException ex) when (unloadException != null)
+                    catch (NUnitEngineUnloadException ex) when (unloadException is not null)
                     {
                         // Both kinds of errors, throw exception with combined message
                         throw new NUnitEngineUnloadException(ExceptionHelper.BuildMessage(unloadException) + Environment.NewLine + ex.Message);
@@ -234,7 +234,7 @@ namespace NUnit.Engine.Runners
                     }
                 }
 
-                if (unloadException != null) // Add message line indicating we managed to stop agent anyway
+                if (unloadException is not null) // Add message line indicating we managed to stop agent anyway
                     throw new NUnitEngineUnloadException("Agent Process was terminated successfully after error.", unloadException);
             }
         }
@@ -242,7 +242,7 @@ namespace NUnit.Engine.Runners
         [MemberNotNull(nameof(_agent), nameof(_remoteRunner))]
         private void CreateAgentAndRunnerIfNeeded()
         {
-            if (_agent == null)
+            if (_agent is null)
             {
                 // Increase the timeout to give time to attach a debugger
                 bool debug = TestPackage.GetSetting(EnginePackageSettings.DebugAgent, false) ||
@@ -250,11 +250,11 @@ namespace NUnit.Engine.Runners
 
                 _agent = _agency.GetAgent(TestPackage);
 
-                if (_agent == null)
+                if (_agent is null)
                     throw new NUnitEngineException("Unable to acquire remote process agent");
             }
 
-            if (_remoteRunner == null)
+            if (_remoteRunner is null)
                 _remoteRunner = _agent.CreateRunner(TestPackage);
         }
 

--- a/src/NUnitEngine/nunit.engine/Runners/TestEngineRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEngineRunner.cs
@@ -41,7 +41,7 @@ namespace NUnit.Engine.Runners
         /// <summary>
         /// Gets an indicator of whether the package has been loaded.
         /// </summary>
-        public bool IsPackageLoaded => LoadResult != null;
+        public bool IsPackageLoaded => LoadResult is not null;
 
         /// <summary>
         /// Loads the TestPackage for exploration or execution.
@@ -130,7 +130,7 @@ namespace NUnit.Engine.Runners
         /// <exception cref="InvalidOperationException">If no package has been loaded</exception>
         public TestEngineResult Reload()
         {
-            if (this.TestPackage == null)
+            if (this.TestPackage is null)
                 throw new InvalidOperationException("MasterTestRunner: Reload called before Load");
 
             return LoadResult = ReloadPackage();

--- a/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
@@ -56,7 +56,7 @@ namespace NUnit.Engine.Runners
             public int CompareTo(InProgressItem? other)
             {
                 // for signaling purposes, return in reverse order
-                if (other == null)
+                if (other is null)
                     return -1;
 
                 return _order.CompareTo(other._order) * -1;
@@ -165,7 +165,7 @@ namespace NUnit.Engine.Runners
                         case "test-case":
                         case "test-suite":
                             string? id = reader.GetAttribute("id");
-                            if (id != null) // TODO: Should we throw if id is null?
+                            if (id is not null) // TODO: Should we throw if id is null?
                                 RemoveItem(id);
 
                             if (_itemsInProcess.Count == 0)

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -73,7 +73,7 @@ namespace NUnit.Engine.Services
                         throw new Exception("Running .NET Core as X86 is currently only supported on Windows");
 
                     string? installDirectory = DotNet.GetX86InstallDirectory();
-                    if (installDirectory == null)
+                    if (installDirectory is null)
                         throw new Exception("The X86 version of dotnet.exe is not installed");
 
                     var x86_dotnet_exe = Path.Combine(installDirectory, "dotnet.exe");

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
@@ -64,7 +64,7 @@ namespace NUnit.Engine.Services
                     && record.Status != AgentStatus.Terminated)
                 {
                     process = record.Process;
-                    return process != null;
+                    return process is not null;
                 }
 
                 process = null;

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -23,14 +23,14 @@ namespace NUnit.Engine.Services
         public bool CanLoadFrom(string path)
         {
             ExtensionNode? node = GetNodeForPath(path);
-            if (node != null && ((IProjectLoader)node.ExtensionObject).CanLoadFrom(path))
+            if (node is not null && ((IProjectLoader)node.ExtensionObject).CanLoadFrom(path))
             {
                 log.Debug($"{node.ExtensionObject.GetType()} can load {path}");
                 return true;
             }
 
             log.Debug($"Cannot load {path}");
-            if (node == null)
+            if (node is null)
                 log.Debug("    No Extension was found");
             return false;
         }
@@ -41,7 +41,7 @@ namespace NUnit.Engine.Services
             {
                 ExtensionNode? node = GetNodeForPath(path);
                 IProjectLoader loader;
-                if (node != null && (loader = (IProjectLoader)node.ExtensionObject).CanLoadFrom(path))
+                if (node is not null && (loader = (IProjectLoader)node.ExtensionObject).CanLoadFrom(path))
                 {
                     log.Debug($"Using loader {loader.GetType()}");
                     return loader.LoadFrom(path);
@@ -55,10 +55,10 @@ namespace NUnit.Engine.Services
         {
             var ext = Path.GetExtension(path);
 
-            if (string.IsNullOrEmpty(ext) || _extensionService == null)
+            if (string.IsNullOrEmpty(ext) || _extensionService is null)
                 return null;
 
-            if (_extensionNodes == null)
+            if (_extensionNodes is null)
                 _extensionNodes = _extensionService.GetExtensionNodes<IProjectLoader>();
 
             foreach (var node in _extensionNodes)
@@ -92,7 +92,7 @@ namespace NUnit.Engine.Services
 
             string? activeConfig = package.GetSetting(EnginePackageSettings.ActiveConfig, (string?)null);
             log.Debug($"Got ActiveConfig setting {activeConfig ?? "<null>"}");
-            if (activeConfig == null)
+            if (activeConfig is null)
                 activeConfig = project.ActiveConfigName;
             else
                 Guard.ArgumentValid(project.ConfigNames.Contains(activeConfig), $"Requested configuration {activeConfig} was not found", "package");
@@ -126,12 +126,12 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                if (ServiceContext == null)
+                if (ServiceContext is null)
                     throw new InvalidOperationException("Only services that have a ServiceContext can be started.");
 
                 _extensionService = ServiceContext.GetService<ExtensionService>();
 
-                Status = _extensionService == null || _extensionService.Status == ServiceStatus.Started
+                Status = _extensionService is null || _extensionService.Status == ServiceStatus.Started
                     ? ServiceStatus.Started : ServiceStatus.Error;
             }
             catch

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -22,11 +22,11 @@ namespace NUnit.Engine.Services
         {
             get
             {
-                if (_formats == null)
+                if (_formats is null)
                 {
                     var formatList = new List<string>(BUILT_IN_FORMATS);
 
-                    if (_extensionNodes != null)
+                    if (_extensionNodes is not null)
                         foreach (var node in _extensionNodes)
                             foreach (var format in node.GetValues("Format"))
                                 formatList.Add(format);
@@ -61,7 +61,7 @@ namespace NUnit.Engine.Services
                     return new XmlTransformResultWriter(args!);
 
                 default:
-                    if (_extensionNodes != null)
+                    if (_extensionNodes is not null)
                         foreach (var node in _extensionNodes)
                             foreach (var supported in node.GetValues("Format"))
                                 if (supported == format)
@@ -77,7 +77,7 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                if (ServiceContext == null)
+                if (ServiceContext is null)
                     throw new InvalidOperationException("Only services that have a ServiceContext can be started.");
 
                 var extensionService = ServiceContext.GetService<ExtensionService>();

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/TestCaseResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/TestCaseResultWriter.cs
@@ -29,7 +29,7 @@ namespace NUnit.Engine.Services
         public void WriteResultFile(XmlNode resultNode, TextWriter writer)
         {
             XmlNodeList? testCases = resultNode.SelectNodes("//test-case");
-            if (testCases != null)
+            if (testCases is not null)
                 foreach (XmlNode node in testCases)
                     writer.WriteLine(node.Attributes?["fullname"]?.Value);
         }

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Services
         /// <summary>
         /// The path to the mono executable, if we are running on Mono.
         /// </summary>
-        public static string MonoExePath => MonoPrefix != null && Environment.OSVersion.Platform == PlatformID.Win32NT
+        public static string MonoExePath => MonoPrefix is not null && Environment.OSVersion.Platform == PlatformID.Win32NT
                     ? Path.Combine(MonoPrefix, "bin/mono.exe")
                     : "mono";
 
@@ -118,7 +118,7 @@ namespace NUnit.Engine.Services
 
         private RuntimeFramework SelectRuntimeFrameworkInner(TestPackage package)
         {
-            if (CurrentFramework == null)
+            if (CurrentFramework is null)
                 throw new InvalidOperationException("Service not Started");
 
             foreach (var subPackage in package.SubPackages)
@@ -220,14 +220,14 @@ namespace NUnit.Engine.Services
         {
             Type? monoRuntimeType = Type.GetType("Mono.Runtime", throwOnError: false);
 
-            Runtime runtime = monoRuntimeType != null
+            Runtime runtime = monoRuntimeType is not null
                 ? Runtime.Mono
                 : Runtime.Net;
 
             int major = Environment.Version.Major;
             int minor = Environment.Version.Minor;
 
-            if (monoRuntimeType != null)
+            if (monoRuntimeType is not null)
             {
                 switch (major)
                 {
@@ -244,10 +244,10 @@ namespace NUnit.Engine.Services
                 if (major == 2)
             {
                 using RegistryKey? key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\.NETFramework");
-                if (key != null)
+                if (key is not null)
                 {
                     string? installRoot = key.GetValue("InstallRoot") as string;
-                    if (installRoot != null)
+                    if (installRoot is not null)
                     {
                         if (Directory.Exists(Path.Combine(installRoot, "v3.5")))
                         {
@@ -262,20 +262,20 @@ namespace NUnit.Engine.Services
                     }
                 }
             }
-            else if (major == 4 && Type.GetType("System.Reflection.AssemblyMetadataAttribute") != null)
+            else if (major == 4 && Type.GetType("System.Reflection.AssemblyMetadataAttribute") is not null)
             {
                 minor = 5;
             }
 
             var currentFramework = new RuntimeFramework(runtime, new Version(major, minor));
 
-            if (monoRuntimeType != null)
+            if (monoRuntimeType is not null)
             {
                 MonoPrefix = GetMonoPrefixFromAssembly(monoRuntimeType.Assembly);
 
                 MethodInfo? getDisplayNameMethod = monoRuntimeType.GetMethod(
                     "GetDisplayName", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding);
-                if (getDisplayNameMethod != null)
+                if (getDisplayNameMethod is not null)
                 {
                     string displayName = (string)getDisplayNameMethod.Invoke(null, new object[0])!;
 
@@ -367,7 +367,7 @@ namespace NUnit.Engine.Services
                     string fn = subPackage.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty);
                     if (fn != string.Empty)
                     {
-                        if (frameworkName == null || fn.CompareTo(frameworkName) < 0)
+                        if (frameworkName is null || fn.CompareTo(frameworkName) < 0)
                             frameworkName = fn;
                     }
 

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetCoreRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetCoreRuntimeLocator.cs
@@ -40,7 +40,7 @@ namespace NUnit.Engine.Services.RuntimeLocators
         {
             string? installDir = DotNet.GetInstallDirectory(x86);
 
-            if (installDir != null && Directory.Exists(installDir) &&
+            if (installDir is not null && Directory.Exists(installDir) &&
                 File.Exists(Path.Combine(installDir, "dotnet.exe")))
             {
                 string runtimeDir = Path.Combine(installDir, Path.Combine("shared", "Microsoft.NETCore.App"));
@@ -78,7 +78,7 @@ namespace NUnit.Engine.Services.RuntimeLocators
             const int VERSION_START = 22;
 
             string? line;
-            while ((line = process.StandardOutput.ReadLine()) != null)
+            while ((line = process.StandardOutput.ReadLine()) is not null)
             {
                 if (line.StartsWith(PREFIX))
                     yield return line.Substring(VERSION_START);

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetFxRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetFxRuntimeLocator.cs
@@ -19,14 +19,14 @@ namespace NUnit.Engine.Services.RuntimeLocators
                 yield return framework;
 
             using RegistryKey? key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\NET Framework Setup\NDP");
-            if (key != null)
+            if (key is not null)
             {
                 foreach (string name in key.GetSubKeyNames())
                 {
                     if (name.StartsWith("v") && name != "v4.0") // v4.0 is a duplicate, legacy key
                     {
                         var versionKey = key.OpenSubKey(name);
-                        if (versionKey == null)
+                        if (versionKey is null)
                             continue;
 
                         if (name.StartsWith("v4", StringComparison.Ordinal))
@@ -51,7 +51,7 @@ namespace NUnit.Engine.Services.RuntimeLocators
         {
             using RegistryKey? key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\.NETFramework\policy\v1.0");
 
-            if (key == null)
+            if (key is null)
                 yield break;
 
             foreach (var build in key.GetValueNames())
@@ -89,7 +89,7 @@ namespace NUnit.Engine.Services.RuntimeLocators
             foreach (string profile in new string[] { "Full", "Client" })
             {
                 var profileKey = versionKey.OpenSubKey(profile);
-                if (profileKey == null)
+                if (profileKey is null)
                     continue;
 
                 if (CheckInstallDword(profileKey))

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -41,7 +41,7 @@ namespace NUnit.Engine.Services
                     }
                 }
 
-            if (theService == null)
+            if (theService is null)
             {
                 string message = $"Requested service {serviceType.FullName} was not found";
                 log.Error(message);

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -52,7 +52,7 @@ namespace NUnit.Engine.Services
 
         public ITestAgent? GetAgent(TestPackage package)
         {
-            if (_runtimeService == null || _availableRuntimeService == null)
+            if (_runtimeService is null || _availableRuntimeService is null)
                 throw new InvalidOperationException("TestAgency needs to be Started first");
 
             // Target Runtime must be specified by this point
@@ -188,7 +188,7 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                if (ServiceContext == null)
+                if (ServiceContext is null)
                     throw new InvalidOperationException("ServiceContext is required for TestAgency");
 
                 _runtimeService = ServiceContext.GetService<IRuntimeFrameworkService>();

--- a/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
@@ -49,7 +49,7 @@ namespace NUnit.Engine
                     filter.Append("</or>");
             }
 
-            if (_whereClause != null)
+            if (_whereClause is not null)
                 filter.Append(TestSelectionParser.Parse(_whereClause));
 
             filter.Append("</filter>");

--- a/src/NUnitEngine/nunit.engine/Services/TestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestRunnerFactory.cs
@@ -19,7 +19,7 @@ namespace NUnit.Engine.Services
         {
             try
             {
-                if (ServiceContext == null)
+                if (ServiceContext is null)
                     throw new InvalidOperationException("Only services that have a ServiceContext can be started.");
 
                 // TestRunnerFactory requires the ProjectService
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Services
         /// <returns>A TestRunner</returns>
         public ITestEngineRunner MakeTestRunner(TestPackage package)
         {
-            if (ServiceContext == null)
+            if (ServiceContext is null)
                 throw new InvalidOperationException("ServiceContext not set.");
 
             if (package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty).StartsWith("Unmanaged,"))

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine
 
         public override string ToString()
         {
-            return Text != null
+            return Text is not null
                 ? Kind.ToString() + ":" + Text
                 : Kind.ToString();
         }
@@ -91,7 +91,7 @@ namespace NUnit.Engine
 
         public Tokenizer(string input)
         {
-            if (input == null)
+            if (input is null)
                 throw new ArgumentNullException("input");
 
             _input = input;
@@ -102,7 +102,7 @@ namespace NUnit.Engine
         {
             get
             {
-                if (_lookahead == null)
+                if (_lookahead is null)
                     _lookahead = GetNextToken();
 
                 return _lookahead;


### PR DESCRIPTION
Partly addresses #1590 

This analyzer is enabled in both nunit and nunit.analyzer projects.

Prefer `xxx is null` over `xxx == null` and `xxx is not null` over `xxx != null`