### PR TITLE
Add StyleCop.Analyzers

### DIFF
--- a/.github/workflows/NUnitConsoleAndEngine.CI.yml
+++ b/.github/workflows/NUnitConsoleAndEngine.CI.yml
@@ -38,7 +38,8 @@ jobs:
             3.1.x
             6.0.x
             7.0.x
-            8.0.100
+            8.0.x
+            9.0.x
 
       - name: 🔧 Install dotnet tools
         run: dotnet tool restore

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ ClientBin/
 *.pfx
 *.publishsettings
 
+!StyleCop.Analyzers.globalconfig
+
 # RIA/Silverlight projects
 Generated_Code/
 
@@ -166,10 +168,8 @@ $RECYCLE.BIN/
 
 .~
 *.userprefs
-*.StyleCop
 *.sdf
 GeneratedAssemblyInfo.cs
-StyleCop.Cache
 local.settings.include
 InternalTrace.txt
 TestResult.xml

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -29,6 +29,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		nunit.ico = nunit.ico
 		package-tests.cake = package-tests.cake
 		README.md = README.md
+		src\StyleCop.Analyzers.globalconfig = src\StyleCop.Analyzers.globalconfig
 		VERSIONING.md = VERSIONING.md
 	EndProjectSection
 EndProject

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "9.0.100",
-    "rollForward": "feature"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,4 +39,10 @@
         <Copyright>Copyright (c) 2022 Charlie Poole, Rob Prouse</Copyright>
     </PropertyGroup>
 
+    <!-- Code Style Analyzers -->
+    <ItemGroup>
+        <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" PrivateAssets="all" />
+        <GlobalAnalyzerConfigFiles Include="$(MSBuildThisFileDirectory)/StyleCop.Analyzers.globalconfig" />
+    </ItemGroup>
+
 </Project>

--- a/src/NUnitCommon/nunit.agent.core.tests/AgentOptionTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/AgentOptionTests.cs
@@ -8,7 +8,7 @@ namespace NUnit.Agents
 {
     public class AgentOptionTests
     {
-        static TestCaseData[] DefaultSettings = new[]
+        private static TestCaseData[] DefaultSettings = new[]
         {
             new TestCaseData("AgentId", Guid.Empty),
             new TestCaseData("AgencyUrl", string.Empty),
@@ -28,8 +28,8 @@ namespace NUnit.Agents
             Assert.That(prop.GetValue(options, new object[0]), Is.EqualTo(defaultValue));
         }
 
-        static readonly Guid AGENT_GUID = Guid.NewGuid();
-        static readonly TestCaseData[] ValidSettings = new[]
+        private static readonly Guid AGENT_GUID = Guid.NewGuid();
+        private static readonly TestCaseData[] ValidSettings = new[]
         {
             // Boolean options - no values provided
             new TestCaseData("--debug-agent", "DebugAgent", true),

--- a/src/NUnitCommon/nunit.agent.core.tests/Drivers/DriverServiceTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Drivers/DriverServiceTests.cs
@@ -26,7 +26,7 @@ namespace NUnit.Engine.Services
             Assert.That(driver, Is.InstanceOf(expectedType));
         }
 
-        static TestCaseData[] DriverSelectionTestCases = new[]
+        private static TestCaseData[] DriverSelectionTestCases = new[]
         {
             new TestCaseData("mock-assembly.dll", false, typeof(NUnitFrameworkDriver)),
             new TestCaseData("mock-assembly.dll", true, typeof(NUnitFrameworkDriver)),

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/DomainManagerStaticTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/DomainManagerStaticTests.cs
@@ -12,16 +12,16 @@ namespace NUnit.Engine.Runners
 {
     public static class DomainManagerStaticTests
     {
-        static string path1 = TestPath("/test/bin/debug/test1.dll");
-        static string path2 = TestPath("/test/bin/debug/test2.dll");
-        static string path3 = TestPath("/test/utils/test3.dll");
+        private static string path1 = TestPath("/test/bin/debug/test1.dll");
+        private static string path2 = TestPath("/test/bin/debug/test2.dll");
+        private static string path3 = TestPath("/test/utils/test3.dll");
 
 #if NETFRAMEWORK
-        const string STANDARD_CONFIG_FILE = "nunit.engine.core.tests.exe.config";
+        private const string STANDARD_CONFIG_FILE = "nunit.engine.core.tests.exe.config";
 #else
         const string STANDARD_CONFIG_FILE = "nunit.engine.core.tests.dll.config";
 #endif
-        const string ALTERNATE_CONFIG_FILE = "alt.config";
+        private const string ALTERNATE_CONFIG_FILE = "alt.config";
 
         [Test]
         public static void GetPrivateBinPath()

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerTests.cs
@@ -16,7 +16,8 @@ namespace NUnit.Engine.Runners
 #if NETFRAMEWORK
     [TestFixture(typeof(TestDomainRunner))]
 #endif
-    public class TestAgentRunnerTests<TRunner> where TRunner : TestAgentRunner
+    public class TestAgentRunnerTests<TRunner>
+        where TRunner : TestAgentRunner
     {
         protected TestPackage _package;
         protected TRunner _runner;
@@ -37,7 +38,7 @@ namespace NUnit.Engine.Runners
             if (_runner != null)
                 _runner.Dispose();
         }
-         
+
         [Test]
         public void Load()
         {

--- a/src/NUnitCommon/nunit.agent.core/AgentOptions.cs
+++ b/src/NUnitCommon/nunit.agent.core/AgentOptions.cs
@@ -8,16 +8,16 @@ using System.IO;
 namespace NUnit.Agents
 {
     /// <summary>
-    /// All agents, either built-in or pluggable, must be able to 
+    /// All agents, either built-in or pluggable, must be able to
     /// handle the options defined in this class. In some cases,
     /// it may be permissible to ignore them but they should never
     /// give rise to an error.
     /// </summary>
     public class AgentOptions
     {
-        static readonly char[] DELIMS = new[] { '=', ':' };
+        private static readonly char[] DELIMS = new[] { '=', ':' };
         // Dictionary containing valid options with bool value true if a value is required.
-        static readonly Dictionary<string, bool> VALID_OPTIONS = new Dictionary<string, bool>();
+        private static readonly Dictionary<string, bool> VALID_OPTIONS = new Dictionary<string, bool>();
 
         static AgentOptions()
         {

--- a/src/NUnitCommon/nunit.agent.core/Agents/RemoteTestAgent.cs
+++ b/src/NUnitCommon/nunit.agent.core/Agents/RemoteTestAgent.cs
@@ -22,7 +22,9 @@ namespace NUnit.Engine.Agents
         /// The first argument is a temporary measure and will be removed
         /// once services are all moved from nunit.engine.core to nunit.engine.
         /// </remarks>
-        public RemoteTestAgent(Guid agentId) : base(agentId) { }
+        public RemoteTestAgent(Guid agentId) : base(agentId)
+        {
+        }
 
         public ITestAgentTransport? Transport;
 

--- a/src/NUnitCommon/nunit.agent.core/Communication/Transports/Remoting/TestAgentRemotingTransport.cs
+++ b/src/NUnitCommon/nunit.agent.core/Communication/Transports/Remoting/TestAgentRemotingTransport.cs
@@ -9,7 +9,6 @@ using NUnit.Engine.Agents;
 
 namespace NUnit.Engine.Communication.Transports.Remoting
 {
-
     /// <summary>
     /// TestAgentRemotingTransport uses remoting to support
     /// a TestAgent in communicating with a TestAgency and

--- a/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
@@ -15,9 +15,9 @@ namespace NUnit.Engine.Drivers
     /// </summary>
     public class DriverService : IDriverService
     {
-        static readonly Logger log = InternalTrace.GetLogger("DriverService");
+        private static readonly Logger log = InternalTrace.GetLogger("DriverService");
 
-        readonly IList<IDriverFactory> _factories = new List<IDriverFactory>();
+        private readonly IList<IDriverFactory> _factories = new List<IDriverFactory>();
 
         public DriverService()
         {
@@ -69,7 +69,7 @@ namespace NUnit.Engine.Drivers
                     if (skipNonTestAssemblies)
                         return new SkippedAssemblyFrameworkDriver(assemblyPath, package.ID);
                     else
-                        return new InvalidAssemblyFrameworkDriver(assemblyPath, package.ID, platform + 
+                        return new InvalidAssemblyFrameworkDriver(assemblyPath, package.ID, platform +
                             " test assemblies are not supported by this version of the engine");
             }
 
@@ -111,7 +111,7 @@ namespace NUnit.Engine.Drivers
             if (skipNonTestAssemblies)
                 return new SkippedAssemblyFrameworkDriver(assemblyPath, package.ID);
             else
-                return new InvalidAssemblyFrameworkDriver(assemblyPath, package.ID, 
+                return new InvalidAssemblyFrameworkDriver(assemblyPath, package.ID,
                     $"No suitable tests found in '{assemblyPath}'.\r\nEither assembly contains no tests or proper test driver has not been found.");
         }
     }

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnit2DriverFactory.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnit2DriverFactory.cs
@@ -16,7 +16,7 @@ namespace NUnit.Engine.Drivers
 
         // TODO: This should be a central service but for now it's local
         private readonly ProvidedPathsAssemblyResolver _resolver;
-        bool _resolverInstalled;
+        private bool _resolverInstalled;
 
         public NUnit2DriverFactory(IExtensionNode driverNode)
         {
@@ -55,13 +55,13 @@ namespace NUnit.Engine.Drivers
             }
 
             return (IFrameworkDriver)AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(
-                _driverNode.AssemblyPath, 
+                _driverNode.AssemblyPath,
                 _driverNode.TypeName,
-                false, 
-                0, 
-                null, 
-                new object[] { domain, id, reference }, 
-                null, 
+                false,
+                0,
+                null,
+                new object[] { domain, id, reference },
+                null,
                 null).ShouldNotBeNull();
         }
     }

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnit3DriverFactory.cs
@@ -9,7 +9,7 @@ namespace NUnit.Engine.Drivers
     public class NUnit3DriverFactory : IDriverFactory
     {
         internal const string NUNIT_FRAMEWORK = "nunit.framework";
-        static readonly Logger log = InternalTrace.GetLogger(typeof(NUnit3DriverFactory));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(NUnit3DriverFactory));
 
         /// <summary>
         /// Gets a flag indicating whether a given assembly name and version

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
@@ -14,16 +14,16 @@ namespace NUnit.Engine.Drivers
     /// As far as I can discover, it first appeared in pre-release 2.9.1,
     /// on launchpad in 2009, hence the name.
     /// </summary>
-    class NUnitFrameworkApi2009 : NUnitFrameworkApi
+    internal class NUnitFrameworkApi2009 : NUnitFrameworkApi
         {
-            static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkApi2009));
+            private static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkApi2009));
 
-            const string LOAD_MESSAGE = "Method called without calling Load first. Possible error in runner.";
-            const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
-            const string FAILED_TO_LOAD_ASSEMBLY = "Failed to load assembly ";
-            const string FAILED_TO_LOAD_NUNIT = "Failed to load the NUnit Framework in the test assembly";
+            private const string LOAD_MESSAGE = "Method called without calling Load first. Possible error in runner.";
+            private const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
+            private const string FAILED_TO_LOAD_ASSEMBLY = "Failed to load assembly ";
+            private const string FAILED_TO_LOAD_NUNIT = "Failed to load the NUnit Framework in the test assembly";
 
-            const string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
+            private const string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
 
             private readonly string _driverId;
 
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Drivers
             private readonly AssemblyName _nunitRef;
 
             private string? _testAssemblyPath;
-            
+
             private object? _frameworkController;
             private Type? _frameworkControllerType;
 
@@ -118,7 +118,7 @@ namespace NUnit.Engine.Drivers
             }
 
             // Actions with no extra arguments beyond controller and handler
-            const string LOAD_ACTION = CONTROLLER_TYPE + "+LoadTestsAction";
+            private const string LOAD_ACTION = CONTROLLER_TYPE + "+LoadTestsAction";
             private string ExecuteAction(string action)
             {
                 CallbackHandler handler = new CallbackHandler();
@@ -127,9 +127,9 @@ namespace NUnit.Engine.Drivers
             }
 
             // Actions with one extra argument
-            const string EXPLORE_ACTION = CONTROLLER_TYPE + "+ExploreTestsAction";
-            const string COUNT_ACTION = CONTROLLER_TYPE + "+CountTestsAction";
-            const string STOP_RUN_ACTION = CONTROLLER_TYPE + "+StopRunAction";
+            private const string EXPLORE_ACTION = CONTROLLER_TYPE + "+ExploreTestsAction";
+            private const string COUNT_ACTION = CONTROLLER_TYPE + "+CountTestsAction";
+            private const string STOP_RUN_ACTION = CONTROLLER_TYPE + "+StopRunAction";
             private string ExecuteAction(string action, object arg1)
             {
                 CallbackHandler handler = new CallbackHandler();
@@ -138,7 +138,7 @@ namespace NUnit.Engine.Drivers
             }
 
             // Run action has two extra arguments and uses a special handler
-            const string RUN_ACTION = CONTROLLER_TYPE + "+RunTestsAction";
+            private const string RUN_ACTION = CONTROLLER_TYPE + "+RunTestsAction";
             private string ExecuteAction(string action, ITestEventListener? listener, string filter)
             {
                 RunTestsCallbackHandler handler = new RunTestsCallbackHandler(listener);

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
@@ -23,14 +23,14 @@ namespace NUnit.Engine.Drivers
     public class NUnitFrameworkApi2018 : NUnitFrameworkApi
 #endif
     {
-        static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkApi2018));
+        private static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkApi2018));
 
-        const string LOAD_MESSAGE = "Method called without calling Load first. Possible error in runner.";
-        const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
-        const string FAILED_TO_LOAD_ASSEMBLY = "Failed to load assembly ";
-        const string FAILED_TO_LOAD_NUNIT = "Failed to load the NUnit Framework in the test assembly";
+        private const string LOAD_MESSAGE = "Method called without calling Load first. Possible error in runner.";
+        private const string INVALID_FRAMEWORK_MESSAGE = "Running tests against this version of the framework using this driver is not supported. Please update NUnit.Framework to the latest version.";
+        private const string FAILED_TO_LOAD_ASSEMBLY = "Failed to load assembly ";
+        private const string FAILED_TO_LOAD_NUNIT = "Failed to load the NUnit Framework in the test assembly";
 
-        const string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
+        private const string CONTROLLER_TYPE = "NUnit.Framework.Api.FrameworkController";
 
         private readonly string _driverId;
 

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
@@ -14,10 +14,10 @@ namespace NUnit.Engine.Drivers
     /// </summary>
     public class NUnitFrameworkDriver : IFrameworkDriver
     {
-        static readonly Version MINIMUM_NUNIT_VERSION = new(3, 2, 0);
-        static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkDriver));
+        private static readonly Version MINIMUM_NUNIT_VERSION = new(3, 2, 0);
+        private static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkDriver));
 
-        readonly NUnitFrameworkApi _api;
+        private readonly NUnitFrameworkApi _api;
 
 #if NETFRAMEWORK
         /// <summary>
@@ -164,17 +164,17 @@ namespace NUnit.Engine.Drivers
         /// <remarks>
         /// This class is absolutely needed when the 2018 NUnit API is used under
         /// the .NET Framework using Windows Remoting as a communication protocol.
-        /// In particular, the MarshalByRef object implementing the listener must 
+        /// In particular, the MarshalByRef object implementing the listener must
         /// be convertible to ITestEventListener via the IConvertible interface.
-        /// 
+        ///
         /// In other cases, the interceptor is not essential, but we use it anyway
         /// for several reasons:
-        /// 
+        ///
         /// 1. We have no control over the implementation of runners using the engine.
-        ///    They may not implement IConvertible and may not even derive from 
+        ///    They may not implement IConvertible and may not even derive from
         ///    MarshaByRefObject.
-        /// 
-        /// 2. The interceptor provides a point of control for checking what events 
+        ///
+        /// 2. The interceptor provides a point of control for checking what events
         ///    are received from the framework and for possible future modifications to
         ///    the events before they are forwarded.
         /// </remarks>
@@ -215,9 +215,9 @@ namespace NUnit.Engine.Drivers
             DateTime IConvertible.ToDateTime(IFormatProvider? provider) => InvalidCast<DateTime>();
             string IConvertible.ToString(IFormatProvider? provider) => InvalidCast<string>();
 
-            static T InvalidCast<T>() => (T)InvalidCast(typeof(T));
+            private static T InvalidCast<T>() => (T)InvalidCast(typeof(T));
 
-            static object InvalidCast(Type type) =>
+            private static object InvalidCast(Type type) =>
                 throw new InvalidCastException($"{nameof(EventInterceptor)} is not convertible to {nameof(type)}");
 
             #endregion

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NotRunnableFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NotRunnableFrameworkDriver.cs
@@ -48,7 +48,6 @@ namespace NUnit.Engine.Drivers
 
         public string ID { get; }
 
-        
         public string Load(string assemblyPath, IDictionary<string, object> settings)
         {
             return GetLoadResult();
@@ -61,7 +60,7 @@ namespace NUnit.Engine.Drivers
 
         public string Run(ITestEventListener? listener, string filter)
         {
-            return string.Format(RUN_RESULT_FORMAT, 
+            return string.Format(RUN_RESULT_FORMAT,
                 _type, TestID, _name, _fullname, _runstate, _result, _label, _message);
         }
 
@@ -94,7 +93,7 @@ namespace NUnit.Engine.Drivers
         private string TestID => ID + "-1";
     }
 
-    public class InvalidAssemblyFrameworkDriver :NotRunnableFrameworkDriver
+    public class InvalidAssemblyFrameworkDriver : NotRunnableFrameworkDriver
     {
         public InvalidAssemblyFrameworkDriver(string assemblyPath, string id, string message)
             : base(assemblyPath, id, message)

--- a/src/NUnitCommon/nunit.agent.core/Drivers/ProvidedPathsAssemblyResolver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/ProvidedPathsAssemblyResolver.cs
@@ -10,9 +10,9 @@ namespace NUnit.Engine.Drivers
 {
     public class ProvidedPathsAssemblyResolver
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(ProvidedPathsAssemblyResolver));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(ProvidedPathsAssemblyResolver));
 
-        static readonly string THIS_ASSEMBLY_LOCATION = Assembly.GetExecutingAssembly().Location;
+        private static readonly string THIS_ASSEMBLY_LOCATION = Assembly.GetExecutingAssembly().Location;
 
         public ProvidedPathsAssemblyResolver()
         {
@@ -53,7 +53,7 @@ namespace NUnit.Engine.Drivers
             RemovePath(dirPath);
         }
 
-        Assembly? AssemblyResolve(object? sender, ResolveEventArgs args)
+        private Assembly? AssemblyResolve(object? sender, ResolveEventArgs args)
         {
             foreach (string path in _resolutionPaths)
             {
@@ -75,6 +75,6 @@ namespace NUnit.Engine.Drivers
             return null;
         }
 
-        readonly List<string> _resolutionPaths;
+        private readonly List<string> _resolutionPaths;
     }
 }

--- a/src/NUnitCommon/nunit.agent.core/NUnitAgent.cs
+++ b/src/NUnitCommon/nunit.agent.core/NUnitAgent.cs
@@ -17,10 +17,10 @@ namespace NUnit.Agents
 {
     public class NUnitAgent<TAgent>
     {
-        static Process? AgencyProcess;
-        static RemoteTestAgent? Agent;
-        static readonly int _pid = Process.GetCurrentProcess().Id;
-        static readonly Logger log = InternalTrace.GetLogger(typeof(TestAgent));
+        private static Process? AgencyProcess;
+        private static RemoteTestAgent? Agent;
+        private static readonly int _pid = Process.GetCurrentProcess().Id;
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(TestAgent));
 
         /// <summary>
         /// The main entry point for the application.

--- a/src/NUnitCommon/nunit.agent.core/RunTestsCallbackHandler.cs
+++ b/src/NUnitCommon/nunit.agent.core/RunTestsCallbackHandler.cs
@@ -57,7 +57,7 @@ namespace NUnit.Engine
 
             // Eliminate suites that do not represent an assembly
             if (!eventArgument.Contains("type=\"Assembly\""))
-                return false; 
+                return false;
             // Return for all except the assembly result. Remaining code is only
             // executed twice per assembly.
 
@@ -75,7 +75,7 @@ namespace NUnit.Engine
             return eventArgument.IndexOf("<test-suite", 12, StringComparison.Ordinal) > 0;
         }
 
-        class NullListener : ITestEventListener
+        private class NullListener : ITestEventListener
         {
             public void OnTestEvent(string report)
             {

--- a/src/NUnitCommon/nunit.agent.core/Runners/DomainDetailsBuilder.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/DomainDetailsBuilder.cs
@@ -23,7 +23,8 @@ namespace NUnit.Engine
         public static string DetailsFor(AppDomain domain, string? errMsg = null)
         {
             var sb = new StringBuilder();
-            if (errMsg != null) sb.AppendLine(errMsg);
+            if (errMsg != null)
+                sb.AppendLine(errMsg);
 
             try
             {

--- a/src/NUnitCommon/nunit.agent.core/Runners/DomainManager.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/DomainManager.cs
@@ -20,7 +20,7 @@ namespace NUnit.Engine.Runners
     /// </summary>
     public class DomainManager
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(DomainManager));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(DomainManager));
 
         private static readonly PropertyInfo TargetFrameworkNameProperty =
             typeof(AppDomainSetup).GetProperty("TargetFrameworkName", BindingFlags.Public | BindingFlags.Instance)!;
@@ -29,7 +29,7 @@ namespace NUnit.Engine.Runners
         /// Construct an application domain for running a test package
         /// </summary>
         /// <param name="package">The TestPackage to be run</param>
-        public AppDomain CreateDomain( TestPackage package )
+        public AppDomain CreateDomain(TestPackage package)
         {
             AppDomainSetup setup = CreateAppDomainSetup(package);
 
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Runners
         }
 
         // Made separate and internal for testing
-        AppDomainSetup CreateAppDomainSetup(TestPackage package)
+        private AppDomainSetup CreateAppDomainSetup(TestPackage package)
         {
             AppDomainSetup setup = new AppDomainSetup();
 
@@ -82,8 +82,8 @@ namespace NUnit.Engine.Runners
                 // If property is null, .NET 4.5+ is not installed, so there is no need
                 if (TargetFrameworkNameProperty != null)
                 {
-                    var frameworkName = package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, "");
-                    if (frameworkName != "")
+                    var frameworkName = package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty);
+                    if (frameworkName != string.Empty)
                         TargetFrameworkNameProperty.SetValue(setup, frameworkName, null);
                 }
             }
@@ -104,7 +104,7 @@ namespace NUnit.Engine.Runners
             new DomainUnloader(domain).Unload();
         }
 
-        class DomainUnloader
+        private class DomainUnloader
         {
             private readonly AppDomain _domain;
             private Thread? _unloadThread;
@@ -232,7 +232,7 @@ namespace NUnit.Engine.Runners
 
             // All subpackages have full names, but this is a public method in a public class so we have no control.
             foreach (var package in packages.Where(p => p.FullName != null))
-                assemblies.Add(package.FullName!); 
+                assemblies.Add(package.FullName!);
 
             return GetCommonAppBase(assemblies);
         }
@@ -246,7 +246,8 @@ namespace NUnit.Engine.Runners
                 string? dir = Path.GetDirectoryName(Path.GetFullPath(assembly))!;
                 if (commonBase == null)
                     commonBase = dir;
-                else while (commonBase != null && !PathUtils.SamePathOrUnder(commonBase, dir))
+                else
+                    while (commonBase != null && !PathUtils.SamePathOrUnder(commonBase, dir))
                         commonBase = Path.GetDirectoryName(commonBase)!;
             }
 
@@ -286,17 +287,17 @@ namespace NUnit.Engine.Runners
             List<string> dirList = new List<string>();
             StringBuilder sb = new StringBuilder(200);
 
-            foreach( string assembly in assemblies )
+            foreach (string assembly in assemblies)
             {
                 string? dir = PathUtils.RelativePath(
                     Path.GetFullPath(basePath),
-                    Path.GetDirectoryName( Path.GetFullPath(assembly) )! );
-                if ( dir != null && dir != string.Empty && dir != "." && !dirList.Contains( dir ) )
+                    Path.GetDirectoryName(Path.GetFullPath(assembly))!);
+                if (dir != null && dir != string.Empty && dir != "." && !dirList.Contains(dir))
                 {
-                    dirList.Add( dir );
-                    if ( sb.Length > 0 )
-                        sb.Append( Path.PathSeparator );
-                    sb.Append( dir );
+                    dirList.Add(dir);
+                    if (sb.Length > 0)
+                        sb.Append(Path.PathSeparator);
+                    sb.Append(dir);
                 }
             }
 

--- a/src/NUnitCommon/nunit.agent.core/Runners/TestAgentRunner.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/TestAgentRunner.cs
@@ -11,7 +11,7 @@ namespace NUnit.Engine.Runners
 {
     /// <summary>
     /// TestAgentRunner is the abstract base for runners used by agents, which
-    /// deal directly with a framework driver. It loads and runs tests in a single 
+    /// deal directly with a framework driver. It loads and runs tests in a single
     /// assembly, creating an <see cref="IFrameworkDriver"/> to do so.
     /// </summary>
     public abstract class TestAgentRunner : ITestEngineRunner
@@ -125,7 +125,9 @@ namespace NUnit.Engine.Runners
             }
         }
 
-        public virtual void Unload() { }
+        public virtual void Unload()
+        {
+        }
         public TestEngineResult Reload() => Load();
 
         /// <summary>
@@ -146,7 +148,6 @@ namespace NUnit.Engine.Runners
             }
         }
 
-
         /// <summary>
         /// Run the tests in the loaded TestPackage.
         /// </summary>
@@ -165,7 +166,6 @@ namespace NUnit.Engine.Runners
             {
                 throw new NUnitEngineException("An exception occurred in the driver while running tests.", ex);
             }
-
         }
 
         public AsyncTestEngineResult RunAsync(ITestEventListener? listener, TestFilter filter)

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyLoadContext.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyLoadContext.cs
@@ -40,7 +40,6 @@ namespace NUnit.Engine.Internal
                 return loadedAssembly;
             }
 
-
             var runtimeResolverPath = _runtimeResolver.ResolveAssemblyToPath(name);
             if (string.IsNullOrEmpty(runtimeResolverPath) == false &&
                 File.Exists(runtimeResolverPath))

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
@@ -28,7 +28,7 @@ namespace NUnit.Engine.Internal
         private static readonly string ASP_NET_CORE_DIR;
 
         // Our Strategies for resolving references
-        List<ResolutionStrategy> ResolutionStrategies;
+        private List<ResolutionStrategy> ResolutionStrategies;
 
         static TestAssemblyResolver()
         {
@@ -91,7 +91,8 @@ namespace NUnit.Engine.Internal
 
         private Assembly? OnResolving(AssemblyLoadContext loadContext, AssemblyName assemblyName)
         {
-            if (loadContext == null) throw new ArgumentNullException("context");
+            if (loadContext == null)
+                throw new ArgumentNullException("context");
 
             Assembly? loadedAssembly;
             foreach (var strategy in ResolutionStrategies)

--- a/src/NUnitCommon/nunit.common.tests/FileSystemAccess/DirectoryFinderTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/FileSystemAccess/DirectoryFinderTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.Engine.Internal
     {
         private Dictionary<string, IDirectory> fakedDirectories;
         private Dictionary<string, IFile> fakedFiles;
-        
+
         private IFileSystem fileSystem;
 
         [SetUp]
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Internal
                 var parts = path.Split('/');
                 for (var i = 0; i < parts.Length; i++)
                 {
-                    var absolutePath = CreateAbsolutePath(parts.Take(i+1));
+                    var absolutePath = CreateAbsolutePath(parts.Take(i + 1));
                     if (!fakedDirectories.ContainsKey(absolutePath))
                     {
                         var fake = Substitute.For<IDirectory>();

--- a/src/NUnitCommon/nunit.common.tests/FileSystemAccess/DirectoryTests2.cs
+++ b/src/NUnitCommon/nunit.common.tests/FileSystemAccess/DirectoryTests2.cs
@@ -47,7 +47,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
 
             this._subDirectories = subDirectories;
             SIO.Directory.CreateDirectory(this._testDirectory);
-            foreach(var directory in this._subDirectories)
+            foreach (var directory in this._subDirectories)
             {
                 SIO.Directory.CreateDirectory(directory);
             }

--- a/src/NUnitCommon/nunit.common.tests/FileSystemAccess/FileTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/FileSystemAccess/FileTests.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
                 Assert.Ignore("This test does not make sense on systems where System.IO.Path.GetInvalidPathChars() returns an empty array.");
             }
 
-            var path = SIO.Path.GetInvalidPathChars()[SIO.Path.GetInvalidPathChars().Length-1] + this.GetTestFileLocation();
+            var path = SIO.Path.GetInvalidPathChars()[SIO.Path.GetInvalidPathChars().Length - 1] + this.GetTestFileLocation();
 
             Assert.That(() => new File(path), Throws.ArgumentException);
         }

--- a/src/NUnitCommon/nunit.common.tests/LoggingTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/LoggingTests.cs
@@ -7,7 +7,7 @@ namespace NUnit.Engine
 {
     public class LoggingTests
     {
-        static readonly InternalTraceLevel[] LEVELS = new [] { InternalTraceLevel.Error, InternalTraceLevel.Warning, InternalTraceLevel.Info, InternalTraceLevel.Debug };
+        private static readonly InternalTraceLevel[] LEVELS = [InternalTraceLevel.Error, InternalTraceLevel.Warning, InternalTraceLevel.Info, InternalTraceLevel.Debug];
 
         [Test, Combinatorial]
         public void LoggerSelectsMessagesToWrite(

--- a/src/NUnitCommon/nunit.common.tests/PathUtilTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/PathUtilTests.cs
@@ -65,61 +65,61 @@ namespace NUnit.Engine.Internal
         }
     }
 
-	[TestFixture]
-	public class PathUtilDefaultsTests : PathUtils
-	{
-		[Test]
-		public void CheckDefaults()
-		{
-			Assert.That(PathUtils.DirectorySeparatorChar, Is.EqualTo(Path.DirectorySeparatorChar));
-			Assert.That(PathUtils.AltDirectorySeparatorChar, Is.EqualTo(Path.AltDirectorySeparatorChar));
-		}
-	}
+    [TestFixture]
+    public class PathUtilDefaultsTests : PathUtils
+    {
+        [Test]
+        public void CheckDefaults()
+        {
+            Assert.That(PathUtils.DirectorySeparatorChar, Is.EqualTo(Path.DirectorySeparatorChar));
+            Assert.That(PathUtils.AltDirectorySeparatorChar, Is.EqualTo(Path.AltDirectorySeparatorChar));
+        }
+    }
 
-	// Local Assert extension
-	internal class PathAssert : NUnit.Framework.Assert
-	{
-		public static void SamePathOrUnder( string path1, string path2 )
-		{
-			Assert.That(PathUtils.SamePathOrUnder( path1, path2 ), Is.True, $"\r\n\texpected: Same path or under <{path1}>\r\n\t but was: <{path2}>");
-		}
+    // Local Assert extension
+    internal class PathAssert : NUnit.Framework.Assert
+    {
+        public static void SamePathOrUnder(string path1, string path2)
+        {
+            Assert.That(PathUtils.SamePathOrUnder(path1, path2), Is.True, $"\r\n\texpected: Same path or under <{path1}>\r\n\t but was: <{path2}>");
+        }
 
-		public static void NotSamePathOrUnder( string path1, string path2 )
-		{
-			Assert.That(PathUtils.SamePathOrUnder( path1, path2 ), Is.False, $"\r\n\texpected: Not same path or under <{path1}>\r\n\t but was: <{path2}>");
-		}
-	}
+        public static void NotSamePathOrUnder(string path1, string path2)
+        {
+            Assert.That(PathUtils.SamePathOrUnder(path1, path2), Is.False, $"\r\n\texpected: Not same path or under <{path1}>\r\n\t but was: <{path2}>");
+        }
+    }
 
-	[TestFixture]
-	public class PathUtilTests_Windows : PathUtils
-	{
-		[OneTimeSetUp]
-		public static void SetUpUnixSeparators()
-		{
-			PathUtils.DirectorySeparatorChar = '\\';
-			PathUtils.AltDirectorySeparatorChar = '/';
-		}
+    [TestFixture]
+    public class PathUtilTests_Windows : PathUtils
+    {
+        [OneTimeSetUp]
+        public static void SetUpUnixSeparators()
+        {
+            PathUtils.DirectorySeparatorChar = '\\';
+            PathUtils.AltDirectorySeparatorChar = '/';
+        }
 
-		[OneTimeTearDown]
-		public static void RestoreDefaultSeparators()
-		{
-			PathUtils.DirectorySeparatorChar = System.IO.Path.DirectorySeparatorChar;
-			PathUtils.AltDirectorySeparatorChar = System.IO.Path.AltDirectorySeparatorChar;
-		}
+        [OneTimeTearDown]
+        public static void RestoreDefaultSeparators()
+        {
+            PathUtils.DirectorySeparatorChar = System.IO.Path.DirectorySeparatorChar;
+            PathUtils.AltDirectorySeparatorChar = System.IO.Path.AltDirectorySeparatorChar;
+        }
 
-		[Test]
-		public void Canonicalize()
-		{
-			Assert.That(PathUtils.Canonicalize( @"C:\folder1\.\folder2\..\file.tmp" ), Is.EqualTo(@"C:\folder1\file.tmp"));
-			Assert.That(PathUtils.Canonicalize( @"folder1\.\folder2\..\file.tmp" ), Is.EqualTo(@"folder1\file.tmp"));
-			Assert.That(PathUtils.Canonicalize( @"folder1\folder2\.\..\file.tmp" ), Is.EqualTo(@"folder1\file.tmp"));
-			Assert.That(PathUtils.Canonicalize( @"folder1\folder2\..\.\..\file.tmp" ), Is.EqualTo(@"file.tmp"));
-			Assert.That(PathUtils.Canonicalize( @"folder1\folder2\..\..\..\file.tmp" ), Is.EqualTo(@"file.tmp"));
-		}
+        [Test]
+        public void Canonicalize()
+        {
+            Assert.That(PathUtils.Canonicalize(@"C:\folder1\.\folder2\..\file.tmp"), Is.EqualTo(@"C:\folder1\file.tmp"));
+            Assert.That(PathUtils.Canonicalize(@"folder1\.\folder2\..\file.tmp"), Is.EqualTo(@"folder1\file.tmp"));
+            Assert.That(PathUtils.Canonicalize(@"folder1\folder2\.\..\file.tmp"), Is.EqualTo(@"folder1\file.tmp"));
+            Assert.That(PathUtils.Canonicalize(@"folder1\folder2\..\.\..\file.tmp"), Is.EqualTo(@"file.tmp"));
+            Assert.That(PathUtils.Canonicalize(@"folder1\folder2\..\..\..\file.tmp"), Is.EqualTo(@"file.tmp"));
+        }
 
         [Test]
         public void RelativePath()
-		{
+        {
             bool windows = false;
 
 #if NETCOREAPP
@@ -131,14 +131,14 @@ namespace NUnit.Engine.Internal
 
             Assume.That(windows, Is.True);
 
-			Assert.That(PathUtils.RelativePath(
-				@"c:\folder1", @"c:\folder1\folder2\folder3" ), Is.EqualTo(@"folder2\folder3"));
-			Assert.That(PathUtils.RelativePath(
-				@"c:\folder1", @"c:\folder2\folder3" ), Is.EqualTo(@"..\folder2\folder3"));
-			Assert.That(PathUtils.RelativePath(
-				@"c:\folder1", @"bin\debug" ), Is.EqualTo(@"bin\debug"));
-			Assert.That( PathUtils.RelativePath( @"C:\folder", @"D:\folder"), Is.Null,
-				"Unrelated paths should return null" );
+            Assert.That(PathUtils.RelativePath(
+                @"c:\folder1", @"c:\folder1\folder2\folder3"), Is.EqualTo(@"folder2\folder3"));
+            Assert.That(PathUtils.RelativePath(
+                @"c:\folder1", @"c:\folder2\folder3"), Is.EqualTo(@"..\folder2\folder3"));
+            Assert.That(PathUtils.RelativePath(
+                @"c:\folder1", @"bin\debug"), Is.EqualTo(@"bin\debug"));
+            Assert.That(PathUtils.RelativePath(@"C:\folder", @"D:\folder"), Is.Null,
+                "Unrelated paths should return null");
             Assert.That(PathUtils.RelativePath(@"C:\", @"D:\"), Is.Null,
                 "Unrelated roots should return null");
             Assert.That(PathUtils.RelativePath(@"C:", @"D:"), Is.Null,
@@ -161,56 +161,55 @@ namespace NUnit.Engine.Internal
                 @"c:\folder1", @"C:\Folder2\folder3"), Is.EqualTo(@"..\Folder2\folder3"));
         }
 
-
         [Test]
         public void SamePathOrUnder()
-		{
-            PathAssert.SamePathOrUnder( @"C:\folder1\folder2\folder3", @"C:\folder1\.\folder2\junk\..\folder3" );
-            PathAssert.SamePathOrUnder( @"C:\folder1\folder2\", @"C:\folder1\.\folder2\junk\..\folder3" );
-            PathAssert.SamePathOrUnder( @"C:\folder1\folder2", @"C:\folder1\.\folder2\junk\..\folder3" );
-            PathAssert.NotSamePathOrUnder( @"C:\folder1\folder2", @"C:\folder1\.\folder22\junk\..\folder3" );
-            PathAssert.NotSamePathOrUnder( @"C:\folder1\folder2ile.tmp", @"D:\folder1\.\folder2\folder3\file.tmp" );
-            PathAssert.NotSamePathOrUnder( @"C:\", @"D:\" );
-            PathAssert.SamePathOrUnder( @"C:\", @"C:\" );
-            PathAssert.SamePathOrUnder( @"C:\", @"C:\bin\debug" );
-		}
-	}
+        {
+            PathAssert.SamePathOrUnder(@"C:\folder1\folder2\folder3", @"C:\folder1\.\folder2\junk\..\folder3");
+            PathAssert.SamePathOrUnder(@"C:\folder1\folder2\", @"C:\folder1\.\folder2\junk\..\folder3");
+            PathAssert.SamePathOrUnder(@"C:\folder1\folder2", @"C:\folder1\.\folder2\junk\..\folder3");
+            PathAssert.NotSamePathOrUnder(@"C:\folder1\folder2", @"C:\folder1\.\folder22\junk\..\folder3");
+            PathAssert.NotSamePathOrUnder(@"C:\folder1\folder2ile.tmp", @"D:\folder1\.\folder2\folder3\file.tmp");
+            PathAssert.NotSamePathOrUnder(@"C:\", @"D:\");
+            PathAssert.SamePathOrUnder(@"C:\", @"C:\");
+            PathAssert.SamePathOrUnder(@"C:\", @"C:\bin\debug");
+        }
+    }
 
-	[TestFixture]
-	public class PathUtilTests_Unix : PathUtils
-	{
-		[OneTimeSetUp]
-		public static void SetUpUnixSeparators()
-		{
-			PathUtils.DirectorySeparatorChar = '/';
-			PathUtils.AltDirectorySeparatorChar = '\\';
-		}
+    [TestFixture]
+    public class PathUtilTests_Unix : PathUtils
+    {
+        [OneTimeSetUp]
+        public static void SetUpUnixSeparators()
+        {
+            PathUtils.DirectorySeparatorChar = '/';
+            PathUtils.AltDirectorySeparatorChar = '\\';
+        }
 
-		[OneTimeTearDown]
-		public static void RestoreDefaultSeparators()
-		{
-			PathUtils.DirectorySeparatorChar = System.IO.Path.DirectorySeparatorChar;
-			PathUtils.AltDirectorySeparatorChar = System.IO.Path.AltDirectorySeparatorChar;
-		}
+        [OneTimeTearDown]
+        public static void RestoreDefaultSeparators()
+        {
+            PathUtils.DirectorySeparatorChar = System.IO.Path.DirectorySeparatorChar;
+            PathUtils.AltDirectorySeparatorChar = System.IO.Path.AltDirectorySeparatorChar;
+        }
 
-		[Test]
-		public void Canonicalize()
-		{
-			Assert.That(PathUtils.Canonicalize( "/folder1/./folder2/../file.tmp" ), Is.EqualTo("/folder1/file.tmp"));
-			Assert.That(PathUtils.Canonicalize( "folder1/./folder2/../file.tmp" ), Is.EqualTo("folder1/file.tmp"));
-			Assert.That(PathUtils.Canonicalize( "folder1/folder2/./../file.tmp" ), Is.EqualTo("folder1/file.tmp"));
-			Assert.That(PathUtils.Canonicalize( "folder1/folder2/.././../file.tmp" ), Is.EqualTo("file.tmp"));
-			Assert.That(PathUtils.Canonicalize( "folder1/folder2/../../../file.tmp" ), Is.EqualTo("file.tmp"));
-		}
+        [Test]
+        public void Canonicalize()
+        {
+            Assert.That(PathUtils.Canonicalize("/folder1/./folder2/../file.tmp"), Is.EqualTo("/folder1/file.tmp"));
+            Assert.That(PathUtils.Canonicalize("folder1/./folder2/../file.tmp"), Is.EqualTo("folder1/file.tmp"));
+            Assert.That(PathUtils.Canonicalize("folder1/folder2/./../file.tmp"), Is.EqualTo("folder1/file.tmp"));
+            Assert.That(PathUtils.Canonicalize("folder1/folder2/.././../file.tmp"), Is.EqualTo("file.tmp"));
+            Assert.That(PathUtils.Canonicalize("folder1/folder2/../../../file.tmp"), Is.EqualTo("file.tmp"));
+        }
 
-		[Test]
-		public void RelativePath()
-		{
-			Assert.That(PathUtils.RelativePath(	"/folder1", "/folder1/folder2/folder3" ), Is.EqualTo("folder2/folder3"));
-			Assert.That(PathUtils.RelativePath( "/folder1", "/folder2/folder3" ), Is.EqualTo("../folder2/folder3"));
-			Assert.That(PathUtils.RelativePath( "/folder1", "bin/debug" ), Is.EqualTo("bin/debug"));
-			Assert.That(PathUtils.RelativePath( "/folder", "/other/folder" ), Is.EqualTo("../other/folder"));
-			Assert.That(PathUtils.RelativePath( "/a/b/c", "/a/d" ), Is.EqualTo("../../d"));
+        [Test]
+        public void RelativePath()
+        {
+            Assert.That(PathUtils.RelativePath("/folder1", "/folder1/folder2/folder3"), Is.EqualTo("folder2/folder3"));
+            Assert.That(PathUtils.RelativePath("/folder1", "/folder2/folder3"), Is.EqualTo("../folder2/folder3"));
+            Assert.That(PathUtils.RelativePath("/folder1", "bin/debug"), Is.EqualTo("bin/debug"));
+            Assert.That(PathUtils.RelativePath("/folder", "/other/folder"), Is.EqualTo("../other/folder"));
+            Assert.That(PathUtils.RelativePath("/a/b/c", "/a/d"), Is.EqualTo("../../d"));
             Assert.That(PathUtils.RelativePath("/a/b", "/a/b"), Is.EqualTo(string.Empty));
             Assert.That(PathUtils.RelativePath("/", "/"), Is.EqualTo(string.Empty));
 
@@ -226,16 +225,16 @@ namespace NUnit.Engine.Internal
             Assert.That(PathUtils.RelativePath("/folder1", "/Folder1/Folder2/folder3"), Is.EqualTo("../Folder1/Folder2/folder3"), "folders differing in case");
         }
 
-		[Test]
-		public void SamePathOrUnder()
-		{
-            PathAssert.SamePathOrUnder( "/folder1/folder2/folder3", "/folder1/./folder2/junk/../folder3" );
-            PathAssert.SamePathOrUnder( "/folder1/folder2/", "/folder1/./folder2/junk/../folder3" );
-            PathAssert.SamePathOrUnder( "/folder1/folder2", "/folder1/./folder2/junk/../folder3" );
-            PathAssert.NotSamePathOrUnder( "/folder1/folder2", "/folder1/./Folder2/junk/../folder3" );
-            PathAssert.NotSamePathOrUnder( "/folder1/folder2", "/folder1/./folder22/junk/../folder3" );
-            PathAssert.SamePathOrUnder( "/", "/" );
-            PathAssert.SamePathOrUnder( "/", "/bin/debug" );
-		}
-	}
+        [Test]
+        public void SamePathOrUnder()
+        {
+            PathAssert.SamePathOrUnder("/folder1/folder2/folder3", "/folder1/./folder2/junk/../folder3");
+            PathAssert.SamePathOrUnder("/folder1/folder2/", "/folder1/./folder2/junk/../folder3");
+            PathAssert.SamePathOrUnder("/folder1/folder2", "/folder1/./folder2/junk/../folder3");
+            PathAssert.NotSamePathOrUnder("/folder1/folder2", "/folder1/./Folder2/junk/../folder3");
+            PathAssert.NotSamePathOrUnder("/folder1/folder2", "/folder1/./folder22/junk/../folder3");
+            PathAssert.SamePathOrUnder("/", "/");
+            PathAssert.SamePathOrUnder("/", "/bin/debug");
+        }
+    }
 }

--- a/src/NUnitCommon/nunit.common.tests/Program.cs
+++ b/src/NUnitCommon/nunit.common.tests/Program.cs
@@ -5,9 +5,9 @@ using NUnitLite;
 
 namespace NUnit.Engine.Tests
 {
-    class Program
+    internal class Program
     {
-        static int Main(string[] args)
+        private static int Main(string[] args)
         {
             return new TextRunner(typeof(Program).Assembly).Execute(args);
         }

--- a/src/NUnitCommon/nunit.common.tests/ResultHelperTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/ResultHelperTests.cs
@@ -126,7 +126,7 @@ namespace NUnit.Engine.Internal
 
             var firstEngineResult = new TestEngineResult(firstResultText);
             var secondEngineResult = new TestEngineResult(secondResultText);
-            var data = new XmlNode[]{ firstEngineResult.Xml, secondEngineResult.Xml };
+            var data = new XmlNode[] { firstEngineResult.Xml, secondEngineResult.Xml };
             XmlNode combined = ResultHelper.Aggregate("test-run", "ID", "NAME", "FULLNAME", data);
             Assert.That(combined.Attributes?["result"]?.Value, Is.EqualTo(aggregateResult));
         }

--- a/src/NUnitCommon/nunit.common.tests/TcpChannelUtilsTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/TcpChannelUtilsTests.cs
@@ -71,7 +71,6 @@ namespace NUnit.Engine.Internal
             }
         }
 
-
         private static ConstraintExpression HasChannelName() =>
             Has.Property(nameof(TcpChannel.ChannelName));
 

--- a/src/NUnitCommon/nunit.common/Communitcation/Protocols/BinarySerializationProtocol.cs
+++ b/src/NUnitCommon/nunit.common/Communitcation/Protocols/BinarySerializationProtocol.cs
@@ -13,7 +13,7 @@ namespace NUnit.Engine.Communication.Protocols
     /// BinarySerializationProtocol serializes messages in the following format:
     ///
     ///     [Message Length (4 bytes)][Serialized Message Content]
-    ///     
+    ///
     /// The message content is in binary form as produced by the .NET BinaryFormatter.
     /// Each message of length n is serialized as n + 4 bytes.
     /// </summary>
@@ -73,7 +73,9 @@ namespace NUnit.Engine.Communication.Protocols
             var messages = new List<TestEngineMessage>();
 
             //Read all available messages and add to messages collection
-            while (ReadSingleMessage(messages)) { }
+            while (ReadSingleMessage(messages))
+            {
+            }
 
             return messages;
         }
@@ -125,7 +127,7 @@ namespace NUnit.Engine.Communication.Protocols
         }
 
         /// <summary>
-        /// This method tries to read a single message and add to the messages collection. 
+        /// This method tries to read a single message and add to the messages collection.
         /// </summary>
         /// <param name="messages">Messages collection to collect messages</param>
         /// <returns>
@@ -215,8 +217,7 @@ namespace NUnit.Engine.Communication.Protocols
             return ((buffer[0] << 24) |
                     (buffer[1] << 16) |
                     (buffer[2] << 8) |
-                    (buffer[3])
-                   );
+                    (buffer[3]));
         }
 
         /// <summary>

--- a/src/NUnitCommon/nunit.common/Communitcation/Transports/Tcp/SocketReader.cs
+++ b/src/NUnitCommon/nunit.common/Communitcation/Transports/Tcp/SocketReader.cs
@@ -56,7 +56,8 @@ namespace NUnit.Engine.Communication.Transports.Tcp
         /// <typeparam name="TMessage">The expected message type</typeparam>
         /// <returns>A message of type TMessage</returns>
         /// <exception cref="InvalidOperationException">A message of a different type was received</exception>
-        public TMessage GetNextMessage<TMessage>() where TMessage : TestEngineMessage
+        public TMessage GetNextMessage<TMessage>()
+            where TMessage : TestEngineMessage
         {
             var receivedMessage = GetNextMessage();
             var expectedMessage = receivedMessage as TMessage;

--- a/src/NUnitCommon/nunit.common/FileSystemAccess/DirectoryFinder.cs
+++ b/src/NUnitCommon/nunit.common/FileSystemAccess/DirectoryFinder.cs
@@ -48,10 +48,10 @@ namespace NUnit.FileSystemAccess
                 else
                 {
                     range = pattern;
-                    pattern = "";
+                    pattern = string.Empty;
                 }
 
-                if (range == "." || range == "")
+                if (range == "." || range == string.Empty)
                     continue;
 
                 dirList = ExpandOneStep(dirList, range);
@@ -89,7 +89,7 @@ namespace NUnit.FileSystemAccess
 
             foreach (var dir in dirList)
             {
-                if (pattern == "." || pattern == "")
+                if (pattern == "." || pattern == string.Empty)
                     newList.Add(dir);
                 else if (pattern == "..")
                 {
@@ -102,12 +102,14 @@ namespace NUnit.FileSystemAccess
                     // add the directory itself to start out.
                     newList.Add(dir);
                     var subDirs = dir.GetDirectories("*", SearchOption.AllDirectories);
-                    if (subDirs.Any()) newList.AddRange(subDirs);
+                    if (subDirs.Any())
+                        newList.AddRange(subDirs);
                 }
                 else
                 {
                     var subDirs = dir.GetDirectories(pattern, SearchOption.TopDirectoryOnly);
-                    if (subDirs.Any()) newList.AddRange(subDirs);
+                    if (subDirs.Any())
+                        newList.AddRange(subDirs);
                 }
             }
 

--- a/src/NUnitCommon/nunit.common/Guard.cs
+++ b/src/NUnitCommon/nunit.common/Guard.cs
@@ -31,7 +31,8 @@ namespace NUnit
         /// <param name="expression">Compiler supplied parameter for the <paramref name="result"/> expression.</param>
         /// <returns>Value of <paramref name="result"/> if not null, throws otherwise.</returns>
         /// <exception cref="InvalidOperationException"></exception>
-        public static T ShouldNotBeNull<T>(this T? result, [CallerArgumentExpression(nameof(result))] string expression = "") where T : class
+        public static T ShouldNotBeNull<T>(this T? result, [CallerArgumentExpression(nameof(result))] string expression = "")
+            where T : class
         {
             if (result == null)
                 throw new InvalidOperationException($"Result {expression} must not be null");
@@ -49,7 +50,7 @@ namespace NUnit
             ArgumentNotNull(value, name);
 
             if (value == string.Empty)
-                throw new ArgumentException("Argument " + name +" must not be the empty string", name);
+                throw new ArgumentException("Argument " + name + " must not be the empty string", name);
         }
 
         /// <summary>

--- a/src/NUnitCommon/nunit.common/Logging/InternalTrace.cs
+++ b/src/NUnitCommon/nunit.common/Logging/InternalTrace.cs
@@ -8,14 +8,14 @@ namespace NUnit
 {
     /// <summary>
     /// InternalTrace provides facilities for tracing the execution
-    /// of the NUnit framework. Tests and classes under test may make use 
+    /// of the NUnit framework. Tests and classes under test may make use
     /// of Console writes, System.Diagnostics.Trace or various loggers and
     /// NUnit itself traps and processes each of them. For that reason, a
     /// separate internal trace is needed.
-    /// 
+    ///
     /// Note:
     /// InternalTrace uses a global lock to allow multiple threads to write
-    /// trace messages. This can easily make it a bottleneck so it must be 
+    /// trace messages. This can easily make it a bottleneck so it must be
     /// used sparingly. Keep the trace Level as low as possible and only
     /// insert InternalTrace writes where they are needed.
     /// TODO: add some buffering and a separate writer thread as an option.

--- a/src/NUnitCommon/nunit.common/Logging/InternalTraceWriter.cs
+++ b/src/NUnitCommon/nunit.common/Logging/InternalTraceWriter.cs
@@ -9,8 +9,8 @@ namespace NUnit
     /// </summary>
     internal class InternalTraceWriter : TextWriter
     {
-        TextWriter _writer;
-        readonly object _myLock = new object();
+        private TextWriter _writer;
+        private readonly object _myLock = new object();
 
         /// <summary>
         /// Construct an InternalTraceWriter that writes to a file.
@@ -24,7 +24,7 @@ namespace NUnit
         }
 
         /// <summary>
-        /// Construct an InternalTraceWriter that writes to a 
+        /// Construct an InternalTraceWriter that writes to a
         /// TextWriter provided by the caller.
         /// </summary>
         /// <param name="writer"></param>

--- a/src/NUnitCommon/nunit.common/PathUtils.cs
+++ b/src/NUnitCommon/nunit.common/PathUtils.cs
@@ -12,11 +12,11 @@ namespace NUnit
     /// <summary>
     /// Static methods for manipulating project paths, including both directories
     /// and files. Some synonyms for System.Path methods are included as well.
-    /// </summary> 
+    /// </summary>
     public class PathUtils
     {
-        public const uint FILE_ATTRIBUTE_DIRECTORY  = 0x00000010;  
-        public const uint FILE_ATTRIBUTE_NORMAL     = 0x00000080;  
+        public const uint FILE_ATTRIBUTE_DIRECTORY = 0x00000010;
+        public const uint FILE_ATTRIBUTE_NORMAL = 0x00000080;
         public const int MAX_PATH = 256;
 
         protected static char DirectorySeparatorChar = Path.DirectorySeparatorChar;
@@ -38,12 +38,12 @@ namespace NUnit
         /// Returns the relative path from a base directory to another
         /// directory or file.
         /// </summary>
-        public static string? RelativePath( string from, string to )
+        public static string? RelativePath(string from, string to)
         {
             if (from == null)
-                throw new ArgumentNullException (from);
+                throw new ArgumentNullException(from);
             if (to == null)
-                throw new ArgumentNullException (to);
+                throw new ArgumentNullException(to);
 
             string? toPathRoot = Path.GetPathRoot(to);
             if (toPathRoot == null || toPathRoot == string.Empty)
@@ -61,56 +61,56 @@ namespace NUnit
             string[] _from = SplitPath(fromNoRoot);
             string[] _to = SplitPath(toNoRoot);
 
-            StringBuilder sb = new StringBuilder (Math.Max (from.Length, to.Length));
+            StringBuilder sb = new StringBuilder(Math.Max(from.Length, to.Length));
 
-            int last_common, min = Math.Min (_from.Length, _to.Length);
-            for (last_common = 0; last_common < min;  ++last_common) 
+            int last_common, min = Math.Min(_from.Length, _to.Length);
+            for (last_common = 0; last_common < min;  ++last_common)
             {
                 if (!PathsEqual(_from[last_common], _to[last_common]))
                     break;
             }
 
             if (last_common < _from.Length)
-                sb.Append ("..");
-            for (int i = last_common + 1; i < _from.Length; ++i) 
+                sb.Append("..");
+            for (int i = last_common + 1; i < _from.Length; ++i)
             {
-                sb.Append (PathUtils.DirectorySeparatorChar).Append ("..");
+                sb.Append(PathUtils.DirectorySeparatorChar).Append("..");
             }
 
             if (sb.Length > 0)
-                sb.Append (PathUtils.DirectorySeparatorChar);
+                sb.Append(PathUtils.DirectorySeparatorChar);
             if (last_common < _to.Length)
-                sb.Append (_to [last_common]);
-            for (int i = last_common + 1; i < _to.Length; ++i) 
+                sb.Append(_to[last_common]);
+            for (int i = last_common + 1; i < _to.Length; ++i)
             {
-                sb.Append (PathUtils.DirectorySeparatorChar).Append (_to [i]);
+                sb.Append(PathUtils.DirectorySeparatorChar).Append(_to[i]);
             }
 
-            return sb.ToString ();
+            return sb.ToString();
         }
 
         /// <summary>
         /// Return the canonical form of a path.
         /// </summary>
-        public static string Canonicalize( string path )
+        public static string Canonicalize(string path)
         {
             List<string> parts = new List<string>(
-                path.Split( DirectorySeparatorChar, AltDirectorySeparatorChar ) );
+                path.Split(DirectorySeparatorChar, AltDirectorySeparatorChar));
 
-            for( int index = 0; index < parts.Count; )
+            for (int index = 0; index < parts.Count;)
             {
                 string part = parts[index];
-        
-                switch( part )
+
+                switch (part)
                 {
                     case ".":
-                        parts.RemoveAt( index );
+                        parts.RemoveAt(index);
                         break;
-                
+
                     case "..":
-                        parts.RemoveAt( index );
-                        if ( index > 0 )
-                            parts.RemoveAt( --index );
+                        parts.RemoveAt(index);
+                        if (index > 0)
+                            parts.RemoveAt(--index);
                         break;
                     default:
                         index++;
@@ -119,7 +119,7 @@ namespace NUnit
             }
 
             // Trailing separator removal
-            if (parts.Count > 1 && path.Length > 1 && parts[parts.Count - 1] == "")
+            if (parts.Count > 1 && path.Length > 1 && parts[parts.Count - 1] == string.Empty)
                 parts.RemoveAt(parts.Count - 1);
 
             return String.Join(DirectorySeparatorChar.ToString(), parts.ToArray());
@@ -127,33 +127,33 @@ namespace NUnit
 
         /// <summary>
         /// True if the two paths are the same or if the second is
-        /// directly or indirectly under the first. Note that paths 
-        /// using different network shares or drive letters are 
+        /// directly or indirectly under the first. Note that paths
+        /// using different network shares or drive letters are
         /// considered unrelated, even if they end up referencing
         /// the same subtrees in the file system.
         /// </summary>
-        public static bool SamePathOrUnder( string path1, string path2 )
+        public static bool SamePathOrUnder(string path1, string path2)
         {
-            path1 = Canonicalize( path1 );
-            path2 = Canonicalize( path2 );
+            path1 = Canonicalize(path1);
+            path2 = Canonicalize(path2);
 
             int length1 = path1.Length;
             int length2 = path2.Length;
 
             // if path1 is longer, then path2 can't be under it
-            if ( length1 > length2 )
+            if (length1 > length2)
                 return false;
 
             // if lengths are the same, check for equality
-            if ( length1 == length2 )
-                return string.Compare( path1, path2, RunningOnWindows ) == 0;
+            if (length1 == length2)
+                return string.Compare(path1, path2, RunningOnWindows) == 0;
 
             // path 2 is longer than path 1: see if initial parts match
-            if ( string.Compare( path1, path2.Substring( 0, length1 ), RunningOnWindows ) != 0 )
+            if (string.Compare(path1, path2.Substring(0, length1), RunningOnWindows) != 0)
                 return false;
-            
+
             // must match through or up to a directory separator boundary
-            return	path2[length1-1] == DirectorySeparatorChar ||
+            return path2[length1 - 1] == DirectorySeparatorChar ||
                 path2[length1] == DirectorySeparatorChar;
         }
 

--- a/src/NUnitCommon/nunit.common/ProcessUtils.cs
+++ b/src/NUnitCommon/nunit.common/ProcessUtils.cs
@@ -62,7 +62,8 @@ namespace NUnit.Engine
             while (true)
             {
                 var nextEscapeChar = literalValue.IndexOfAny(CharsThatRequireEscaping, nextPosition);
-                if (nextEscapeChar == -1) break;
+                if (nextEscapeChar == -1)
+                    break;
 
                 builder.Append(literalValue, nextPosition, nextEscapeChar - nextPosition);
                 nextPosition = nextEscapeChar + 1;

--- a/src/NUnitCommon/nunit.common/ResultHelper.cs
+++ b/src/NUnitCommon/nunit.common/ResultHelper.cs
@@ -77,7 +77,7 @@ namespace NUnit.Engine
         /// <param name="results">A collection of <see cref="TestEngineResult"/> to merge.</param>
         /// <returns>A TestEngineResult merging all the input results.</returns>
         /// <remarks>Used by AbstractTestRunner MakePackageResult method.</remarks>
-        public static TestEngineResult Merge(IList<TestEngineResult> results) 
+        public static TestEngineResult Merge(IList<TestEngineResult> results)
         {
             var mergedResult = new TestEngineResult();
 

--- a/src/NUnitCommon/nunit.common/RuntimeInformation.cs
+++ b/src/NUnitCommon/nunit.common/RuntimeInformation.cs
@@ -80,7 +80,6 @@ namespace NUnit.Engine.Internal.Backports
         public static Version FrameworkVersion { get; }
         public static string FrameworkDescription => $"{FrameworkName} {FrameworkVersion}";
 
-
         private struct MinimumRelease
         {
             public readonly int Release;

--- a/src/NUnitCommon/nunit.common/TcpChannelUtils.ObservableServerChannelSinkProvider.cs
+++ b/src/NUnitCommon/nunit.common/TcpChannelUtils.ObservableServerChannelSinkProvider.cs
@@ -17,7 +17,8 @@ namespace NUnit.Engine
 
             public ObservableServerChannelSinkProvider(CurrentMessageCounter currentMessageCounter)
             {
-                if (currentMessageCounter == null) throw new ArgumentNullException(nameof(currentMessageCounter));
+                if (currentMessageCounter == null)
+                    throw new ArgumentNullException(nameof(currentMessageCounter));
                 _currentMessageCounter = currentMessageCounter;
             }
 
@@ -34,7 +35,6 @@ namespace NUnit.Engine
 
             public IServerChannelSinkProvider? Next { get; set; }
 
-
             private sealed class ObservableServerChannelSink : IServerChannelSink
             {
                 private readonly IServerChannelSink _next;
@@ -42,7 +42,8 @@ namespace NUnit.Engine
 
                 public ObservableServerChannelSink(CurrentMessageCounter currentMessageCounter, IServerChannelSink next)
                 {
-                    if (next == null) throw new ArgumentNullException(nameof(next));
+                    if (next == null)
+                        throw new ArgumentNullException(nameof(next));
                     _currentMessageCounter = currentMessageCounter;
                     _next = next;
                 }
@@ -64,7 +65,8 @@ namespace NUnit.Engine
                     }
                     finally
                     {
-                        if (!isAsync) _currentMessageCounter.OnMessageEnd();
+                        if (!isAsync)
+                            _currentMessageCounter.OnMessageEnd();
                     }
                 }
 

--- a/src/NUnitCommon/nunit.common/TcpChannelUtils.cs
+++ b/src/NUnitCommon/nunit.common/TcpChannelUtils.cs
@@ -61,7 +61,7 @@ namespace NUnit.Engine
         /// <returns>The specified <see cref="TcpChannel"/> or <see langword="null"/> if it cannot be found and created.</returns>
         public static TcpChannel? GetTcpChannel(CurrentMessageCounter? currentMessageCounter = null)
         {
-            return GetTcpChannel("", 0, 2, currentMessageCounter);
+            return GetTcpChannel(string.Empty, 0, 2, currentMessageCounter);
         }
 
         /// <summary>
@@ -91,7 +91,8 @@ namespace NUnit.Engine
         public static TcpChannel? GetTcpChannel(string name, int port, int limit, CurrentMessageCounter? currentMessageCounter = null)
         {
             var existingChannel = ChannelServices.GetChannel(name) as TcpChannel;
-            if (existingChannel != null) return existingChannel;
+            if (existingChannel != null)
+                return existingChannel;
 
             // NOTE: Retries are normally only needed when rapidly creating
             // and destroying channels, as in running the NUnit tests.

--- a/src/NUnitCommon/nunit.common/TextDisplay/ColorConsoleWriter.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ColorConsoleWriter.cs
@@ -11,7 +11,9 @@ namespace NUnit.TextDisplay
         /// <summary>
         /// Construct a ColorConsoleWriter.
         /// </summary>
-        public ColorConsoleWriter() : this(true) { }
+        public ColorConsoleWriter() : this(true)
+        {
+        }
 
         /// <summary>
         /// Construct a ColorConsoleWriter.

--- a/src/NUnitCommon/nunit.common/TextDisplay/ExtendedTextWriter.cs
+++ b/src/NUnitCommon/nunit.common/TextDisplay/ExtendedTextWriter.cs
@@ -5,7 +5,7 @@ using System.IO;
 namespace NUnit.TextDisplay
 {
     /// <summary>
-    /// ExtendedTextWriter extends the TextWriter abstract class 
+    /// ExtendedTextWriter extends the TextWriter abstract class
     /// to support displaying text in color.
     /// </summary>
     public abstract class ExtendedTextWriter : TextWriter

--- a/src/NUnitCommon/nunit.common/XmlHelper.cs
+++ b/src/NUnitCommon/nunit.common/XmlHelper.cs
@@ -7,7 +7,9 @@ using System.Xml;
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
-    sealed class ExtensionAttribute : Attribute { }
+    internal sealed class ExtensionAttribute : Attribute
+    {
+    }
 }
 
 namespace NUnit
@@ -25,7 +27,7 @@ namespace NUnit
         public static XmlNode CreateTopLevelElement(string name)
         {
             XmlDocument doc = new XmlDocument();
-            doc.LoadXml( "<" + name + "/>" );
+            doc.LoadXml("<" + name + "/>");
             return doc.FirstChild.ShouldNotBeNull();
         }
 

--- a/src/NUnitCommon/nunit.extensibility.api/ExtensionAttribute.cs
+++ b/src/NUnitCommon/nunit.extensibility.api/ExtensionAttribute.cs
@@ -20,7 +20,7 @@ namespace NUnit.Extensibility
         }
 
         /// <summary>
-        /// A unique string identifying the ExtensionPoint for which this Extension is 
+        /// A unique string identifying the ExtensionPoint for which this Extension is
         /// intended. This is an optional field provided NUnit is able to deduce the
         /// ExtensionPoint from the Type of the extension class.
         /// </summary>

--- a/src/NUnitCommon/nunit.extensibility.api/ExtensionPointAttribute.cs
+++ b/src/NUnitCommon/nunit.extensibility.api/ExtensionPointAttribute.cs
@@ -24,13 +24,13 @@ namespace NUnit.Extensibility
 
         /// <summary>
         /// The unique string identifying this ExtensionPoint. This identifier
-        /// is typically formatted as a path using '/' and the set of extension 
+        /// is typically formatted as a path using '/' and the set of extension
         /// points is sometimes viewed as forming a tree.
         /// </summary>
         public string Path { get; }
 
         /// <summary>
-        /// The required Type (usually an interface) of any extension that is 
+        /// The required Type (usually an interface) of any extension that is
         /// installed at this ExtensionPoint.
         /// </summary>
         public Type Type { get; }

--- a/src/NUnitCommon/nunit.extensibility.api/IExtensionPoint.cs
+++ b/src/NUnitCommon/nunit.extensibility.api/IExtensionPoint.cs
@@ -15,7 +15,7 @@ namespace NUnit.Extensibility
         /// Gets the unique path identifying this extension point.
         /// </summary>
         string Path { get; }
-    
+
         /// <summary>
         /// Gets the description of this extension point. May be null.
         /// </summary>
@@ -32,4 +32,3 @@ namespace NUnit.Extensibility
         IEnumerable<IExtensionNode> Extensions { get; }
     }
 }
-

--- a/src/NUnitCommon/nunit.extensibility.api/TypeExtensionPointAttribute.cs
+++ b/src/NUnitCommon/nunit.extensibility.api/TypeExtensionPointAttribute.cs
@@ -27,12 +27,11 @@ namespace NUnit.Extensibility
         /// </summary>
         public TypeExtensionPointAttribute()
         {
-
         }
 
         /// <summary>
         /// The unique string identifying this ExtensionPoint. This identifier
-        /// is typically formatted as a path using '/' and the set of extension 
+        /// is typically formatted as a path using '/' and the set of extension
         /// points is sometimes viewed as forming a tree.
         /// </summary>
         public string? Path { get; }

--- a/src/NUnitCommon/nunit.extensibility.tests/AddinsFileTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/AddinsFileTests.cs
@@ -26,7 +26,7 @@ namespace NUnit.Extensibility
             var content = new[]
             {
                 "# This line is a comment and is ignored. The next (blank) line is ignored as well.",
-                "",
+                string.Empty,
                 "*.dll                   # include all dlls in the same directory",
                 "addins/*.dll            # include all dlls in the addins directory too",
                 "special/myassembly.dll  # include a specific dll in a special directory",

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionAssemblyTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionAssemblyTests.cs
@@ -47,7 +47,7 @@ namespace NUnit.Extensibility
             Assert.Multiple(() =>
             {
                 Assert.That(_ea.FrameworkName.Identifier, Is.EqualTo(".NETFramework"));
-                Assert.That(_ea.FrameworkName.Version, Is.EqualTo(new Version(4,6,2)));
+                Assert.That(_ea.FrameworkName.Version, Is.EqualTo(new Version(4, 6, 2)));
             });
         }
 #endif

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionAttributeTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionAttributeTests.cs
@@ -28,4 +28,3 @@ namespace NUnit.Extensibility
         }
     }
 }
-

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionManagerTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionManagerTests.cs
@@ -16,7 +16,8 @@ namespace NUnit.Extensibility
         private ExtensionManager _extensionManager;
 
 #pragma warning disable 414
-        private static readonly string[] KnownExtensionPointPaths = {
+        private static readonly string[] KnownExtensionPointPaths =
+        {
             "/NUnit/Engine/TypeExtensions/IDriverFactory",
             "/NUnit/Engine/TypeExtensions/IProjectLoader",
             "/NUnit/Engine/TypeExtensions/IResultWriter",
@@ -25,7 +26,8 @@ namespace NUnit.Extensibility
             "/NUnit/Engine/NUnitV2Driver"
         };
 
-        private static readonly Type[] KnownExtensionPointTypes = {
+        private static readonly Type[] KnownExtensionPointTypes =
+        {
             typeof(IDriverFactory),
             typeof(IProjectLoader),
             typeof(IResultWriter),
@@ -44,7 +46,8 @@ namespace NUnit.Extensibility
         private const string FAKE_DISABLED_EXTENSION = "NUnit.Engine.Fakes.FakeDisabledExtension";
         private const string FAKE_NUNIT_V2_DRIVER_EXTENSION = "NUnit.Engine.Fakes.V2DriverExtension";
 
-        private readonly string[] KnownExtensions = {
+        private readonly string[] KnownExtensions =
+        {
             FAKE_FRAMEWORK_DRIVER_EXTENSION,
             FAKE_PROJECT_LOADER_EXTENSION,
             FAKE_RESULT_WRITER_EXTENSION,

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionSelectorTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionSelectorTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-
 #if NETFRAMEWORK
 using System;
 using System.Runtime.Versioning;

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionWrapperTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionWrapperTests.cs
@@ -133,12 +133,14 @@ namespace NUnit.Extensibility
 
     #region DummyExtensionWrapper
 
-    class DummyExtensionWrapper : ExtensionWrapper
+    internal class DummyExtensionWrapper : ExtensionWrapper
     {
         private static readonly Type[] IntStringTypes = [typeof(int), typeof(string)];
         private static readonly Type[] IntType = [typeof(int)];
 
-        public DummyExtensionWrapper(object wrappedInstance) : base(wrappedInstance) { }
+        public DummyExtensionWrapper(object wrappedInstance) : base(wrappedInstance)
+        {
+        }
 
         public void CallVoidMethod() => Invoke("VoidMethod", NoTypes);
 
@@ -260,7 +262,9 @@ namespace NUnit.Extensibility
 
     public class ThingyWrapper : ExtensionWrapper, IThingy
     {
-        public ThingyWrapper(object wrappedInstance) : base(wrappedInstance) { }
+        public ThingyWrapper(object wrappedInstance) : base(wrappedInstance)
+        {
+        }
 
         public string Name => "THINGY";
     }

--- a/src/NUnitCommon/nunit.extensibility.tests/Program.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/Program.cs
@@ -5,9 +5,9 @@ using NUnitLite;
 
 namespace NUnit.Engine.Tests
 {
-    class Program
+    internal class Program
     {
-        static int Main(string[] args)
+        private static int Main(string[] args)
         {
             return new TextRunner(typeof(Program).Assembly).Execute(args);
         }

--- a/src/NUnitCommon/nunit.extensibility/AddinsFile.cs
+++ b/src/NUnitCommon/nunit.extensibility/AddinsFile.cs
@@ -42,7 +42,7 @@ namespace NUnit.Extensibility
                 while ((line = reader.ReadLine()) != null)
                 {
                     var entry = new AddinsFileEntry(++lineNumber, line);
-                    if (entry.Text != "" && !entry.IsValid)
+                    if (entry.Text != string.Empty && !entry.IsValid)
                     {
                         string msg = $"Invalid Entry in {fullName}:\r\n  {entry}";
                         throw new InvalidOperationException(msg);
@@ -55,7 +55,9 @@ namespace NUnit.Extensibility
             }
         }
 
-        private AddinsFile() { }
+        private AddinsFile()
+        {
+        }
 
         public override string ToString()
         {
@@ -68,12 +70,15 @@ namespace NUnit.Extensibility
         public override bool Equals(object? obj)
         {
             var other = obj as AddinsFile;
-            if (other == null) return false;
+            if (other == null)
+                return false;
 
-            if (Count != other.Count) return false;
+            if (Count != other.Count)
+                return false;
 
             for (int i = 0; i < Count; i++)
-                if (this[i] != other[i]) return false;
+                if (this[i] != other[i])
+                    return false;
 
             return true;
         }

--- a/src/NUnitCommon/nunit.extensibility/AddinsFileEntry.cs
+++ b/src/NUnitCommon/nunit.extensibility/AddinsFileEntry.cs
@@ -37,7 +37,8 @@ namespace NUnit.Extensibility
         public override bool Equals(object? obj)
         {
             var other = obj as AddinsFileEntry;
-            if (other == null) return false;
+            if (other == null)
+                return false;
 
             return LineNumber == other.LineNumber && RawText == other.RawText;
         }

--- a/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
@@ -14,13 +14,13 @@ namespace NUnit.Extensibility
 {
     public class ExtensionManager
     {
-        static readonly Version CURRENT_ENGINE_VERSION = Assembly.GetExecutingAssembly().GetName().Version ?? new Version();
-        static readonly string EXTENSION_ATTRIBUTE = typeof(ExtensionAttribute).FullName.ShouldNotBeNull();
-        static readonly string EXTENSION_PROPERTY_ATTRIBUTE = typeof(ExtensionPropertyAttribute).FullName.ShouldNotBeNull();
-        static readonly string V3_EXTENSION_ATTRIBUTE = "NUnit.Engine.Extensibility.ExtensionAttribute";
-        static readonly string V3_EXTENSION_PROPERTY_ATTRIBUTE = "NUnit.Engine.Extensibility.ExtensionPropertyAttribute";
+        private static readonly Version CURRENT_ENGINE_VERSION = Assembly.GetExecutingAssembly().GetName().Version ?? new Version();
+        private static readonly string EXTENSION_ATTRIBUTE = typeof(ExtensionAttribute).FullName.ShouldNotBeNull();
+        private static readonly string EXTENSION_PROPERTY_ATTRIBUTE = typeof(ExtensionPropertyAttribute).FullName.ShouldNotBeNull();
+        private static readonly string V3_EXTENSION_ATTRIBUTE = "NUnit.Engine.Extensibility.ExtensionAttribute";
+        private static readonly string V3_EXTENSION_PROPERTY_ATTRIBUTE = "NUnit.Engine.Extensibility.ExtensionPropertyAttribute";
 
-        static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionManager));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionManager));
 
         private readonly IFileSystem _fileSystem;
         //private readonly IAddinsFileReader _addinsReader;
@@ -166,7 +166,6 @@ namespace NUnit.Extensibility
             string[] extensionPatterns = isChocolateyPackage
                 ? new[] { "nunit-extension-*/**/tools/", "nunit-extension-*/**/tools/*/" }
                 : new[] { "NUnit.Extension.*/**/tools/", "NUnit.Extension.*/**/tools/*/" };
-
 
             IDirectory? startDir = _fileSystem.GetDirectory(AssemblyHelper.GetDirectoryName(hostAssembly));
 
@@ -382,7 +381,7 @@ namespace NUnit.Extensibility
                     if (entry.IsFullyQualified)
                     {
                         baseDir = _fileSystem.GetDirectory(entry.Text);
-                        foreach (var dir in _directoryFinder.GetDirectories(_fileSystem.GetDirectory(entryDir), ""))
+                        foreach (var dir in _directoryFinder.GetDirectories(_fileSystem.GetDirectory(entryDir), string.Empty))
                             ProcessDirectory(dir, isWild);
                     }
                     else
@@ -438,7 +437,7 @@ namespace NUnit.Extensibility
                 log.Debug("  Adding this assembly");
                 _assemblies.Add(candidateAssembly);
             }
-            catch (Exception) when(fromWildCard)
+            catch (Exception) when (fromWildCard)
             {
                 // When we are using wildcards, we may reach assemblies built for some other
                 // runtime, which we cannot load. We ignore those assemblies.
@@ -496,7 +495,7 @@ namespace NUnit.Extensibility
             {
                 bool isV3Extension = false;
                 CustomAttribute extensionAttr = extensionType.GetAttribute(EXTENSION_ATTRIBUTE);
-                if (extensionAttr == null) 
+                if (extensionAttr == null)
                 {
                     extensionAttr = extensionType.GetAttribute(V3_EXTENSION_ATTRIBUTE);
                     isV3Extension = true;
@@ -658,7 +657,7 @@ namespace NUnit.Extensibility
 
         public void Dispose()
         {
-            // Make sure all assemblies release the underlying file streams. 
+            // Make sure all assemblies release the underlying file streams.
             foreach (var candidate in _assemblies)
             {
                 candidate.Dispose();

--- a/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
@@ -15,11 +15,10 @@ namespace NUnit.Extensibility
     /// </summary>
     public class ExtensionNode : IExtensionNode
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionNode));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionNode));
 
         private object? _extensionObject;
         private readonly Dictionary<string, List<string>> _properties = new Dictionary<string, List<string>>();
-
 
         /// <summary>
         /// Construct an ExtensionNode supplying the assembly path and type name.
@@ -50,7 +49,7 @@ namespace NUnit.Extensibility
         /// Gets or sets a value indicating whether this <see cref="NUnit.Engine.Extensibility.ExtensionNode"/> is enabled.
         /// </summary>
         /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
-        public bool Enabled	{ get; set; }
+        public bool Enabled { get; set; }
 
         /// <summary>
         /// Gets and sets the unique string identifying the ExtensionPoint for which

--- a/src/NUnitCommon/nunit.extensibility/ExtensionWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionWrapper.cs
@@ -108,8 +108,8 @@ namespace NUnit.Extensibility
             public readonly object[] ArgTypes;
 
             public MethodSignature(string name, object[] argTypes)
-            {  
-                Name = name; 
+            {
+                Name = name;
                 ArgTypes = argTypes;
             }
 

--- a/src/NUnitCommon/nunit.extensibility/NUnitExtensibilityException.cs
+++ b/src/NUnitCommon/nunit.extensibility/NUnitExtensibilityException.cs
@@ -30,6 +30,8 @@ namespace NUnit.Extensibility
         /// <summary>
         /// Serialization constructor
         /// </summary>
-        public NUnitExtensibilityException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        public NUnitExtensibilityException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
     }
 }

--- a/src/NUnitCommon/nunit.extensibility/Wrappers/ProjectLoaderWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/Wrappers/ProjectLoaderWrapper.cs
@@ -15,7 +15,10 @@ namespace NUnit.Extensibility.Wrappers
     /// </summary>
     public class ProjectLoaderWrapper : ExtensionWrapper, IProjectLoader
     {
-        public ProjectLoaderWrapper(object projectLoader) : base(projectLoader) { log.Debug("Creating ProjectLoaderWrapper"); }
+        public ProjectLoaderWrapper(object projectLoader) : base(projectLoader)
+        {
+            log.Debug("Creating ProjectLoaderWrapper");
+        }
 
         public bool CanLoadFrom(string path)
         {
@@ -31,7 +34,9 @@ namespace NUnit.Extensibility.Wrappers
 
         public class ProjectWrapper : ExtensionWrapper, IProject
         {
-            public ProjectWrapper(object wrappedInstance) : base(wrappedInstance) { }
+            public ProjectWrapper(object wrappedInstance) : base(wrappedInstance)
+            {
+            }
 
             public string ProjectPath => GetProperty<string>(nameof(ProjectPath)).ShouldNotBeNull();
 
@@ -65,7 +70,9 @@ namespace NUnit.Extensibility.Wrappers
 
         public class TestPackageWrapper : ExtensionWrapper, ITestPackage
         {
-            public TestPackageWrapper(object wrappedInstance) : base(wrappedInstance) { }
+            public TestPackageWrapper(object wrappedInstance) : base(wrappedInstance)
+            {
+            }
 
             public IDictionary<string, object> Settings => throw new NotImplementedException();
 

--- a/src/NUnitCommon/nunit.extensibility/Wrappers/ResultWriterWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/Wrappers/ResultWriterWrapper.cs
@@ -15,7 +15,9 @@ namespace NUnit.Extensibility.Wrappers
         private static readonly Type[] XmlNodeStringTypes = [typeof(XmlNode), typeof(string)];
         private static readonly Type[] XmlNodeTextWriterTypes = [typeof(XmlNode), typeof(TextWriter)];
 
-        public ResultWriterWrapper(object writer) : base(writer) { }
+        public ResultWriterWrapper(object writer) : base(writer)
+        {
+        }
 
         public void CheckWritability(string outputPath)
         {

--- a/src/NUnitCommon/nunit.extensibility/Wrappers/TestEventListenerWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/Wrappers/TestEventListenerWrapper.cs
@@ -9,7 +9,9 @@ namespace NUnit.Extensibility.Wrappers
     /// </summary>
     public class TestEventListenerWrapper : ExtensionWrapper, ITestEventListener
     {
-        public TestEventListenerWrapper(object listener) : base(listener) { }
+        public TestEventListenerWrapper(object listener) : base(listener)
+        {
+        }
 
         public void OnTestEvent(string report)
         {

--- a/src/NUnitConsole/nunit4-console.tests/ColorConsoleTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ColorConsoleTests.cs
@@ -14,9 +14,9 @@ namespace NUnit.TextDisplay
         public void SetUp()
         {
             // Find a test color that is different than the console color
-            if (Console.ForegroundColor != ColorConsole.GetColor( ColorStyle.Error ))
+            if (Console.ForegroundColor != ColorConsole.GetColor(ColorStyle.Error))
                 _testStyle = ColorStyle.Error;
-            else if (Console.ForegroundColor != ColorConsole.GetColor( ColorStyle.Pass ))
+            else if (Console.ForegroundColor != ColorConsole.GetColor(ColorStyle.Pass))
                 _testStyle = ColorStyle.Pass;
             else
                 Assert.Inconclusive("Could not find a color to test with");
@@ -37,11 +37,11 @@ namespace NUnit.TextDisplay
         public void TestConstructor()
         {
             ConsoleColor expected = ColorConsole.GetColor(_testStyle);
-            using(new ColorConsole(_testStyle))
+            using (new ColorConsole(_testStyle))
             {
                 Assert.That(Console.ForegroundColor, Is.EqualTo(expected));
             }
-            Assert.That( Console.ForegroundColor, Is.Not.EqualTo(expected) );
+            Assert.That(Console.ForegroundColor, Is.Not.EqualTo(expected));
         }
     }
 }

--- a/src/NUnitConsole/nunit4-console.tests/ColorStyleTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ColorStyleTests.cs
@@ -13,7 +13,7 @@ namespace NUnit.TextDisplay
         [TestCase(ColorStyle.Failure, ConsoleColor.Red)]
         //[TestCase(ColorStyle.Warning, ConsoleColor.Yellow)]
         [TestCase(ColorStyle.Error, ConsoleColor.Red)]
-        public void TestGetColor( ColorStyle style, ConsoleColor expected )
+        public void TestGetColor(ColorStyle style, ConsoleColor expected)
         {
             Assert.That(ColorConsole.GetColor(style), Is.EqualTo(expected));
         }

--- a/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
@@ -199,7 +199,7 @@ namespace NUnit.ConsoleRunner
        // We can't predict which runtimes are available on the test machine, so we don't
         // test for any good or bad values. TODO: Create a fake list of availble runtimes.
         [TestCase("RuntimeFramework", "framework", new string[0], new string[0])]
-        [TestCase("ConfigurationFile", "configfile", new string[] { "mytest.config" }, new string[0] )]
+        [TestCase("ConfigurationFile", "configfile", new string[] { "mytest.config" }, new string[0])]
         [TestCase("PrincipalPolicy", "set-principal-policy", new string[] { "UnauthenticatedPrincipal", "NoPrincipal", "WindowsPrincipal" }, new string[] { "JUNK" })]
 #endif
         public void CanRecognizeStringOptions(string propertyName, string pattern, string[] goodValues, string[] badValues)
@@ -570,7 +570,7 @@ namespace NUnit.ConsoleRunner
             Assume.That(testListPath, Does.Exist);
             var options = ConsoleMocks.Options("--testlist=" + testListPath);
             Assert.That(options.ErrorMessages, Is.Empty);
-            Assert.That(options.TestList, Is.EqualTo(new[] {"AmazingTest"}));
+            Assert.That(options.TestList, Is.EqualTo(new[] { "AmazingTest" }));
         }
 
         [Test]

--- a/src/NUnitConsole/nunit4-console.tests/ConsoleOutputTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ConsoleOutputTests.cs
@@ -14,7 +14,6 @@ namespace NUnit.ConsoleRunner
             Console.WriteLine("OneTimeSetUp: Console.WriteLine()");
             Console.Error.WriteLine("OneTimeSetUp: Console.Error.WriteLine()");
             TestContext.Out.WriteLine("OneTimeSetUp: TestContext.WriteLine()");
-
         }
 
         [SetUp]

--- a/src/NUnitConsole/nunit4-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ConsoleRunnerTests.cs
@@ -13,7 +13,7 @@ using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {
-    class ConsoleRunnerTests
+    internal class ConsoleRunnerTests
     {
         private ITestEngine _testEngine;
         private IResultService _resultService;
@@ -61,7 +61,6 @@ namespace NUnit.ConsoleRunner
 
         public string[] Formats
         {
-
             get
             {
                 return new[] { "nunit3" };
@@ -79,7 +78,7 @@ namespace NUnit.ConsoleRunner
         private FakeResultService _service;
 
         public FakeResultWriter(FakeResultService service)
-        { 
+        {
             _service = service;
         }
 

--- a/src/NUnitConsole/nunit4-console.tests/ExceptionHelperTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ExceptionHelperTests.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 
 namespace NUnit.ConsoleRunner
 {
-    class ExceptionHelperTests
+    internal class ExceptionHelperTests
     {
         [TestCaseSource(nameof(TestCases))]
         public void TestMessageContainsAllInnerExceptions(Exception ex, params Type[] expectedExceptions)
@@ -58,6 +58,5 @@ namespace NUnit.ConsoleRunner
                     .SetName("{m}(LoaderException)");
             }
         }
-
     }
 }

--- a/src/NUnitConsole/nunit4-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/MakeTestPackageTests.cs
@@ -22,7 +22,7 @@ namespace NUnit.ConsoleRunner
         [Test]
         public void MultipleAssemblies()
         {
-            var names = new [] { "test1.dll", "test2.dll", "test3.dll" };
+            var names = new string[] { "test1.dll", "test2.dll", "test3.dll" };
             var options = ConsoleMocks.Options(names);
             var package = ConsoleRunner.MakeTestPackage(options);
 
@@ -111,6 +111,5 @@ namespace NUnit.ConsoleRunner
 
             Assert.That(package.Settings.Keys, Is.EquivalentTo(new string[] { "WorkDirectory", "DisposeRunners" }));
         }
-
     }
 }

--- a/src/NUnitConsole/nunit4-console.tests/Options/NetCoreConsoleOptionsTest.cs
+++ b/src/NUnitConsole/nunit4-console.tests/Options/NetCoreConsoleOptionsTest.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-
 using System.Collections.Generic;
 using NUnit.Framework;
 
 namespace NUnit.ConsoleRunner.Options
 {
 #if NETCOREAPP
-    class NetCoreConsoleOptionsTest
+    internal class NetCoreConsoleOptionsTest
     {
         [TestCaseSource(nameof(TestCases))]
         public void InvalidOptionsShowError(string arg, bool isValidOnNetCore)

--- a/src/NUnitConsole/nunit4-console.tests/Options/OutputSpecificationTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/Options/OutputSpecificationTests.cs
@@ -15,7 +15,6 @@ namespace NUnit.ConsoleRunner.Options
                 Throws.TypeOf<ArgumentNullException>());
         }
 
-
         [Test]
         public void SpecOptionMustContainEqualSign()
         {
@@ -113,7 +112,7 @@ namespace NUnit.ConsoleRunner.Options
         {
             const string fileName = "transform.xslt";
             var spec = new OutputSpecification($"MyFile.xml;transform=transform.xslt", transformFolder);
-            var expectedTransform = Path.Combine(transformFolder ?? "", fileName);
+            var expectedTransform = Path.Combine(transformFolder ?? string.Empty, fileName);
             Assert.That(spec.Transform, Is.EqualTo(expectedTransform));
         }
     }

--- a/src/NUnitConsole/nunit4-console.tests/Program.cs
+++ b/src/NUnitConsole/nunit4-console.tests/Program.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 
 namespace NUnit.Engine.Tests
 {
-    class Program
+    internal class Program
     {
-        static int Main(string[] args)
+        private static int Main(string[] args)
         {
             return new NUnitLite.TextRunner(typeof(Program).Assembly).Execute(args);
         }

--- a/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
@@ -14,7 +14,6 @@ using NUnit.TextDisplay;
 
 namespace NUnit.ConsoleRunner
 {
-
     public class ResultReporterTests
     {
         private XmlNode _result;
@@ -28,11 +27,13 @@ namespace NUnit.ConsoleRunner
             var frameworkSettings = new Dictionary<string, object>
             {
                 { "TestParameters", "1=d;2=c" },
-                { "TestParametersDictionary", new Dictionary<string, string>
+                {
+                    "TestParametersDictionary", new Dictionary<string, string>
                 {
                     { "1", "d" },
                     { "2", "c" }
-                }}
+                }
+                }
             };
 
             var controller = new FrameworkController(mockAssembly, "id", frameworkSettings);
@@ -79,7 +80,9 @@ namespace NUnit.ConsoleRunner
         [Test]
         public void SummaryReportTest()
         {
-            var expected = new[] {
+#pragma warning disable SA1137 // Elements should have the same indentation
+            var expected = new[]
+            {
                 "Test Run Summary",
                 "    Overall result: Failed",
                $"    Test Count: {MockAssembly.Tests}, Pass: {MockAssembly.Passed}, Fail: 11, Warn: 1, Inconclusive: 1, Skip: 7",
@@ -88,8 +91,9 @@ namespace NUnit.ConsoleRunner
                 "    Start time: 2015-10-19 02:12:28Z",
                 "    End time: 2015-10-19 02:12:29Z",
                 "    Duration: 0.349 seconds",
-                ""
+                string.Empty
             };
+#pragma warning restore SA1137 // Elements should have the same indentation
 
             var actualSummary = GetReportLines(_reporter.WriteSummaryReport);
             Assert.That(actualSummary, Is.EqualTo(expected));
@@ -100,7 +104,8 @@ namespace NUnit.ConsoleRunner
         {
             var nl = Environment.NewLine;
 
-            var expected = new[] {
+            var expected = new[]
+            {
                 "Errors, Failures and Warnings",
                 "1) Failed : NUnit.TestData.Assemblies.MockTestFixture.FailingTest" + nl +
                 "Intentional failure",
@@ -127,29 +132,30 @@ namespace NUnit.ConsoleRunner
         [Test]
         public void TestsNotRunTest()
         {
-            var expected = new[] {
+            var expected = new[]
+            {
                 "Tests Not Run",
-                "",
+                string.Empty,
                 "1) Explicit : NUnit.TestData.Assemblies.MockTestFixture.ExplicitTest",
-                "",
+                string.Empty,
                 "2) Ignored : NUnit.TestData.Assemblies.MockTestFixture.IgnoreTest",
                 "Ignore Message",
-                "",
+                string.Empty,
                 "3) Explicit : NUnit.TestData.ExplicitFixture.Test1",
                 "OneTimeSetUp: ",
-                "",
+                string.Empty,
                 "4) Explicit : NUnit.TestData.ExplicitFixture.Test2",
                 "OneTimeSetUp: ",
-                "",
+                string.Empty,
                 "5) Ignored : NUnit.TestData.IgnoredFixture.Test1",
                 "OneTimeSetUp: BECAUSE",
-                "",
+                string.Empty,
                 "6) Ignored : NUnit.TestData.IgnoredFixture.Test2",
                 "OneTimeSetUp: BECAUSE",
-                "",
+                string.Empty,
                 "7) Ignored : NUnit.TestData.IgnoredFixture.Test3",
                 "OneTimeSetUp: BECAUSE",
-                ""
+                string.Empty
             };
 
             var report = GetReportLines(_reporter.WriteNotRunReport);
@@ -165,7 +171,8 @@ namespace NUnit.ConsoleRunner
         [Test]
         public void TestParameterSettingsWrittenCorrectly()
         {
-            var expected = new[] {
+            var expected = new[]
+            {
                 "    TestParameters: |1=d;2=c|",
                 "    TestParametersDictionary:",
                 "        1 -> |d|",

--- a/src/NUnitConsole/nunit4-console.tests/TestEventHandlerTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/TestEventHandlerTests.cs
@@ -13,7 +13,10 @@ namespace NUnit.ConsoleRunner
         private StringBuilder _output;
         private ExtendedTextWriter _writer;
 
-        private string Output {  get { return _output.ToString(); } }
+        private string Output
+        {
+            get { return _output.ToString(); }
+        }
 
         [SetUp]
         public void CreateWriter()
@@ -63,23 +66,23 @@ namespace NUnit.ConsoleRunner
             Assert.That(Output, Is.EqualTo(expected));
         }
 
-        static readonly TestCaseData[] SingleEventData = new TestCaseData[]
+        private static readonly TestCaseData[] SingleEventData = new TestCaseData[]
         {
             // Start Events
-            new TestCaseData("<start-test fullname='SomeName'/>", "Off", ""),
-            new TestCaseData("<start-test fullname='SomeName'/>", "OnOutputOnly", ""),
+            new TestCaseData("<start-test fullname='SomeName'/>", "Off", string.Empty),
+            new TestCaseData("<start-test fullname='SomeName'/>", "OnOutputOnly", string.Empty),
             new TestCaseData("<start-test fullname='SomeName'/>", "Before", "=> SomeName\r\n"),
-            new TestCaseData("<start-test fullname='SomeName'/>", "After", ""),
+            new TestCaseData("<start-test fullname='SomeName'/>", "After", string.Empty),
             new TestCaseData("<start-test fullname='SomeName'/>", "BeforeAndAfter", "=> SomeName\r\n"),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "Off", ""),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "OnOutputOnly", ""),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "Before", ""),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "After", ""),
-            new TestCaseData("<start-suite fullname='SomeName'/>", "BeforeAndAfter", ""),
+            new TestCaseData("<start-suite fullname='SomeName'/>", "Off", string.Empty),
+            new TestCaseData("<start-suite fullname='SomeName'/>", "OnOutputOnly", string.Empty),
+            new TestCaseData("<start-suite fullname='SomeName'/>", "Before", string.Empty),
+            new TestCaseData("<start-suite fullname='SomeName'/>", "After", string.Empty),
+            new TestCaseData("<start-suite fullname='SomeName'/>", "BeforeAndAfter", string.Empty),
             // Finish Events - No Output
-            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "Off", ""),
-            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "OnOutputOnly", ""),
-            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "Before", ""),
+            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "Off", string.Empty),
+            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "OnOutputOnly", string.Empty),
+            new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "Before", string.Empty),
             new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "After", "Passed => SomeName\r\n"),
             new TestCaseData("<test-case fullname='SomeName' result='Passed'/>", "BeforeAndAfter", "Passed => SomeName\r\n"),
             new TestCaseData("<test-case fullname='SomeName' result='Failed'/>", "After", "Failed => SomeName\r\n"),
@@ -98,11 +101,11 @@ namespace NUnit.ConsoleRunner
             new TestCaseData("<test-case fullname='SomeName' result='Skipped'/>", "BeforeAndAfter", "Skipped => SomeName\r\n"),
             new TestCaseData("<test-case fullname='SomeName' result='Skipped' label='Ignored'/>", "After", "Ignored => SomeName\r\n"),
             new TestCaseData("<test-case fullname='SomeName' result='Skipped' label='Ignored'/>", "BeforeAndAfter", "Ignored => SomeName\r\n"),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "Off", ""),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "OnOutputOnly", ""),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "Before", ""),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "After", ""),
-            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "BeforeAndAfter", ""),
+            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "Off", string.Empty),
+            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "OnOutputOnly", string.Empty),
+            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "Before", string.Empty),
+            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "After", string.Empty),
+            new TestCaseData("<test-suite fullname='SomeName' result='Passed'/>", "BeforeAndAfter", string.Empty),
             // Finish Events - With Output
             new TestCaseData(
                 "<test-case fullname='SomeName' result='Passed'><output>OUTPUT</output></test-case>",
@@ -227,26 +230,26 @@ namespace NUnit.ConsoleRunner
                 "=> SomeName\r\nOUTPUT")
         };
 
-        static string[] SingleTest_StartAndFinish = new string[]
+        private static string[] SingleTest_StartAndFinish = new string[]
         {
             "<start-test fullname='TestName'/>",
             "<test-case fullname='TestName' result='Passed'><output>OUTPUT</output></test-case>"
         };
 
-        static string[] SingleTest_ImmediateOutput = new string[]
+        private static string[] SingleTest_ImmediateOutput = new string[]
         {
             "<start-test fullname='TEST1'/>",
             "<test-output testname='TEST1'>Immediate output from TEST1</test-output>",
             string.Format("<test-case fullname='TEST1' result='Passed'><output>Output{0}from{0}TEST1</output></test-case>", Environment.NewLine)
         };
 
-        static string[] SingleTest_SuiteFinish = new string[]
+        private static string[] SingleTest_SuiteFinish = new string[]
         {
             "<test-output testname='TEST1'>Immediate output from TEST1</test-output>",
             string.Format("<test-suite fullname='TEST1' result='Passed'><output>Output from Suite TEST1</output></test-suite>")
         };
 
-        static string[] TwoTests_SequentialExecution = new string[]
+        private static string[] TwoTests_SequentialExecution = new string[]
         {
             "<start-test fullname='TEST1'/>",
             "<test-case fullname='TEST1' result='Failed'><output>Output from first test</output></test-case>",
@@ -254,7 +257,7 @@ namespace NUnit.ConsoleRunner
             "<test-case fullname='TEST2' result='Passed'><output>Output from second test</output></test-case>"
         };
 
-        static string[] TwoTests_InterleavedExecution = new string[]
+        private static string[] TwoTests_InterleavedExecution = new string[]
         {
             "<start-test fullname='TEST1'/>",
             "<test-output testname='TEST1'>Immediate output from first test</test-output>",
@@ -265,7 +268,7 @@ namespace NUnit.ConsoleRunner
             "<test-case fullname='TEST2' result='Passed'><output>Output from second test</output></test-case>"
         };
 
-        static string[] TwoTests_NestedExecution = new string[]
+        private static string[] TwoTests_NestedExecution = new string[]
         {
             "<start-test fullname='TEST1'/>",
             "<test-output testname='TEST1'>Immediate output from first test</test-output>",
@@ -275,7 +278,7 @@ namespace NUnit.ConsoleRunner
             "<test-case fullname='TEST1' result='Failed'><output>Output from first test</output></test-case>"
         };
 
-        static readonly TestCaseData[] MultipleEventData = new TestCaseData[]
+        private static readonly TestCaseData[] MultipleEventData = new TestCaseData[]
         {
             new TestCaseData(
                 SingleTest_StartAndFinish,
@@ -284,247 +287,312 @@ namespace NUnit.ConsoleRunner
             new TestCaseData(
                 SingleTest_StartAndFinish,
                 "OnOutputOnly",
-                "=> TestName\r\nOUTPUT"),
+                """
+                => TestName
+                OUTPUT
+                """),
             new TestCaseData(
                 SingleTest_StartAndFinish,
                 "Before",
-                "=> TestName\r\nOUTPUT"),
+                """
+                => TestName
+                OUTPUT
+                """),
             new TestCaseData(
                 SingleTest_StartAndFinish,
                 "After",
-                "=> TestName\r\nOUTPUT\r\nPassed => TestName\r\n"),
+                """
+                => TestName
+                OUTPUT
+                Passed => TestName
+
+                """),
             new TestCaseData(
                 SingleTest_StartAndFinish,
                 "BeforeAndAfter",
-                "=> TestName\r\nOUTPUT\r\nPassed => TestName\r\n"),
+                """
+                => TestName
+                OUTPUT
+                Passed => TestName
+
+                """),
             new TestCaseData(
                 SingleTest_ImmediateOutput,
                 "Off",
-@"Immediate output from TEST1
-Output
-from
-TEST1"),
+                """
+                Immediate output from TEST1
+                Output
+                from
+                TEST1
+                """),
             new TestCaseData(
                 SingleTest_ImmediateOutput,
                 "OnOutputOnly",
-@"=> TEST1
-Immediate output from TEST1
-Output
-from
-TEST1"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output
+                from
+                TEST1
+                """),
             new TestCaseData(
                 SingleTest_ImmediateOutput,
                 "Before",
-@"=> TEST1
-Immediate output from TEST1
-Output
-from
-TEST1"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output
+                from
+                TEST1
+                """),
             new TestCaseData(
                 SingleTest_ImmediateOutput,
                 "After",
-@"=> TEST1
-Immediate output from TEST1
-Output
-from
-TEST1
-Passed => TEST1
-"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output
+                from
+                TEST1
+                Passed => TEST1
+
+                """),
             new TestCaseData(
                 SingleTest_ImmediateOutput,
                 "BeforeAndAfter",
-                @"=> TEST1
-Immediate output from TEST1
-Output
-from
-TEST1
-Passed => TEST1
-"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output
+                from
+                TEST1
+                Passed => TEST1
+
+                """),
             new TestCaseData(
                 SingleTest_SuiteFinish,
                 "Off",
-@"Immediate output from TEST1
-Output from Suite TEST1"),
+                """
+                Immediate output from TEST1
+                Output from Suite TEST1
+                """),
             new TestCaseData(
                 SingleTest_SuiteFinish,
                 "OnOutputOnly",
-@"=> TEST1
-Immediate output from TEST1
-Output from Suite TEST1"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output from Suite TEST1
+                """),
             new TestCaseData(
                 SingleTest_SuiteFinish,
                 "Before",
-@"=> TEST1
-Immediate output from TEST1
-Output from Suite TEST1"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output from Suite TEST1
+                """),
             new TestCaseData(
                 SingleTest_SuiteFinish,
                 "After",
-@"=> TEST1
-Immediate output from TEST1
-Output from Suite TEST1"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output from Suite TEST1
+                """),
             new TestCaseData(
                 SingleTest_SuiteFinish,
                 "BeforeAndAfter",
-                @"=> TEST1
-Immediate output from TEST1
-Output from Suite TEST1"),
+                """
+                => TEST1
+                Immediate output from TEST1
+                Output from Suite TEST1
+                """),
             new TestCaseData(
                 TwoTests_SequentialExecution,
                 "Off",
-@"Output from first test
-Output from second test"),
+                """
+                Output from first test
+                Output from second test
+                """),
             new TestCaseData(
                 TwoTests_SequentialExecution,
                 "OnOutputOnly",
-@"=> TEST1
-Output from first test
-=> TEST2
-Output from second test"),
+                """
+                => TEST1
+                Output from first test
+                => TEST2
+                Output from second test
+                """),
             new TestCaseData(
                 TwoTests_SequentialExecution,
                 "Before",
-@"=> TEST1
-Output from first test
-=> TEST2
-Output from second test"),
+                """
+                => TEST1
+                Output from first test
+                => TEST2
+                Output from second test
+                """),
             new TestCaseData(
                 TwoTests_SequentialExecution,
                 "After",
-@"=> TEST1
-Output from first test
-Failed => TEST1
-=> TEST2
-Output from second test
-Passed => TEST2
-"),
+                """
+                => TEST1
+                Output from first test
+                Failed => TEST1
+                => TEST2
+                Output from second test
+                Passed => TEST2
+
+                """),
             new TestCaseData(
                 TwoTests_SequentialExecution,
                 "BeforeAndAfter",
-                @"=> TEST1
-Output from first test
-Failed => TEST1
-=> TEST2
-Output from second test
-Passed => TEST2
-"),
+                """
+                => TEST1
+                Output from first test
+                Failed => TEST1
+                => TEST2
+                Output from second test
+                Passed => TEST2
+
+                """),
             new TestCaseData(
                 TwoTests_InterleavedExecution,
                 "Off",
-@"Immediate output from first testAnother immediate output from first test
-Immediate output from second test
-Output from first test
-Output from second test"),
+                """
+                Immediate output from first testAnother immediate output from first test
+                Immediate output from second test
+                Output from first test
+                Output from second test
+                """),
             new TestCaseData(
                 TwoTests_InterleavedExecution,
                 "OnOutputOnly",
-@"=> TEST1
-Immediate output from first testAnother immediate output from first test
-=> TEST2
-Immediate output from second test
-=> TEST1
-Output from first test
-=> TEST2
-Output from second test"),
+                """
+                => TEST1
+                Immediate output from first testAnother immediate output from first test
+                => TEST2
+                Immediate output from second test
+                => TEST1
+                Output from first test
+                => TEST2
+                Output from second test
+                """),
             new TestCaseData(
                 TwoTests_InterleavedExecution,
                 "Before",
-@"=> TEST1
-Immediate output from first test
-=> TEST2
-=> TEST1
-Another immediate output from first test
-=> TEST2
-Immediate output from second test
-=> TEST1
-Output from first test
-=> TEST2
-Output from second test"),
+                """
+                => TEST1
+                Immediate output from first test
+                => TEST2
+                => TEST1
+                Another immediate output from first test
+                => TEST2
+                Immediate output from second test
+                => TEST1
+                Output from first test
+                => TEST2
+                Output from second test
+                """),
             new TestCaseData(
                 TwoTests_InterleavedExecution,
                 "After",
-@"=> TEST1
-Immediate output from first testAnother immediate output from first test
-=> TEST2
-Immediate output from second test
-=> TEST1
-Output from first test
-Failed => TEST1
-=> TEST2
-Output from second test
-Passed => TEST2
-"),
+                """
+                => TEST1
+                Immediate output from first testAnother immediate output from first test
+                => TEST2
+                Immediate output from second test
+                => TEST1
+                Output from first test
+                Failed => TEST1
+                => TEST2
+                Output from second test
+                Passed => TEST2
+
+                """),
             new TestCaseData(
                 TwoTests_InterleavedExecution,
                 "BeforeAndAfter",
-                @"=> TEST1
-Immediate output from first test
-=> TEST2
-=> TEST1
-Another immediate output from first test
-=> TEST2
-Immediate output from second test
-=> TEST1
-Output from first test
-Failed => TEST1
-=> TEST2
-Output from second test
-Passed => TEST2
-"),
+                """
+                => TEST1
+                Immediate output from first test
+                => TEST2
+                => TEST1
+                Another immediate output from first test
+                => TEST2
+                Immediate output from second test
+                => TEST1
+                Output from first test
+                Failed => TEST1
+                => TEST2
+                Output from second test
+                Passed => TEST2
+
+                """),
             new TestCaseData(
                 TwoTests_NestedExecution,
                 "Off",
-@"Immediate output from first test
-Immediate output from second test
-Output from second test
-Output from first test"),
+                """
+                Immediate output from first test
+                Immediate output from second test
+                Output from second test
+                Output from first test
+                """),
             new TestCaseData(
                 TwoTests_NestedExecution,
                 "OnOutputOnly",
-@"=> TEST1
-Immediate output from first test
-=> TEST2
-Immediate output from second test
-Output from second test
-=> TEST1
-Output from first test"),
+                """
+                => TEST1
+                Immediate output from first test
+                => TEST2
+                Immediate output from second test
+                Output from second test
+                => TEST1
+                Output from first test
+                """),
             new TestCaseData(
                 TwoTests_NestedExecution,
                 "Before",
-@"=> TEST1
-Immediate output from first test
-=> TEST2
-Immediate output from second test
-Output from second test
-=> TEST1
-Output from first test"),
+                """
+                => TEST1
+                Immediate output from first test
+                => TEST2
+                Immediate output from second test
+                Output from second test
+                => TEST1
+                Output from first test
+                """),
             new TestCaseData(
                 TwoTests_NestedExecution,
                 "After",
-@"=> TEST1
-Immediate output from first test
-=> TEST2
-Immediate output from second test
-Output from second test
-Passed => TEST2
-=> TEST1
-Output from first test
-Failed => TEST1
-"),
+                """
+                => TEST1
+                Immediate output from first test
+                => TEST2
+                Immediate output from second test
+                Output from second test
+                Passed => TEST2
+                => TEST1
+                Output from first test
+                Failed => TEST1
+
+                """),
             new TestCaseData(
                 TwoTests_NestedExecution,
                 "BeforeAndAfter",
-                @"=> TEST1
-Immediate output from first test
-=> TEST2
-Immediate output from second test
-Output from second test
-Passed => TEST2
-=> TEST1
-Output from first test
-Failed => TEST1
-")
+                """
+                => TEST1
+                Immediate output from first test
+                => TEST2
+                Immediate output from second test
+                Output from second test
+                Passed => TEST2
+                => TEST1
+                Output from first test
+                Failed => TEST1
+
+                """)
         };
-#pragma warning restore 414
     }
 }

--- a/src/NUnitConsole/nunit4-console.tests/VirtualFileSystem.cs
+++ b/src/NUnitConsole/nunit4-console.tests/VirtualFileSystem.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace NUnit.ConsoleRunner
 {
-    internal class VirtualFileSystem: IFileSystem
+    internal class VirtualFileSystem : IFileSystem
     {
         private readonly Dictionary<string, IEnumerable<string>> files = new Dictionary<string, IEnumerable<string>>();
 

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -6,11 +6,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using NUnit.ConsoleRunner.Options;
 
 namespace NUnit.ConsoleRunner
 {
-    using Options;
-
     /// <summary>
     /// <c>ConsoleOptions</c> encapsulates the option settings for
     /// the nunit4-console program. The class inherits from the Mono
@@ -62,17 +61,29 @@ namespace NUnit.ConsoleRunner
         public string? WhereClause { get; private set; }
 
         [MemberNotNullWhen(true, nameof(WhereClause))]
-        public bool WhereClauseSpecified { get { return WhereClause != null; } }
+        public bool WhereClauseSpecified
+        {
+            get { return WhereClause != null; }
+        }
 
         public int DefaultTestCaseTimeout { get; private set; } = -1;
-        public bool DefaultTestCaseTimeoutSpecified { get { return DefaultTestCaseTimeout >= 0; } }
+        public bool DefaultTestCaseTimeoutSpecified
+        {
+            get { return DefaultTestCaseTimeout >= 0; }
+        }
 
         public int RandomSeed { get; private set; } = -1;
-        public bool RandomSeedSpecified { get { return RandomSeed >= 0; } }
+        public bool RandomSeedSpecified
+        {
+            get { return RandomSeed >= 0; }
+        }
 
         public string? DefaultTestNamePattern { get; private set; }
         public int NumberOfTestWorkers { get; private set; } = -1;
-        public bool NumberOfTestWorkersSpecified { get { return NumberOfTestWorkers >= 0; } }
+        public bool NumberOfTestWorkersSpecified
+        {
+            get { return NumberOfTestWorkers >= 0; }
+        }
 
         public bool StopOnError { get; private set; }
 
@@ -89,7 +100,10 @@ namespace NUnit.ConsoleRunner
         public string? OutFile { get; private set; }
 
         [MemberNotNullWhen(true, nameof(OutFile))]
-        public bool OutFileSpecified { get { return OutFile != null; } }
+        public bool OutFileSpecified
+        {
+            get { return OutFile != null; }
+        }
 
         public string? DisplayTestLabels { get; private set; }
 
@@ -98,12 +112,18 @@ namespace NUnit.ConsoleRunner
         {
             get { return workDirectory ?? CURRENT_DIRECTORY_ON_ENTRY; }
         }
-        public bool WorkDirectorySpecified { get { return workDirectory != null; } }
+        public bool WorkDirectorySpecified
+        {
+            get { return workDirectory != null; }
+        }
 
         public string? InternalTraceLevel { get; private set; }
 
         [MemberNotNullWhen(true, nameof(InternalTraceLevel))]
-        public bool InternalTraceLevelSpecified { get { return InternalTraceLevel != null; } }
+        public bool InternalTraceLevelSpecified
+        {
+            get { return InternalTraceLevel != null; }
+        }
 
         private readonly List<OutputSpecification> resultOutputSpecifications = new List<OutputSpecification>();
         public IList<OutputSpecification> ResultOutputSpecifications
@@ -128,14 +148,20 @@ namespace NUnit.ConsoleRunner
         public string? ActiveConfig { get; private set; }
 
         [MemberNotNullWhen(true, nameof(ActiveConfig))]
-        public bool ActiveConfigSpecified { get { return ActiveConfig != null; } }
+        public bool ActiveConfigSpecified
+        {
+            get { return ActiveConfig != null; }
+        }
 
         // How to Run Tests
 
         public string? RuntimeFramework { get; private set; }
 
         [MemberNotNullWhen(true, nameof(RuntimeFramework))]
-        public bool RuntimeFrameworkSpecified { get { return RuntimeFramework != null; } }
+        public bool RuntimeFrameworkSpecified
+        {
+            get { return RuntimeFramework != null; }
+        }
 
         public string? ConfigurationFile { get; private set; }
 
@@ -150,8 +176,14 @@ namespace NUnit.ConsoleRunner
         public bool SkipNonTestAssemblies { get; private set; }
 
         private int _maxAgents = -1;
-        public int MaxAgents { get { return _maxAgents; } }
-        public bool MaxAgentsSpecified { get { return _maxAgents >= 0; } }
+        public int MaxAgents
+        {
+            get { return _maxAgents; }
+        }
+        public bool MaxAgentsSpecified
+        {
+            get { return _maxAgents >= 0; }
+        }
 
         public bool DebugTests { get; private set; }
 
@@ -245,23 +277,23 @@ namespace NUnit.ConsoleRunner
                 v =>
                 {
                     var spec = parser.ResolveOutputSpecification(parser.RequiredValue(v, "--resultxml"), resultOutputSpecifications, _fileSystem, CURRENT_DIRECTORY_ON_ENTRY);
-                    if (spec != null) resultOutputSpecifications.Add(spec);
+                    if (spec != null)
+                        resultOutputSpecifications.Add(spec);
                 });
 
             this.Add("explore:", "Display or save test info rather than running tests. Optionally provide an output {SPEC} for saving the test info. This option may be repeated.", v =>
             {
                 Explore = true;
                 var spec = parser.ResolveOutputSpecification(v, ExploreOutputSpecifications, _fileSystem, CURRENT_DIRECTORY_ON_ENTRY);
-                if (spec != null) ExploreOutputSpecifications.Add(spec);
+                if (spec != null)
+                    ExploreOutputSpecifications.Add(spec);
             });
 
             this.Add("noresult", "Don't save any test results.",
                 v => NoResultSpecified = !string.IsNullOrEmpty(v));
 
             this.Add("labels=", "Specify whether to write test case names to the output. Values: Off (Default), On, OnOutput, Before, After, BeforeAndAfter. On is currently an alias for OnOutput, but is subject to change.",
-                v => {
-                        DisplayTestLabels = parser.RequiredValue(v, "--labels", "Off", "On", "OnOutput", "Before", "After", "BeforeAndAfter");
-                });
+                v => DisplayTestLabels = parser.RequiredValue(v, "--labels", "Off", "On", "OnOutput", "Before", "After", "BeforeAndAfter"));
 
             this.Add("extensionDirectory=", "Specifies an additional directory to be examined for extensions. May be repeated.", v =>
             {
@@ -391,7 +423,8 @@ namespace NUnit.ConsoleRunner
 
         public IEnumerable<string> PreParse(IEnumerable<string> args)
         {
-            if (args == null) throw new ArgumentNullException("args");
+            if (args == null)
+                throw new ArgumentNullException("args");
 
             if (++_nesting > 3)
             {
@@ -467,10 +500,10 @@ namespace NUnit.ConsoleRunner
 
         private string? ExpandToFullPath(string path)
         {
-            if (path == null) return null;
+            if (path == null)
+                return null;
 
             return Path.GetFullPath(path);
         }
-
     }
 }

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -21,7 +21,7 @@ namespace NUnit.ConsoleRunner
     /// </summary>
     public class ConsoleRunner
     {
-        static Logger log = InternalTrace.GetLogger(typeof(ConsoleRunner));
+        private static Logger log = InternalTrace.GetLogger(typeof(ConsoleRunner));
 
         // Some operating systems truncate the return code to 8 bits, which
         // only allows us a maximum of 127 in the positive range. We limit
@@ -113,7 +113,8 @@ namespace NUnit.ConsoleRunner
         private bool IsExtensionInstalled(string typeName)
         {
             foreach (var node in _extensionService.Extensions)
-                if (node.TypeName == typeName) return true;
+                if (node.TypeName == typeName)
+                    return true;
 
             return false;
         }
@@ -193,15 +194,14 @@ namespace NUnit.ConsoleRunner
 
         private int RunTests(TestPackage package, TestFilter filter)
         {
-
             var writer = new ColorConsoleWriter(!_options.NoColor);
 
             foreach (var spec in _options.ResultOutputSpecifications)
             {
                 var outputPath = Path.Combine(_workDirectory, spec.OutputPath);
-                
+
                 IResultWriter resultWriter;
-                
+
                 try
                 {
                     resultWriter = GetResultWriter(spec);
@@ -237,7 +237,6 @@ namespace NUnit.ConsoleRunner
                             "The path specified in --result {0} could not be written to",
                             spec.OutputPath), ex);
                 }
-
             }
 
             var labels = _options.DisplayTestLabels != null
@@ -325,7 +324,6 @@ namespace NUnit.ConsoleRunner
             OutWriter.WriteLabelLine(INDENT4 + "Runtime: ", RuntimeInformation.FrameworkDescription);
 #endif
 
-
             OutWriter.WriteLine();
         }
 
@@ -354,7 +352,7 @@ namespace NUnit.ConsoleRunner
         }
 
         [DllImport("libc")]
-        static extern int uname(IntPtr buf);
+        private static extern int uname(IntPtr buf);
 
         private void DisplayExtensionList()
         {
@@ -375,7 +373,7 @@ namespace NUnit.ConsoleRunner
                 {
                     _outWriter.Write(INDENT6 + "Extension: ");
                     _outWriter.Write(ColorStyle.Value, $"{node.TypeName}");
-                    _outWriter.WriteLine(node.Enabled ? "" : " (Disabled)");
+                    _outWriter.WriteLine(node.Enabled ? string.Empty : " (Disabled)");
 
                     _outWriter.Write(INDENT8 + "Version: ");
                     _outWriter.WriteLine(ColorStyle.Value, node.AssemblyVersion.ToString());
@@ -444,7 +442,7 @@ namespace NUnit.ConsoleRunner
 
             // Console runner always sets DisposeRunners
             //if (options.DisposeRunners)
-                package.AddSetting(EnginePackageSettings.DisposeRunners, true);
+            package.AddSetting(EnginePackageSettings.DisposeRunners, true);
 
             if (options.ShadowCopyFiles)
                 package.AddSetting(EnginePackageSettings.ShadowCopyFiles, true);
@@ -574,4 +572,3 @@ namespace NUnit.ConsoleRunner
         }
     }
 }
-

--- a/src/NUnitConsole/nunit4-console/FileSystem.cs
+++ b/src/NUnitConsole/nunit4-console/FileSystem.cs
@@ -10,14 +10,16 @@ namespace NUnit.ConsoleRunner
     {
         public bool FileExists(string fileName)
         {
-            if (fileName == null) throw new ArgumentNullException("fileName");
+            if (fileName == null)
+                throw new ArgumentNullException("fileName");
 
             return File.Exists(fileName);
         }
 
         public IEnumerable<string> ReadLines(string fileName)
         {
-            if (fileName == null) throw new ArgumentNullException("fileName");
+            if (fileName == null)
+                throw new ArgumentNullException("fileName");
 
             using (var file = File.OpenText(fileName))
             {

--- a/src/NUnitConsole/nunit4-console/FrameworkPackageSettings.cs
+++ b/src/NUnitConsole/nunit4-console/FrameworkPackageSettings.cs
@@ -46,7 +46,7 @@ namespace NUnit.ConsoleRunner
         public const string InternalTraceWriter = "InternalTraceWriter";
 
         /// <summary>
-        /// A list of tests to be loaded. 
+        /// A list of tests to be loaded.
         /// </summary>
         // TODO: Remove?
         public const string LOAD = "LOAD";

--- a/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
@@ -32,7 +32,6 @@ namespace NUnit.ConsoleRunner.Options
                 foreach (string valid in validValues)
                     if (string.Compare(valid, val, StringComparison.OrdinalIgnoreCase) == 0)
                         return valid;
-
             }
 
             if (!isValid)

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -18,10 +18,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -42,16 +42,16 @@
 // A Getopt::Long-inspired option parsing library for C#.
 //
 // Mono.Options.OptionSet is built upon a key/value table, where the
-// key is a option format string and the value is a delegate that is 
+// key is a option format string and the value is a delegate that is
 // invoked when the format string is matched.
 //
 // Option format strings:
-//  Regex-like BNF Grammar: 
+//  Regex-like BNF Grammar:
 //    name: .+
 //    type: [=:]
 //    sep: ( [^{}]+ | '{' .+ '}' )?
 //    aliases: ( name type sep ) ( '|' name type sep )*
-// 
+//
 // Each '|'-delimited name is an alias for the associated action.  If the
 // format string ends in a '=', it has a required value.  If the format
 // string ends in a ':', it has an optional value.  If neither '=' or ':'
@@ -97,7 +97,7 @@
 //  p.Parse (new string[]{"-v", "--v", "/v", "-name=A", "/name", "B", "extra"});
 //
 // The above would parse the argument string array, and would invoke the
-// lambda expression three times, setting `verbose' to 3 when complete.  
+// lambda expression three times, setting `verbose' to 3 when complete.
 // It would also print out "A" and "B" to standard output.
 // The returned array would contain the string "extra".
 //
@@ -172,11 +172,9 @@ using System.Security.Permissions;
 using System.Text;
 using System.Text.RegularExpressions;
 
-
 #if LINQ
 using System.Linq;
 #endif
-
 
 #if PCL
 using MessageLocalizerConverter = System.Func<string, string>;
@@ -186,9 +184,8 @@ using MessageLocalizerConverter = System.Converter<string, string>;
 
 namespace NUnit.ConsoleRunner.Options
 {
-    static class StringCoda
+    internal static class StringCoda
     {
-
         public static IEnumerable<string> WrappedLines(string self, params int[] widths)
         {
             IEnumerable<int> w = widths;
@@ -221,7 +218,7 @@ namespace NUnit.ConsoleRunner.Options
                     if (char.IsWhiteSpace(c))
                         --end;
                     bool needContinuation = end != self.Length && !IsEolChar(c);
-                    string continuation = "";
+                    string continuation = string.Empty;
                     if (needContinuation)
                     {
                         --end;
@@ -233,7 +230,8 @@ namespace NUnit.ConsoleRunner.Options
                     if (char.IsWhiteSpace(c))
                         ++start;
                     width = GetNextWidth(ewidths, width, ref hw);
-                } while (start < self.Length);
+                }
+                while (start < self.Length);
             }
         }
 
@@ -277,8 +275,8 @@ namespace NUnit.ConsoleRunner.Options
 
     public class OptionValueCollection : IList, IList<string>
     {
-        readonly List<string> values = new List<string>();
-        readonly OptionContext c;
+        private readonly List<string> values = new List<string>();
+        private readonly OptionContext c;
 
         internal OptionValueCollection(OptionContext c)
         {
@@ -286,44 +284,113 @@ namespace NUnit.ConsoleRunner.Options
         }
 
         #region ICollection
-        void ICollection.CopyTo(Array array, int index) { (values as ICollection).CopyTo(array, index); }
-        bool ICollection.IsSynchronized { get { return (values as ICollection).IsSynchronized; } }
-        object ICollection.SyncRoot { get { return (values as ICollection).SyncRoot; } }
+        void ICollection.CopyTo(Array array, int index)
+        {
+            (values as ICollection).CopyTo(array, index);
+        }
+        bool ICollection.IsSynchronized
+        {
+            get { return (values as ICollection).IsSynchronized; }
+        }
+        object ICollection.SyncRoot
+        {
+            get { return (values as ICollection).SyncRoot; }
+        }
         #endregion
 
         #region ICollection<T>
-        public void Add(string item) { values.Add(item); }
-        public void Clear() { values.Clear(); }
-        public bool Contains(string item) { return values.Contains(item); }
-        public void CopyTo(string[] array, int arrayIndex) { values.CopyTo(array, arrayIndex); }
-        public bool Remove(string item) { return values.Remove(item); }
-        public int Count { get { return values.Count; } }
-        public bool IsReadOnly { get { return false; } }
+        public void Add(string item)
+        {
+            values.Add(item);
+        }
+        public void Clear()
+        {
+            values.Clear();
+        }
+        public bool Contains(string item)
+        {
+            return values.Contains(item);
+        }
+        public void CopyTo(string[] array, int arrayIndex)
+        {
+            values.CopyTo(array, arrayIndex);
+        }
+        public bool Remove(string item)
+        {
+            return values.Remove(item);
+        }
+        public int Count
+        {
+            get { return values.Count; }
+        }
+        public bool IsReadOnly
+        {
+            get { return false; }
+        }
         #endregion
 
         #region IEnumerable
-        IEnumerator IEnumerable.GetEnumerator() { return values.GetEnumerator(); }
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return values.GetEnumerator();
+        }
         #endregion
 
         #region IEnumerable<T>
-        public IEnumerator<string> GetEnumerator() { return values.GetEnumerator(); }
+        public IEnumerator<string> GetEnumerator()
+        {
+            return values.GetEnumerator();
+        }
         #endregion
 
         #region IList
-        int IList.Add(object? value) { return (values as IList).Add(value); }
-        bool IList.Contains(object? value) { return (values as IList).Contains(value); }
-        int IList.IndexOf(object? value) { return (values as IList).IndexOf(value); }
-        void IList.Insert(int index, object? value) { (values as IList).Insert(index, value); }
-        void IList.Remove(object? value) { (values as IList).Remove(value); }
-        void IList.RemoveAt(int index) { (values as IList).RemoveAt(index); }
-        bool IList.IsFixedSize { get { return false; } }
-        object? IList.this[int index] { get { return this[index]; } set { (values as IList)[index] = value; } }
+        int IList.Add(object? value)
+        {
+            return (values as IList).Add(value);
+        }
+        bool IList.Contains(object? value)
+        {
+            return (values as IList).Contains(value);
+        }
+        int IList.IndexOf(object? value)
+        {
+            return (values as IList).IndexOf(value);
+        }
+        void IList.Insert(int index, object? value)
+        {
+            (values as IList).Insert(index, value);
+        }
+        void IList.Remove(object? value)
+        {
+            (values as IList).Remove(value);
+        }
+        void IList.RemoveAt(int index)
+        {
+            (values as IList).RemoveAt(index);
+        }
+        bool IList.IsFixedSize
+        {
+            get { return false; }
+        }
+        object? IList.this[int index]
+        {
+            get { return this[index]; } set { (values as IList)[index] = value; }
+        }
         #endregion
 
         #region IList<T>
-        public int IndexOf(string item) { return values.IndexOf(item); }
-        public void Insert(int index, string item) { values.Insert(index, item); }
-        public void RemoveAt(int index) { values.RemoveAt(index); }
+        public int IndexOf(string item)
+        {
+            return values.IndexOf(item);
+        }
+        public void Insert(int index, string item)
+        {
+            values.Insert(index, item);
+        }
+        public void RemoveAt(int index)
+        {
+            values.RemoveAt(index);
+        }
 
         private void AssertValid(int index)
         {
@@ -421,13 +488,13 @@ namespace NUnit.ConsoleRunner.Options
 
     public abstract class Option
     {
-        readonly string prototype;
-        readonly string? description;
-        readonly string[] names;
-        readonly OptionValueType type;
-        readonly int count;
-        string[]? separators;
-        readonly bool hidden;
+        private readonly string prototype;
+        private readonly string? description;
+        private readonly string[] names;
+        private readonly OptionValueType type;
+        private readonly int count;
+        private string[]? separators;
+        private readonly bool hidden;
 
         protected Option(string prototype, string? description)
             : this(prototype, description, 1, false)
@@ -480,11 +547,26 @@ namespace NUnit.ConsoleRunner.Options
                         "prototype");
         }
 
-        public string Prototype { get { return prototype; } }
-        public string? Description { get { return description; } }
-        public OptionValueType OptionValueType { get { return type; } }
-        public int MaxValueCount { get { return count; } }
-        public bool Hidden { get { return hidden; } }
+        public string Prototype
+        {
+            get { return prototype; }
+        }
+        public string? Description
+        {
+            get { return description; }
+        }
+        public OptionValueType OptionValueType
+        {
+            get { return type; }
+        }
+        public int MaxValueCount
+        {
+            get { return count; }
+        }
+        public bool Hidden
+        {
+            get { return hidden; }
+        }
 
         public string[] GetNames()
         {
@@ -544,10 +626,16 @@ namespace NUnit.ConsoleRunner.Options
             return t;
         }
 
-        internal string[] Names { get { return names; } }
-        internal string[]? ValueSeparators { get { return separators; } }
+        internal string[] Names
+        {
+            get { return names; }
+        }
+        internal string[]? ValueSeparators
+        {
+            get { return separators; }
+        }
 
-        static readonly char[] NameTerminator = new char[] { '=', ':' };
+        private static readonly char[] NameTerminator = new char[] { '=', ':' };
 
         private OptionValueType ParsePrototype()
         {
@@ -649,7 +737,6 @@ namespace NUnit.ConsoleRunner.Options
 
     public abstract class ArgumentSource
     {
-
         protected ArgumentSource()
         {
         }
@@ -671,7 +758,7 @@ namespace NUnit.ConsoleRunner.Options
         }
 
         // Cribbed from mcs/driver.cs:LoadArgs(string)
-        static IEnumerable<string> GetArguments(TextReader reader, bool close)
+        private static IEnumerable<string> GetArguments(TextReader reader, bool close)
         {
             try
             {
@@ -728,7 +815,6 @@ namespace NUnit.ConsoleRunner.Options
 #if !PCL || NETSTANDARD1_3
     public class ResponseFileSource : ArgumentSource
     {
-
         public override string[] GetNames()
         {
             return new string[] { "@file" };
@@ -817,12 +903,13 @@ namespace NUnit.ConsoleRunner.Options
         {
             this.roSources = new ReadOnlyCollection<ArgumentSource>(sources);
             this.localizer = localizer ??
-                delegate (string f) {
+                delegate(string f)
+                {
                     return f;
                 };
         }
 
-        MessageLocalizerConverter localizer;
+        private MessageLocalizerConverter localizer;
 
         private new IDictionary<string, Option> Dictionary => base.Dictionary!;
 
@@ -832,14 +919,13 @@ namespace NUnit.ConsoleRunner.Options
             internal set { localizer = value; }
         }
 
-        readonly List<ArgumentSource> sources = new List<ArgumentSource>();
-        readonly ReadOnlyCollection<ArgumentSource> roSources;
+        private readonly List<ArgumentSource> sources = new List<ArgumentSource>();
+        private readonly ReadOnlyCollection<ArgumentSource> roSources;
 
         public ReadOnlyCollection<ArgumentSource> ArgumentSources
         {
             get { return roSources; }
         }
-
 
         protected override string GetKeyForItem(Option item)
         {
@@ -922,7 +1008,6 @@ namespace NUnit.ConsoleRunner.Options
 
         internal sealed class Category : Option
         {
-
             // Prototype starts with '=' because this is an invalid prototype
             // (see Option.ParsePrototype(), and thus it'll prevent Category
             // instances from being accidentally used as normal options.
@@ -937,16 +1022,15 @@ namespace NUnit.ConsoleRunner.Options
             }
         }
 
-
         public new OptionSet Add(Option option)
         {
             base.Add(option);
             return this;
         }
 
-        sealed class ActionOption : Option
+        private sealed class ActionOption : Option
         {
-            readonly Action<OptionValueCollection> action;
+            private readonly Action<OptionValueCollection> action;
 
             public ActionOption(string prototype, string? description, int count, Action<OptionValueCollection> action)
                 : this(prototype, description, count, action, false)
@@ -982,7 +1066,7 @@ namespace NUnit.ConsoleRunner.Options
             if (action == null)
                 throw new ArgumentNullException("action");
             Option p = new ActionOption(prototype, description, 1,
-                    delegate (OptionValueCollection v) { action(v[0]); }, hidden);
+                    delegate(OptionValueCollection v) { action(v[0]); }, hidden);
             base.Add(p);
             return this;
         }
@@ -1002,14 +1086,14 @@ namespace NUnit.ConsoleRunner.Options
             if (action == null)
                 throw new ArgumentNullException("action");
             Option p = new ActionOption(prototype, description, 2,
-                    delegate (OptionValueCollection v) { action(v[0], v[1]); }, hidden);
+                    delegate(OptionValueCollection v) { action(v[0], v[1]); }, hidden);
             base.Add(p);
             return this;
         }
 
-        sealed class ActionOption<T> : Option
+        private sealed class ActionOption<T> : Option
         {
-            readonly Action<T> action;
+            private readonly Action<T> action;
 
             public ActionOption(string prototype, string? description, Action<T> action)
                 : base(prototype, description, 1)
@@ -1025,9 +1109,9 @@ namespace NUnit.ConsoleRunner.Options
             }
         }
 
-        sealed class ActionOption<TKey, TValue> : Option
+        private sealed class ActionOption<TKey, TValue> : Option
         {
-            readonly OptionAction<TKey, TValue> action;
+            private readonly OptionAction<TKey, TValue> action;
 
             public ActionOption(string prototype, string? description, OptionAction<TKey, TValue> action)
                 : base(prototype, description, 2)
@@ -1111,9 +1195,9 @@ namespace NUnit.ConsoleRunner.Options
             return unprocessed;
         }
 
-        class ArgumentEnumerator : IEnumerable<string>
+        private class ArgumentEnumerator : IEnumerable<string>
         {
-            readonly List<IEnumerator<string>> sources = new List<IEnumerator<string>>();
+            private readonly List<IEnumerator<string>> sources = new List<IEnumerator<string>>();
 
             public ArgumentEnumerator(IEnumerable<string> arguments)
             {
@@ -1137,7 +1221,8 @@ namespace NUnit.ConsoleRunner.Options
                         c.Dispose();
                         sources.RemoveAt(sources.Count - 1);
                     }
-                } while (sources.Count > 0);
+                }
+                while (sources.Count > 0);
             }
 
             IEnumerator IEnumerable.GetEnumerator()
@@ -1146,7 +1231,7 @@ namespace NUnit.ConsoleRunner.Options
             }
         }
 
-        bool AddSource(ArgumentEnumerator ae, string argument)
+        private bool AddSource(ArgumentEnumerator ae, string argument)
         {
             foreach (ArgumentSource source in sources)
             {
@@ -1328,8 +1413,8 @@ namespace NUnit.ConsoleRunner.Options
         private const int Description_FirstWidth = 80 - OptionWidth;
         private const int Description_RemWidth = 80 - OptionWidth - 2;
 
-        static readonly string CommandHelpIndentStart = new string(' ', OptionWidth);
-        static readonly string CommandHelpIndentRemaining = new string(' ', OptionWidth + 2);
+        private static readonly string CommandHelpIndentStart = new string(' ', OptionWidth);
+        private static readonly string CommandHelpIndentRemaining = new string(' ', OptionWidth + 2);
 
         public void WriteOptionDescriptions(TextWriter o)
         {
@@ -1343,7 +1428,7 @@ namespace NUnit.ConsoleRunner.Options
                 Category? c = p as Category;
                 if (c != null)
                 {
-                    WriteDescription(o, p.Description, "", 80, 80);
+                    WriteDescription(o, p.Description, string.Empty, 80, 80);
                     continue;
                 }
                 CommandOption? co = p as CommandOption;
@@ -1406,12 +1491,12 @@ namespace NUnit.ConsoleRunner.Options
             }
             else
             {
-                WriteDescription(o, name, "", 80, 80);
+                WriteDescription(o, name, string.Empty, 80, 80);
                 WriteDescription(o, CommandHelpIndentStart + c.Help, CommandHelpIndentRemaining, 80, Description_RemWidth);
             }
         }
 
-        void WriteDescription(TextWriter o, string? value, string prefix, int firstWidth, int remWidth)
+        private void WriteDescription(TextWriter o, string? value, string prefix, int firstWidth, int remWidth)
         {
             bool indent = false;
             foreach (string line in GetLines(localizer(GetDescription(value)), firstWidth, remWidth))
@@ -1423,7 +1508,7 @@ namespace NUnit.ConsoleRunner.Options
             }
         }
 
-        bool WriteOptionPrototype(TextWriter o, Option p, ref int written)
+        private bool WriteOptionPrototype(TextWriter o, Option p, ref int written)
         {
             string[] names = p.Names;
 
@@ -1473,7 +1558,7 @@ namespace NUnit.ConsoleRunner.Options
             return true;
         }
 
-        static int GetNextOptionIndex(string[] names, int i)
+        private static int GetNextOptionIndex(string[] names, int i)
         {
             while (i < names.Length && names[i] == "<>")
             {
@@ -1482,16 +1567,16 @@ namespace NUnit.ConsoleRunner.Options
             return i;
         }
 
-        static void Write(TextWriter o, ref int n, string s)
+        private static void Write(TextWriter o, ref int n, string s)
         {
             n += s.Length;
             o.Write(s);
         }
 
-        static string GetArgumentName(int index, int maxIndex, string? description)
+        private static string GetArgumentName(int index, int maxIndex, string? description)
         {
-            var matches = Regex.Matches(description ?? "", @"(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))"); // ignore double braces 
-            string argName = "";
+            var matches = Regex.Matches(description ?? string.Empty, @"(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))"); // ignore double braces
+            string argName = string.Empty;
             foreach (Match match in matches)
             {
                 var parts = match.Value.Split(':');
@@ -1589,7 +1674,7 @@ namespace NUnit.ConsoleRunner.Options
             Help = help;
         }
 
-        static string NormalizeCommandName(string name)
+        private static string NormalizeCommandName(string name)
         {
             var value = new StringBuilder(name.Length);
             var space = false;
@@ -1617,7 +1702,7 @@ namespace NUnit.ConsoleRunner.Options
         }
     }
 
-    class CommandOption : Option
+    internal class CommandOption : Option
     {
         public Command Command { get; }
         public string CommandName { get; }
@@ -1640,10 +1725,10 @@ namespace NUnit.ConsoleRunner.Options
         }
     }
 
-    class HelpOption : Option
+    internal class HelpOption : Option
     {
-        readonly Option option;
-        readonly CommandSet commands;
+        private readonly Option option;
+        private readonly CommandSet commands;
 
         public HelpOption(CommandSet commands, Option d)
             : base(d.Prototype, d.Description, d.MaxValueCount, d.Hidden)
@@ -1660,9 +1745,9 @@ namespace NUnit.ConsoleRunner.Options
         }
     }
 
-    class CommandOptionSet : OptionSet
+    internal class CommandOptionSet : OptionSet
     {
-        readonly CommandSet commands;
+        private readonly CommandSet commands;
 
         public CommandOptionSet(CommandSet commands, MessageLocalizerConverter? localizer)
             : base(localizer)
@@ -1680,7 +1765,7 @@ namespace NUnit.ConsoleRunner.Options
             base.SetItem(index, item);
         }
 
-        bool ShouldWrapOption(Option item)
+        private bool ShouldWrapOption(Option item)
         {
             if (item == null)
                 return false;
@@ -1708,11 +1793,11 @@ namespace NUnit.ConsoleRunner.Options
 
     public class CommandSet : KeyedCollection<string, Command>
     {
-        readonly string suite;
+        private readonly string suite;
 
-        OptionSet options;
-        TextWriter outWriter;
-        TextWriter errorWriter;
+        private OptionSet options;
+        private TextWriter outWriter;
+        private TextWriter errorWriter;
 
         internal List<CommandSet>? NestedCommandSets;
 
@@ -1763,7 +1848,7 @@ namespace NUnit.ConsoleRunner.Options
             return this;
         }
 
-        void AddCommand(Command value)
+        private void AddCommand(Command value)
         {
             if (value.CommandSet != null && value.CommandSet != this)
             {
@@ -1891,7 +1976,7 @@ namespace NUnit.ConsoleRunner.Options
             return this;
         }
 
-        bool AlreadyAdded(CommandSet value)
+        private bool AlreadyAdded(CommandSet value)
         {
             if (value == this)
                 return true;
@@ -1933,10 +2018,10 @@ namespace NUnit.ConsoleRunner.Options
             }
         }
 
-        static void ExtractToken([NotNull] ref string? input, out string rest)
+        private static void ExtractToken([NotNull] ref string? input, out string rest)
         {
-            rest = "";
-            input = input ?? "";
+            rest = string.Empty;
+            input = input ?? string.Empty;
 
             int top = input.Length;
             for (int i = 0; i < top; i++)
@@ -1953,7 +2038,7 @@ namespace NUnit.ConsoleRunner.Options
                         return;
                     }
                 }
-                rest = "";
+                rest = string.Empty;
                 if (i != 0)
                     input = input.Substring(i).Trim();
                 return;
@@ -1974,11 +2059,11 @@ namespace NUnit.ConsoleRunner.Options
             Action<string> setHelp = v => showHelp = v != null;
             if (!options.Contains("help"))
             {
-                options.Add("help", "", setHelp, hidden: true);
+                options.Add("help", string.Empty, setHelp, hidden: true);
             }
             if (!options.Contains("?"))
             {
-                options.Add("?", "", setHelp, hidden: true);
+                options.Add("?", string.Empty, setHelp, hidden: true);
             }
             var extra = options.Parse(arguments);
             if (extra.Count == 0)
@@ -2014,7 +2099,7 @@ namespace NUnit.ConsoleRunner.Options
             return TryGetLocalCommand(extra) ?? TryGetNestedCommand(extra);
         }
 
-        Command? TryGetLocalCommand(List<string> extra)
+        private Command? TryGetLocalCommand(List<string> extra)
         {
             var name = extra[0];
             if (Contains(name))
@@ -2033,7 +2118,7 @@ namespace NUnit.ConsoleRunner.Options
             return null;
         }
 
-        Command? TryGetNestedCommand(List<string> extra)
+        private Command? TryGetNestedCommand(List<string> extra)
         {
             if (NestedCommandSets == null)
                 return null;
@@ -2109,7 +2194,7 @@ namespace NUnit.ConsoleRunner.Options
             return command.Invoke(new[] { "--help" });
         }
 
-        List<KeyValuePair<string, Command>> GetCommands()
+        private List<KeyValuePair<string, Command>> GetCommands()
         {
             var commands = new List<KeyValuePair<string, Command>>();
 
@@ -2125,13 +2210,13 @@ namespace NUnit.ConsoleRunner.Options
 
             foreach (var nc in commandSet.NestedCommandSets)
             {
-                AddNestedCommands(commands, "", nc);
+                AddNestedCommands(commands, string.Empty, nc);
             }
 
             return commands;
         }
 
-        void AddNestedCommands(List<KeyValuePair<string, Command>> commands, string outer, CommandSet value)
+        private void AddNestedCommands(List<KeyValuePair<string, Command>> commands, string outer, CommandSet value)
         {
             foreach (var v in value)
             {
@@ -2154,4 +2239,3 @@ namespace NUnit.ConsoleRunner.Options
         }
     }
 }
-

--- a/src/NUnitConsole/nunit4-console/Options/OutputSpecification.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OutputSpecification.cs
@@ -56,7 +56,7 @@ namespace NUnit.ConsoleRunner.Options
                                 string.Format("Conflicting format options: {0}", spec));
 
                         this.Format = "user";
-                        this.Transform = Path.Combine(transformFolder ?? "", val);
+                        this.Transform = Path.Combine(transformFolder ?? string.Empty, val);
                         break;
                 }
             }
@@ -83,8 +83,10 @@ namespace NUnit.ConsoleRunner.Options
         public override string ToString()
         {
             var sb = new StringBuilder($"OutputPath: {OutputPath}");
-            if (Format != null) sb.Append($", Format: {Format}");
-            if (Transform != null) sb.Append($", Transform: {Transform}");
+            if (Format != null)
+                sb.Append($", Format: {Format}");
+            if (Transform != null)
+                sb.Append($", Transform: {Transform}");
             return sb.ToString();
         }
     }

--- a/src/NUnitConsole/nunit4-console/Options/TestNameParser.cs
+++ b/src/NUnitConsole/nunit4-console/Options/TestNameParser.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace NUnit.ConsoleRunner.Options
 {
     /// <summary>
-    /// TestNameParser is used to parse the arguments to the 
+    /// TestNameParser is used to parse the arguments to the
     /// -run option, separating testnames at the correct point.
     /// </summary>
     public class TestNameParser

--- a/src/NUnitConsole/nunit4-console/Program.cs
+++ b/src/NUnitConsole/nunit4-console/Program.cs
@@ -20,7 +20,7 @@ namespace NUnit.ConsoleRunner
     public class Program
     {
         //static Logger log = InternalTrace.GetLogger(typeof(Runner));
-        static readonly ConsoleOptions Options = new ConsoleOptions(new FileSystem());
+        private static readonly ConsoleOptions Options = new ConsoleOptions(new FileSystem());
         private static ExtendedTextWriter? _outWriter;
 
         // This has to be lazy otherwise NoColor command line option is not applied correctly
@@ -28,7 +28,8 @@ namespace NUnit.ConsoleRunner
         {
             get
             {
-                if (_outWriter == null) _outWriter = new ColorConsoleWriter(!Options.NoColor);
+                if (_outWriter == null)
+                    _outWriter = new ColorConsoleWriter(!Options.NoColor);
 
                 return _outWriter;
             }
@@ -182,7 +183,8 @@ namespace NUnit.ConsoleRunner
             if (configurationAttributes.Length > 0)
             {
                 string configuration = ((AssemblyConfigurationAttribute)configurationAttributes[0]).Configuration;
-                if (!string.IsNullOrEmpty(configuration)) header += $" ({configuration})";
+                if (!string.IsNullOrEmpty(configuration))
+                    header += $" ({configuration})";
             }
 
             OutWriter.WriteLine(ColorStyle.Header, header);

--- a/src/NUnitConsole/nunit4-console/ResultReporter.cs
+++ b/src/NUnitConsole/nunit4-console/ResultReporter.cs
@@ -100,12 +100,12 @@ namespace NUnit.ConsoleRunner
 
             ColorStyle overall = OverallResult == "Passed"
                 ? ColorStyle.Pass
-                : OverallResult == "Failed"  || OverallResult == "Unknown"
+                : OverallResult == "Failed" || OverallResult == "Unknown"
                     ? ColorStyle.Failure
                     : OverallResult == "Warning"
                         ? ColorStyle.Warning
                         : ColorStyle.Output;
-            
+
             Writer.WriteLine(ColorStyle.SectionHeader, "Test Run Summary");
             Writer.WriteLabelLine(INDENT4 + "Overall result: ", OverallResult, overall);
 
@@ -188,7 +188,7 @@ namespace NUnit.ConsoleRunner
                             // Where did this happen? Default is in the current test.
                             var site = resultNode.GetAttribute("site");
 
-                            // Correct a problem in some framework versions, whereby warnings and some failures 
+                            // Correct a problem in some framework versions, whereby warnings and some failures
                             // are promulgated to the containing suite without setting the FailureSite.
                             if (site == null)
                             {
@@ -206,10 +206,11 @@ namespace NUnit.ConsoleRunner
                                 new ConsoleTestResult(resultNode, ++ReportIndex).WriteResult(Writer);
 
                             // Do not list individual "failed" tests after a one-time setup failure
-                            if (site == "SetUp") return;
+                            if (site == "SetUp")
+                                return;
                         }
                     }
-                    
+
                     foreach (XmlNode childResult in resultNode.ChildNodes)
                         WriteErrorsFailuresAndWarnings(childResult);
 

--- a/src/NUnitConsole/nunit4-console/ResultSummary.cs
+++ b/src/NUnitConsole/nunit4-console/ResultSummary.cs
@@ -32,7 +32,7 @@ namespace NUnit.ConsoleRunner
         /// <summary>
         /// Returns the number of test cases actually run.
         /// </summary>
-        public int RunCount 
+        public int RunCount
         {
             get { return PassCount + FailureCount + ErrorCount + InconclusiveCount;  }
         }
@@ -194,8 +194,10 @@ namespace NUnit.ConsoleRunner
                 case "test-suite":
                     if (status == "Failed" && label == "Invalid")
                     {
-                        if (type == "Assembly") InvalidAssemblies++;
-                        else InvalidTestFixtures++;
+                        if (type == "Assembly")
+                            InvalidAssemblies++;
+                        else
+                            InvalidTestFixtures++;
                     }
                     if (type == "Assembly" && status == "Failed" && label == "Error")
                     {

--- a/src/NUnitConsole/nunit4-console/SafeAttributeAccess.cs
+++ b/src/NUnitConsole/nunit4-console/SafeAttributeAccess.cs
@@ -7,7 +7,9 @@ using System.Xml;
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Method)]
-    sealed class ExtensionAttribute : Attribute { }
+    internal sealed class ExtensionAttribute : Attribute
+    {
+    }
 }
 
 namespace NUnit.ConsoleRunner

--- a/src/NUnitConsole/nunit4-netcore-console/Program.cs
+++ b/src/NUnitConsole/nunit4-netcore-console/Program.cs
@@ -19,7 +19,7 @@ namespace NUnit.ConsoleRunner
     public class Program
     {
         //static Logger log = InternalTrace.GetLogger(typeof(Runner));
-        static readonly ConsoleOptions Options = new ConsoleOptions(new FileSystem());
+        private static readonly ConsoleOptions Options = new ConsoleOptions(new FileSystem());
         private static ExtendedTextWriter? _outWriter;
 
         // This has to be lazy otherwise NoColor command line option is not applied correctly
@@ -27,7 +27,8 @@ namespace NUnit.ConsoleRunner
         {
             get
             {
-                if (_outWriter == null) _outWriter = new ColorConsoleWriter(!Options.NoColor);
+                if (_outWriter == null)
+                    _outWriter = new ColorConsoleWriter(!Options.NoColor);
 
                 return _outWriter;
             }
@@ -160,7 +161,8 @@ namespace NUnit.ConsoleRunner
             if (configurationAttributes.Length > 0)
             {
                 string configuration = ((AssemblyConfigurationAttribute)configurationAttributes[0]).Configuration;
-                if (!string.IsNullOrEmpty(configuration)) header += $" ({configuration})";
+                if (!string.IsNullOrEmpty(configuration))
+                    header += $" ({configuration})";
             }
 
             OutWriter.WriteLine(ColorStyle.Header, header);

--- a/src/NUnitEngine/nunit.engine.api/AsyncTestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine.api/AsyncTestEngineResult.cs
@@ -37,7 +37,7 @@ namespace NUnit.Engine
         {
             get { return _waitHandle; }
         }
-        
+
         /// <summary>
         /// Used by tests
         /// </summary>
@@ -67,7 +67,10 @@ namespace NUnit.Engine
         /// <summary>
         /// True if the test run has completed
         /// </summary>
-        public bool IsComplete { get { return _result != null; } }
+        public bool IsComplete
+        {
+            get { return _result != null; }
+        }
 
         XmlNode ITestRun.Result
         {

--- a/src/NUnitEngine/nunit.engine.api/EnginePackageSettings.cs
+++ b/src/NUnitEngine/nunit.engine.api/EnginePackageSettings.cs
@@ -6,7 +6,7 @@ namespace NUnit
 {
     /// <summary>
     /// EngineSettings contains constant values that
-    /// are used as keys in setting up a TestPackage. 
+    /// are used as keys in setting up a TestPackage.
     /// Values here are used in the engine, and set by the runner.
     /// Setting values may be a string, int or bool.
     /// </summary>
@@ -31,7 +31,7 @@ namespace NUnit
         public const string AutoBinPath = "AutoBinPath";
 
         /// <summary>
-        /// The ApplicationBase to use in loading the tests. If not 
+        /// The ApplicationBase to use in loading the tests. If not
         /// specified, and each assembly has its own process, then the
         /// location of the assembly is used. For multiple  assemblies
         /// in a single process, the closest common root directory is used.
@@ -39,7 +39,7 @@ namespace NUnit
         public const string BasePath = "BasePath";
 
         /// <summary>
-        /// Path to the config file to use in running the tests. 
+        /// Path to the config file to use in running the tests.
         /// </summary>
         public const string ConfigurationFile = "ConfigurationFile";
 
@@ -49,7 +49,7 @@ namespace NUnit
         public const string DebugTests = "DebugTests";
 
         /// <summary>
-        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// Bool flag indicating whether a debugger should be launched at agent
         /// startup. Used only for debugging NUnit itself.
         /// </summary>
         public const string DebugAgent = "DebugAgent";
@@ -62,13 +62,13 @@ namespace NUnit
         public const string PrivateBinPath = "PrivateBinPath";
 
         /// <summary>
-        /// The maximum number of test agents permitted to run simultaneously. 
+        /// The maximum number of test agents permitted to run simultaneously.
         /// Ignored if the ProcessModel is not set or defaulted to Multiple.
         /// </summary>
         public const string MaxAgents = "MaxAgents";
 
         /// <summary>
-        /// Indicates the desired runtime to use for the tests. Values 
+        /// Indicates the desired runtime to use for the tests. Values
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
@@ -76,7 +76,7 @@ namespace NUnit
         public const string RuntimeFramework = "RequestedRuntimeFramework";
 
         /// <summary>
-        /// Indicates the desired runtime to use for the tests. Values 
+        /// Indicates the desired runtime to use for the tests. Values
         /// are strings like "net-4.5", "mono-4.0", etc. Default is to
         /// use the target framework for which an assembly was built.
         /// </summary>
@@ -89,7 +89,7 @@ namespace NUnit
         public const string TargetRuntimeFramework = "TargetRuntimeFramework";
 
         /// <summary>
-        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// Bool flag indicating that the test should be run in a 32-bit process
         /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
         /// a 64-bit system. Ignored if set on a 32-bit system.
         /// </summary>
@@ -101,7 +101,7 @@ namespace NUnit
         public const string DisposeRunners = "DisposeRunners";
 
         /// <summary>
-        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Bool flag indicating that the test assemblies should be shadow copied.
         /// Defaults to false.
         /// </summary>
         public const string ShadowCopyFiles = "ShadowCopyFiles";

--- a/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineException.cs
+++ b/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineException.cs
@@ -30,6 +30,8 @@ namespace NUnit.Engine
         /// <summary>
         /// Serialization constructor
         /// </summary>
-        public NUnitEngineException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        public NUnitEngineException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineUnloadException.cs
+++ b/src/NUnitEngine/nunit.engine.api/Exceptions/NUnitEngineUnloadException.cs
@@ -6,18 +6,16 @@ using System.Runtime.Serialization;
 
 namespace NUnit.Engine
 {
-
     /// <summary>
     /// NUnitEngineUnloadException is thrown when a test run has completed successfully
     /// but one or more errors were encountered when attempting to unload
     /// and shut down the test run cleanly.
     /// </summary>
     [Serializable]
-    public class NUnitEngineUnloadException : NUnitEngineException  //Inherits from NUnitEngineException for backwards compatibility of calling runners
+    public class NUnitEngineUnloadException : NUnitEngineException // Inherits from NUnitEngineException for backwards compatibility of calling runners
     {
         private const string AggregatedExceptionsMsg =
             "Multiple exceptions encountered. Retrieve AggregatedExceptions property for more information";
-
 
         /// <summary>
         /// Construct with a message
@@ -44,7 +42,9 @@ namespace NUnit.Engine
         /// <summary>
         /// Serialization constructor.
         /// </summary>
-        public NUnitEngineUnloadException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        public NUnitEngineUnloadException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
 
         /// <summary>
         /// Gets the collection of exceptions .

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IProject.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IProject.cs
@@ -28,7 +28,7 @@ namespace NUnit.Engine.Extensibility
 
         /// <summary>
         /// Gets a test package for the primary or active
-        /// configuration within the project. The package 
+        /// configuration within the project. The package
         /// includes all the assemblies and any settings
         /// specified in the project format.
         /// </summary>
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Extensibility
         /// <summary>
         /// Gets a TestPackage for a specific configuration
         /// within the project. The package includes all the
-        /// assemblies and any settings specified in the 
+        /// assemblies and any settings specified in the
         /// project format.
         /// </summary>
         /// <param name="configName">The name of the config to use</param>

--- a/src/NUnitEngine/nunit.engine.api/Extensibility/IProjectLoader.cs
+++ b/src/NUnitEngine/nunit.engine.api/Extensibility/IProjectLoader.cs
@@ -19,7 +19,7 @@ namespace NUnit.Engine.Extensibility
         /// </summary>
         /// <param name="path">The path of the project file</param>
         /// <returns>True if the loader knows how to load this file, otherwise false</returns>
-        bool CanLoadFrom( string path );
+        bool CanLoadFrom(string path);
 
         /// <summary>
         /// Loads a project of a known format.

--- a/src/NUnitEngine/nunit.engine.api/IExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IExtensionService.cs
@@ -42,7 +42,5 @@ namespace NUnit.Engine
         /// Enable or disable an extension
         /// </summary>
         void EnableExtension(string typeName, bool enabled);
-
     }
 }
-

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFramework.cs
@@ -27,7 +27,7 @@ namespace NUnit.Engine
 
         /// <summary>
         /// Gets a string representing the particular profile installed,
-        /// or null if there is no profile. Currently. the only defined 
+        /// or null if there is no profile. Currently. the only defined
         /// values are Full and Client.
         /// </summary>
         string? Profile { get; }

--- a/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine.api/IRuntimeFrameworkService.cs
@@ -29,7 +29,7 @@ namespace NUnit.Engine
         /// <summary>
         /// Selects a target runtime framework for a TestPackage based on
         /// the settings in the package and the assemblies themselves.
-        /// The package RuntimeFramework setting may be updated as a 
+        /// The package RuntimeFramework setting may be updated as a
         /// result and the selected runtime is returned.
         ///
         /// Note that if a package has subpackages, the subpackages may run on a different

--- a/src/NUnitEngine/nunit.engine.api/IServiceLocator.cs
+++ b/src/NUnitEngine/nunit.engine.api/IServiceLocator.cs
@@ -7,7 +7,7 @@ namespace NUnit.Engine
     /// <summary>
     /// IServiceLocator allows clients to locate any NUnit services
     /// for which the interface is referenced. In normal use, this
-    /// linits it to those services using interfaces defined in the 
+    /// linits it to those services using interfaces defined in the
     /// nunit.engine.api assembly.
     /// </summary>
     public interface IServiceLocator
@@ -15,7 +15,8 @@ namespace NUnit.Engine
         /// <summary>
         /// Return a specified type of service
         /// </summary>
-        T GetService<T>() where T : class;
+        T GetService<T>()
+            where T : class;
 
         /// <summary>
         /// Return a specified type of service

--- a/src/NUnitEngine/nunit.engine.api/ITestAgency.cs
+++ b/src/NUnitEngine/nunit.engine.api/ITestAgency.cs
@@ -5,7 +5,7 @@ using System;
 namespace NUnit.Engine
 {
     /// <summary>
-    /// The ITestAgency interface is implemented by a TestAgency in 
+    /// The ITestAgency interface is implemented by a TestAgency in
     /// order to allow TestAgents to register with it.
     /// </summary>
     public interface ITestAgency

--- a/src/NUnitEngine/nunit.engine.api/TestEngineResult.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestEngineResult.cs
@@ -12,18 +12,18 @@ namespace NUnit.Engine
     /// by the test engine for most operations. The XML is
     /// stored as a string in order to allow serialization
     /// and actual XmlNodes are created on demand.
-    /// 
+    ///
     /// In principal, there should only be one XmlNode in
     /// a result. However, as work progresses, there may
     /// temporarily be multiple nodes, which have not yet
     /// been aggregated under a higher level suite. For
     /// that reason, TestEngineResult maintains a list
     /// of XmlNodes and another of the corresponding text.
-    /// 
+    ///
     /// Static methods are provided for aggregating the
     /// internal XmlNodes into a single node as well as
     /// for combining multiple TestEngineResults into one.
-    /// 
+    ///
     /// </summary>
     [Serializable]
     public class TestEngineResult
@@ -63,7 +63,7 @@ namespace NUnit.Engine
         /// Gets a flag indicating whether this is a single result
         /// having only one XmlNode associated with it.
         /// </summary>
-        public bool IsSingle 
+        public bool IsSingle
         {
             get { return _xmlText.Count == 1; }
         }
@@ -100,13 +100,13 @@ namespace NUnit.Engine
         /// </exception>
         public XmlNode Xml
         {
-            get 
+            get
             {
                 // TODO: Fix this in some way and also allow for a count of zero
                 if (!IsSingle)
                     throw new InvalidOperationException("May not use 'Xml' property on a result with multiple XmlNodes");
-                    
-                return XmlNodes[0]; 
+
+                return XmlNodes[0];
             }
         }
 

--- a/src/NUnitEngine/nunit.engine.api/TestPackage.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestPackage.cs
@@ -11,12 +11,12 @@ namespace NUnit.Engine
     /// be loaded by a TestRunner. Each TestPackage represents
     /// tests for one or more test files. TestPackages may be named
     /// or anonymous, depending on the constructor used.
-    /// 
+    ///
     /// Upon construction, a package is given an ID (string), which
     /// remains unchanged for the lifetime of the TestPackage instance.
     /// The package ID is passed to the test framework for use in generating
     /// test IDs.
-    /// 
+    ///
     /// A runner that reloads test assemblies and wants the ids to remain stable
     /// should avoid creating a new package but should instead use the original
     /// package, changing settings as needed. This gives the best chance for the
@@ -95,7 +95,7 @@ namespace NUnit.Engine
         /// <summary>
         /// Gets the settings dictionary for this package.
         /// </summary>
-        public IDictionary<string,object> Settings { get; } = new Dictionary<string, object>();
+        public IDictionary<string, object> Settings { get; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Add a subpackage to the package.

--- a/src/NUnitEngine/nunit.engine.api/TestSelectionParserException.cs
+++ b/src/NUnitEngine/nunit.engine.api/TestSelectionParserException.cs
@@ -15,18 +15,24 @@ namespace NUnit.Engine
         /// <summary>
         /// Construct with a message
         /// </summary>
-        public TestSelectionParserException(string message) : base(message) { }
+        public TestSelectionParserException(string message) : base(message)
+        {
+        }
 
         /// <summary>
         /// Construct with a message and inner exception
         /// </summary>
         /// <param name="message"></param>
         /// <param name="innerException"></param>
-        public TestSelectionParserException(string message, Exception innerException) : base(message, innerException) { }
+        public TestSelectionParserException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
 
         /// <summary>
         /// Serialization constructor
         /// </summary>
-        public TestSelectionParserException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        public TestSelectionParserException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Acceptance/InstantiateEngineInsideTest.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Acceptance/InstantiateEngineInsideTest.cs
@@ -5,9 +5,8 @@ using NUnit.Framework;
 
 namespace NUnit.Engine
 {
-    class InstantiateEngineInsideTest
+    internal class InstantiateEngineInsideTest
     {
-
         /// <summary>
         /// Historically it wasn't possible to instantiate a full engine inside
         /// a running NUnit test due to issues with URI collisions for
@@ -40,6 +39,5 @@ namespace NUnit.Engine
                 // No action
             }
         }
-
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/AsyncTestEngineResultTests.cs
@@ -68,7 +68,7 @@ namespace NUnit.Engine
         public void Wait_AllowsMultipleWaits()
         {
             _asyncResult.SetResult(new TestEngineResult());
-            
+
             Assert.That(_asyncResult.Wait(0), Is.True, "Expected wait to be true because the test is complete");
 
             Assert.That(_asyncResult.Wait(0), Is.True, "Expected the second wait to be non blocking");

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/ProcessTester.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/ProcessTester.cs
@@ -24,7 +24,8 @@ namespace NUnit.Engine.TestHelpers
 
                 process.OutputDataReceived += (sender, e) =>
                 {
-                    if (e.Data == null) return;
+                    if (e.Data == null)
+                        return;
                     if (currentDataIsError)
                     {
                         if (currentData.Length != 0)
@@ -36,7 +37,8 @@ namespace NUnit.Engine.TestHelpers
                 };
                 process.ErrorDataReceived += (sender, e) =>
                 {
-                    if (e.Data == null) return;
+                    if (e.Data == null)
+                        return;
                     if (!currentDataIsError)
                     {
                         if (currentData.Length != 0)
@@ -78,7 +80,8 @@ namespace NUnit.Engine.TestHelpers
             {
                 var r = new StringBuilder("Exit code ").Append(ExitCode);
 
-                if (StandardStreamData.Length != 0) r.AppendLine();
+                if (StandardStreamData.Length != 0)
+                    r.AppendLine();
 
                 foreach (var data in StandardStreamData)
                 {

--- a/src/NUnitEngine/nunit.engine.tests/Helpers/StackEnumerator.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Helpers/StackEnumerator.cs
@@ -24,7 +24,8 @@ namespace NUnit.Engine.TestHelpers
             while (!current.MoveNext())
             {
                 current.Dispose();
-                if (stack.Count == 0) return false;
+                if (stack.Count == 0)
+                    return false;
                 current = stack.Pop();
             }
 
@@ -35,13 +36,15 @@ namespace NUnit.Engine.TestHelpers
 
         public void Recurse(IEnumerator<T> newCurrent)
         {
-            if (newCurrent == null) return;
+            if (newCurrent == null)
+                return;
             stack.Push(current);
             current = newCurrent;
         }
         public void Recurse(IEnumerable<T> newCurrent)
         {
-            if (newCurrent == null) return;
+            if (newCurrent == null)
+                return;
             Recurse(newCurrent.GetEnumerator());
         }
         public void Recurse(params T[] newCurrent)

--- a/src/NUnitEngine/nunit.engine.tests/Integration/RunnerInDirectoryWithoutFramework.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Integration/RunnerInDirectoryWithoutFramework.cs
@@ -24,16 +24,17 @@ namespace NUnit.Engine.Integration
 
         public void Dispose()
         {
-            for (;;) try
-            {
-                File.Delete(AgentExe);
-                File.Delete(AgentX86Exe);
-                break;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                Thread.Sleep(100);
-            }
+            for (; ;)
+                try
+                {
+                    File.Delete(AgentExe);
+                    File.Delete(AgentX86Exe);
+                    break;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    Thread.Sleep(100);
+                }
 
             directory.Dispose();
         }

--- a/src/NUnitEngine/nunit.engine.tests/Program.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Program.cs
@@ -5,9 +5,9 @@ using NUnitLite;
 
 namespace NUnit.Engine.Tests
 {
-    class Program
+    internal class Program
     {
-        static int Main(string[] args)
+        private static int Main(string[] args)
         {
             return new TextRunner(typeof(Program).Assembly).Execute(args);
         }

--- a/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/ParallelTaskWorkerPoolTests.cs
@@ -101,7 +101,9 @@ namespace NUnit.Engine.Runners
 
         private class NoOpTask : ITestExecutionTask
         {
-            public void Execute() { }
+            public void Execute()
+            {
+            }
         }
 
         private enum BusyTaskState

--- a/src/NUnitEngine/nunit.engine.tests/Runners/WorkItemTrackerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/WorkItemTrackerTests.cs
@@ -55,40 +55,40 @@ namespace NUnit.Engine.Runners
 
         // HACK: All of this is very fragile, since any white-space or ordering change will break it.
         // TODO: When NUnit has XML testing, rewrite.
-        const string START_ASSEMBLY = "<start-suite type=\"Assembly\" id=\"1\" name=\"test.dll\" fullname=\"/path/to/test.dll\" />";
-        const string START_NS_1 = "<start-suite type=\"TestSuite\" id=\"2\" name=\"My\" fullname=\"My\" />";
-        const string START_NS_2 = "<start-suite type=\"TestSuite\" id=\"3\" name=\"Tests\" fullname=\"My.Tests\" />";
-        const string START_FIXTURE_1 = "<start-suite type=\"TestFixture\" id=\"4\" name=\"Fixture1\" fullname=\"My.Tests.Fixture1\" />";
-        const string START_FIXTURE_2 = "<start-suite type=\"TestFixture\" id=\"5\" name=\"Fixture2\" fullname=\"My.Tests.Fixture2\" />";
+        private const string START_ASSEMBLY = "<start-suite type=\"Assembly\" id=\"1\" name=\"test.dll\" fullname=\"/path/to/test.dll\" />";
+        private const string START_NS_1 = "<start-suite type=\"TestSuite\" id=\"2\" name=\"My\" fullname=\"My\" />";
+        private const string START_NS_2 = "<start-suite type=\"TestSuite\" id=\"3\" name=\"Tests\" fullname=\"My.Tests\" />";
+        private const string START_FIXTURE_1 = "<start-suite type=\"TestFixture\" id=\"4\" name=\"Fixture1\" fullname=\"My.Tests.Fixture1\" />";
+        private const string START_FIXTURE_2 = "<start-suite type=\"TestFixture\" id=\"5\" name=\"Fixture2\" fullname=\"My.Tests.Fixture2\" />";
 
-        static readonly string END_ASSEMBLY = START_ASSEMBLY.Replace("start-suite", "test-suite");
-        static readonly string END_NS_1 = START_NS_1.Replace("start-suite", "test-suite");
-        static readonly string END_NS_2 = START_NS_2.Replace("start-suite", "test-suite");
-        static readonly string END_FIXTURE_1 = START_FIXTURE_1.Replace("start-suite", "test-suite");
-        static readonly string END_FIXTURE_2 = START_FIXTURE_2.Replace("start-suite", "test-suite");
+        private static readonly string END_ASSEMBLY = START_ASSEMBLY.Replace("start-suite", "test-suite");
+        private static readonly string END_NS_1 = START_NS_1.Replace("start-suite", "test-suite");
+        private static readonly string END_NS_2 = START_NS_2.Replace("start-suite", "test-suite");
+        private static readonly string END_FIXTURE_1 = START_FIXTURE_1.Replace("start-suite", "test-suite");
+        private static readonly string END_FIXTURE_2 = START_FIXTURE_2.Replace("start-suite", "test-suite");
 
-        const string CANCEL_INFO = "result=\"Failed\" label=\"Cancelled\"><failure><message><![CDATA[Test run cancelled by user]]></message></failure></test-suite>";
-        static readonly string CANCEL_ASSEMBLY = END_ASSEMBLY.Replace("/>", CANCEL_INFO);
-        static readonly string CANCEL_NS_1 = END_NS_1.Replace("/>", CANCEL_INFO);
-        static readonly string CANCEL_NS_2 = END_NS_2.Replace("/>", CANCEL_INFO);
-        static readonly string CANCEL_FIXTURE_1 = END_FIXTURE_1.Replace("/>", CANCEL_INFO);
-        static readonly string CANCEL_FIXTURE_2 = END_FIXTURE_2.Replace("/>", CANCEL_INFO);
+        private const string CANCEL_INFO = "result=\"Failed\" label=\"Cancelled\"><failure><message><![CDATA[Test run cancelled by user]]></message></failure></test-suite>";
+        private static readonly string CANCEL_ASSEMBLY = END_ASSEMBLY.Replace("/>", CANCEL_INFO);
+        private static readonly string CANCEL_NS_1 = END_NS_1.Replace("/>", CANCEL_INFO);
+        private static readonly string CANCEL_NS_2 = END_NS_2.Replace("/>", CANCEL_INFO);
+        private static readonly string CANCEL_FIXTURE_1 = END_FIXTURE_1.Replace("/>", CANCEL_INFO);
+        private static readonly string CANCEL_FIXTURE_2 = END_FIXTURE_2.Replace("/>", CANCEL_INFO);
 
-        static readonly TestCaseData[] AllItemsComplete =
+        private static readonly TestCaseData[] AllItemsComplete =
         [
             new TestCaseData(new ReportSequence(
                 START_ASSEMBLY, START_NS_1, START_NS_2,
                 START_FIXTURE_1, END_FIXTURE_1,
                 START_FIXTURE_2, END_FIXTURE_2,
-                END_NS_2, END_NS_1, END_ASSEMBLY )),
+                END_NS_2, END_NS_1, END_ASSEMBLY)),
             new TestCaseData(new ReportSequence(
                 START_ASSEMBLY, START_NS_1, START_NS_2,
                 START_FIXTURE_1, START_FIXTURE_2,
                 END_FIXTURE_1, END_FIXTURE_2,
-                END_NS_2, END_NS_1, END_ASSEMBLY ))
+                END_NS_2, END_NS_1, END_ASSEMBLY))
         ];
 
-        static readonly TestCaseData[] SomeItemsIncomplete =
+        private static readonly TestCaseData[] SomeItemsIncomplete =
         [
             new TestCaseData(
                 new ReportSequence(
@@ -101,14 +101,14 @@ namespace NUnit.Engine.Runners
                 new ReportSequence(
                     START_ASSEMBLY, START_NS_1, START_NS_2,
                     START_FIXTURE_1, END_FIXTURE_1,
-                    START_FIXTURE_2  ), // Fixture 2 hangs!
+                    START_FIXTURE_2), // Fixture 2 hangs!
                 new ReportSequence(
                     CANCEL_FIXTURE_2, CANCEL_NS_2, CANCEL_NS_1, CANCEL_ASSEMBLY)),
             new TestCaseData(
                 new ReportSequence(
                     START_ASSEMBLY, START_NS_1, START_NS_2,
                     START_FIXTURE_1,
-                    START_FIXTURE_2  ), // Both fixtures hang!
+                    START_FIXTURE_2), // Both fixtures hang!
                 new ReportSequence(
                     CANCEL_FIXTURE_2, CANCEL_FIXTURE_1, CANCEL_NS_2, CANCEL_NS_1, CANCEL_ASSEMBLY)),
         ];

--- a/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/RuntimeFrameworkTests.cs
@@ -47,67 +47,69 @@ namespace NUnit.Engine
         }
 
 #pragma warning disable 414
-        static TestCaseData[] matchData = new TestCaseData[] {
+        private static TestCaseData[] matchData = new TestCaseData[]
+        {
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(3,5)),
-                new RuntimeFramework(Runtime.Net, new Version(2,0)))
+                new RuntimeFramework(Runtime.Net, new Version(3, 5)),
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(2,0)),
-                new RuntimeFramework(Runtime.Net, new Version(3,5)))
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(3, 5)))
                 .Returns(false),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(3,5)),
-                new RuntimeFramework(Runtime.Net, new Version(3,5)))
+                new RuntimeFramework(Runtime.Net, new Version(3, 5)),
+                new RuntimeFramework(Runtime.Net, new Version(3, 5)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(2,0)),
-                new RuntimeFramework(Runtime.Net, new Version(2,0)))
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(2,0)),
-                new RuntimeFramework(Runtime.Mono, new Version(2,0)))
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)),
+                new RuntimeFramework(Runtime.Mono, new Version(2, 0)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Mono, new Version(2,0)),
-                new RuntimeFramework(Runtime.Net, new Version(2,0)))
+                new RuntimeFramework(Runtime.Mono, new Version(2, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(4,0)),
-                new RuntimeFramework(Runtime.Mono, new Version(4,0)))
+                new RuntimeFramework(Runtime.Net, new Version(4, 0)),
+                new RuntimeFramework(Runtime.Mono, new Version(4, 0)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Mono, new Version(4,0)),
-                new RuntimeFramework(Runtime.Net, new Version(4,0)))
+                new RuntimeFramework(Runtime.Mono, new Version(4, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(4, 0)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Mono, new Version(4,0)),
-                new RuntimeFramework(Runtime.Net, new Version(4,6,2)))
+                new RuntimeFramework(Runtime.Mono, new Version(4, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(4, 6, 2)))
                 .Returns(true),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(2,0)),
-                new RuntimeFramework(Runtime.Net, new Version(1,1)))
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(1, 1)))
                 .Returns(false),
             new TestCaseData(
-                new RuntimeFramework(Runtime.Mono, new Version(1,1)), // non-existent version but it works
-                new RuntimeFramework(Runtime.Mono, new Version(1,0)))
+                new RuntimeFramework(Runtime.Mono, new Version(1, 1)), // non-existent version but it works
+                new RuntimeFramework(Runtime.Mono, new Version(1, 0)))
                 .Returns(true),
-            };
+        };
 
-        private static readonly TestCaseData[] CanLoadData = {
+        private static readonly TestCaseData[] CanLoadData =
+        {
             new TestCaseData(
-                new RuntimeFramework(Runtime.Net, new Version(2,0)),
-                new RuntimeFramework(Runtime.Net, new Version(2,0)))
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)),
+                new RuntimeFramework(Runtime.Net, new Version(2, 0)))
                 .Returns(true),
             new TestCaseData(
-                    new RuntimeFramework(Runtime.Net, new Version(2,0)),
-                    new RuntimeFramework(Runtime.Net, new Version(4,0)))
+                    new RuntimeFramework(Runtime.Net, new Version(2, 0)),
+                    new RuntimeFramework(Runtime.Net, new Version(4, 0)))
                 .Returns(false),
             new TestCaseData(
-                    new RuntimeFramework(Runtime.Net, new Version(4,0)),
-                    new RuntimeFramework(Runtime.Net, new Version(2,0)))
+                    new RuntimeFramework(Runtime.Net, new Version(4, 0)),
+                    new RuntimeFramework(Runtime.Net, new Version(2, 0)))
                 .Returns(true)
-            };
+        };
 #pragma warning restore 414
 
         public struct FrameworkData
@@ -132,32 +134,33 @@ namespace NUnit.Engine
             }
         }
 
-        static readonly FrameworkData[] frameworkData = new FrameworkData[] {
-            new FrameworkData(Runtime.Net, new Version(1,0), "net-1.0", ".NET 1.0"),
-            new FrameworkData(Runtime.Net, new Version(1,1), "net-1.1", ".NET 1.1"),
-            new FrameworkData(Runtime.Net, new Version(2,0), "net-2.0", ".NET 2.0"),
-            new FrameworkData(Runtime.Net, new Version(3,0), "net-3.0", ".NET 3.0"),
-            new FrameworkData(Runtime.Net, new Version(3,5), "net-3.5", ".NET 3.5"),
-            new FrameworkData(Runtime.Net, new Version(4,0), "net-4.0", ".NET 4.0"),
-            new FrameworkData(Runtime.Net, new Version(4,5), "net-4.5", ".NET 4.5"),
-            new FrameworkData(Runtime.Net, new Version(4,5,1), "net-4.5.1", ".NET 4.5.1"),
-            new FrameworkData(Runtime.Net, new Version(4,5,2), "net-4.5.2", ".NET 4.5.2"),
-            new FrameworkData(Runtime.Net, new Version(4,6), "net-4.6", ".NET 4.6"),
-            new FrameworkData(Runtime.Net, new Version(4,6,1), "net-4.6.1", ".NET 4.6.1"),
-            new FrameworkData(Runtime.Net, new Version(4,6,2), "net-4.6.2", ".NET 4.6.2"),
-            new FrameworkData(Runtime.Net, new Version(4,7), "net-4.7", ".NET 4.7"),
-            new FrameworkData(Runtime.Net, new Version(4,7,1), "net-4.7.1", ".NET 4.7.1"),
-            new FrameworkData(Runtime.Net, new Version(4,7,2), "net-4.7.2", ".NET 4.7.2"),
-            new FrameworkData(Runtime.Net, new Version(4,8), "net-4.8", ".NET 4.8"),
-            new FrameworkData(Runtime.Mono, new Version(1,0), "mono-1.0", "Mono 1.0"),
-            new FrameworkData(Runtime.Mono, new Version(2,0), "mono-2.0", "Mono 2.0"),
-            new FrameworkData(Runtime.Mono, new Version(3,5), "mono-3.5", "Mono 3.5"),
-            new FrameworkData(Runtime.Mono, new Version(4,0), "mono-4.0", "Mono 4.0"),
-            new FrameworkData(Runtime.NetCore, new Version(2,1), "netcore-2.1", ".NETCore 2.1"),
-            new FrameworkData(Runtime.NetCore, new Version(3,1), "netcore-3.1", ".NETCore 3.1"),
-            new FrameworkData(Runtime.NetCore, new Version(5,0), "netcore-5.0", ".NETCore 5.0"),
-            new FrameworkData(Runtime.NetCore, new Version(6,0), "netcore-6.0", ".NETCore 6.0"),
-            new FrameworkData(Runtime.NetCore, new Version(7,0), "netcore-7.0", ".NETCore 7.0"),
+        private static readonly FrameworkData[] frameworkData = new FrameworkData[]
+        {
+            new FrameworkData(Runtime.Net, new Version(1, 0), "net-1.0", ".NET 1.0"),
+            new FrameworkData(Runtime.Net, new Version(1, 1), "net-1.1", ".NET 1.1"),
+            new FrameworkData(Runtime.Net, new Version(2, 0), "net-2.0", ".NET 2.0"),
+            new FrameworkData(Runtime.Net, new Version(3, 0), "net-3.0", ".NET 3.0"),
+            new FrameworkData(Runtime.Net, new Version(3, 5), "net-3.5", ".NET 3.5"),
+            new FrameworkData(Runtime.Net, new Version(4, 0), "net-4.0", ".NET 4.0"),
+            new FrameworkData(Runtime.Net, new Version(4, 5), "net-4.5", ".NET 4.5"),
+            new FrameworkData(Runtime.Net, new Version(4, 5, 1), "net-4.5.1", ".NET 4.5.1"),
+            new FrameworkData(Runtime.Net, new Version(4, 5, 2), "net-4.5.2", ".NET 4.5.2"),
+            new FrameworkData(Runtime.Net, new Version(4, 6), "net-4.6", ".NET 4.6"),
+            new FrameworkData(Runtime.Net, new Version(4, 6, 1), "net-4.6.1", ".NET 4.6.1"),
+            new FrameworkData(Runtime.Net, new Version(4, 6, 2), "net-4.6.2", ".NET 4.6.2"),
+            new FrameworkData(Runtime.Net, new Version(4, 7), "net-4.7", ".NET 4.7"),
+            new FrameworkData(Runtime.Net, new Version(4, 7, 1), "net-4.7.1", ".NET 4.7.1"),
+            new FrameworkData(Runtime.Net, new Version(4, 7, 2), "net-4.7.2", ".NET 4.7.2"),
+            new FrameworkData(Runtime.Net, new Version(4, 8), "net-4.8", ".NET 4.8"),
+            new FrameworkData(Runtime.Mono, new Version(1, 0), "mono-1.0", "Mono 1.0"),
+            new FrameworkData(Runtime.Mono, new Version(2, 0), "mono-2.0", "Mono 2.0"),
+            new FrameworkData(Runtime.Mono, new Version(3, 5), "mono-3.5", "Mono 3.5"),
+            new FrameworkData(Runtime.Mono, new Version(4, 0), "mono-4.0", "Mono 4.0"),
+            new FrameworkData(Runtime.NetCore, new Version(2, 1), "netcore-2.1", ".NETCore 2.1"),
+            new FrameworkData(Runtime.NetCore, new Version(3, 1), "netcore-3.1", ".NETCore 3.1"),
+            new FrameworkData(Runtime.NetCore, new Version(5, 0), "netcore-5.0", ".NETCore 5.0"),
+            new FrameworkData(Runtime.NetCore, new Version(6, 0), "netcore-6.0", ".NETCore 6.0"),
+            new FrameworkData(Runtime.NetCore, new Version(7, 0), "netcore-7.0", ".NETCore 7.0"),
         };
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentProcessTests.cs
@@ -28,9 +28,9 @@ namespace NUnit.Engine.Services
         }
 
 #if DEBUG
-        const string AGENTS_DIR = "../../../../nunit.engine/bin/Debug/agents/";
+        private const string AGENTS_DIR = "../../../../nunit.engine/bin/Debug/agents/";
 #else
-        const string AGENTS_DIR = "../../../../nunit.engine/bin/Release/agents/";
+        private const string AGENTS_DIR = "../../../../nunit.engine/bin/Release/agents/";
 #endif
 
         [TestCase("net-4.8", false, "net462/nunit-agent-net462.exe")]
@@ -124,7 +124,6 @@ namespace NUnit.Engine.Services
             var agentProcess = GetAgentProcess();
             Assert.That(agentProcess.AgentArgs.ToString(), Is.EqualTo(REQUIRED_ARGS + " --debug-agent"));
         }
-
 
         [Test]
         public void LoadUserProfile()

--- a/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/AgentStoreTests.cs
@@ -207,7 +207,8 @@ namespace NUnit.Engine.Services
             foreach (var thread in threads)
                 thread.Join();
 
-            if (exceptions.Count != 0) throw exceptions[0];
+            if (exceptions.Count != 0)
+                throw exceptions[0];
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/Services/FakeService.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/FakeService.cs
@@ -4,8 +4,9 @@ using System;
 
 namespace NUnit.Engine.Services
 {
-    interface IFakeService
-    { }
+    internal interface IFakeService
+    {
+    }
 
     public class FakeService : IFakeService, IService
     {

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultWriters/XmlTransformResultWriterTests.cs
@@ -38,7 +38,6 @@ namespace NUnit.Engine.Services.ResultWriters
             }
         }
 
-
         [Test]
         public void SummaryTransformTest()
         {

--- a/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/RuntimeFrameworkServiceTests.cs
@@ -46,9 +46,9 @@ namespace NUnit.Engine.Services
         }
 
 #if DEBUG
-        const string AGENTS_DIR = "../../../../nunit.engine/bin/Debug/agents/";
+        private const string AGENTS_DIR = "../../../../nunit.engine/bin/Debug/agents/";
 #else
-        const string AGENTS_DIR = "../../../../nunit.engine/bin/Release/agents/";
+        private const string AGENTS_DIR = "../../../../nunit.engine/bin/Release/agents/";
 #endif
 
         [TestCase("net35", false)]
@@ -63,7 +63,7 @@ namespace NUnit.Engine.Services
 
             var returnValue = _runtimeService.SelectRuntimeFramework(package);
 
-            Assert.That(package.GetSetting("TargetRuntimeFramework", ""), Is.EqualTo(returnValue));
+            Assert.That(package.GetSetting("TargetRuntimeFramework", string.Empty), Is.EqualTo(returnValue));
             Assert.That(package.GetSetting("RunAsX86", false), Is.EqualTo(runAsX86));
         }
 
@@ -143,7 +143,7 @@ namespace NUnit.Engine.Services
             Assume.That(_runtimeService.IsAvailable("net-4.0", false));
             Assume.That(_runtimeService.IsAvailable("net-4.0", true));
 
-            var topLevelPackage = new TestPackage(new [] {"a.dll", "b.dll"});
+            var topLevelPackage = new TestPackage(new string[] { "a.dll", "b.dll" });
 
             var net20Package = topLevelPackage.SubPackages[0];
             net20Package.Settings.Add(EnginePackageSettings.ImageRuntimeVersion, new Version("2.0"));

--- a/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ServiceManagerTests.cs
@@ -42,7 +42,7 @@ namespace NUnit.Engine.Services
         public void InitializationFailure()
         {
             ((FakeService)_fakeService).FailToStart = true;
-            Assert.That(() => _serviceManager.StartServices(), 
+            Assert.That(() => _serviceManager.StartServices(),
                 Throws.InstanceOf<InvalidOperationException>().And.Message.Contains("FakeService"));
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilterBuilderTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilterBuilderTests.cs
@@ -9,7 +9,7 @@ namespace NUnit.Engine.Services
 {
     public class TestFilterBuilderTests
     {
-        TestFilterBuilder builder;
+        private TestFilterBuilder builder;
 
         [SetUp]
         public void CreateBuilder()

--- a/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/TestFilteringTests.cs
@@ -8,7 +8,6 @@ using NUnit.Engine.Drivers;
 
 namespace NUnit.Engine.Services
 {
-
     public class TestFilteringTests
     {
         private const string MOCK_ASSEMBLY = "mock-assembly.dll";
@@ -55,7 +54,6 @@ namespace NUnit.Engine.Services
             builder.AddTest(testName);
 
             Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(count));
-
         }
 
         [TestCase("test==NUnit.TestData.Assemblies.MockTestFixture", MockTestFixture.Tests, TestName = "{m}_MockTestFixture")]
@@ -71,7 +69,6 @@ namespace NUnit.Engine.Services
             builder.SelectWhere(expression);
 
             Assert.That(_driver.CountTestCases(builder.GetFilter().Text), Is.EqualTo(count));
-
         }
     }
 }

--- a/src/NUnitEngine/nunit.engine.tests/TestData.cs
+++ b/src/NUnitEngine/nunit.engine.tests/TestData.cs
@@ -12,9 +12,9 @@ namespace NUnit.Engine
     internal class TestData
     {
 #if NET8_0
-        const string CURRENT_RUNTIME = "net8.0";
+        private const string CURRENT_RUNTIME = "net8.0";
 #else
-        const string CURRENT_RUNTIME = "net462";
+        private const string CURRENT_RUNTIME = "net462";
 #endif
         [Test]
         public void SelfTest()

--- a/src/NUnitEngine/nunit.engine.tests/WorkingDirectoryTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/WorkingDirectoryTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace NUnit.Engine
 {
     [NonParallelizable]
-    class WorkingDirectoryTests
+    internal class WorkingDirectoryTests
     {
         private string _origWorkingDir;
 

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Remoting/TestAgencyRemotingTransport.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Remoting/TestAgencyRemotingTransport.cs
@@ -68,15 +68,15 @@ namespace NUnit.Engine.Communication.Transports.Remoting
         [System.Runtime.Remoting.Messaging.OneWay]
         public void Stop()
         {
-            lock( _theLock )
+            lock (_theLock)
             {
-                if ( this._isMarshalled )
+                if (this._isMarshalled)
                 {
-                    RemotingServices.Disconnect( this );
+                    RemotingServices.Disconnect(this);
                     this._isMarshalled = false;
                 }
 
-                if ( this._channel != null )
+                if (this._channel != null)
                 {
                     try
                     {
@@ -90,7 +90,7 @@ namespace NUnit.Engine.Communication.Transports.Remoting
                     }
                 }
 
-                Monitor.PulseAll( _theLock );
+                Monitor.PulseAll(_theLock);
             }
         }
 
@@ -101,9 +101,9 @@ namespace NUnit.Engine.Communication.Transports.Remoting
 
         public void WaitForStop()
         {
-            lock( _theLock )
+            lock (_theLock)
             {
-                Monitor.Wait( _theLock );
+                Monitor.Wait(_theLock);
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TcpServer.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TcpServer.cs
@@ -13,9 +13,9 @@ namespace NUnit.Engine.Communication.Transports.Tcp
 
         private const int GUID_BUFFER_SIZE = 16;
 
-        TcpListener _tcpListener;
-        Thread? _listenerThread;
-        volatile bool _running;
+        private TcpListener _tcpListener;
+        private Thread? _listenerThread;
+        private volatile bool _running;
 
         public delegate void ConnectionEventHandler(Socket clientSocket, Guid id);
 

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgencyTcpTransport.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgencyTcpTransport.cs
@@ -19,7 +19,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
 
         private object _theLock = new object();
 
-        public TestAgencyTcpTransport(ITestAgency agency, int port=0)
+        public TestAgencyTcpTransport(ITestAgency agency, int port = 0)
         {
             Guard.ArgumentNotNull(agency, nameof(agency));
             Guard.ArgumentValid(port >= IPEndPoint.MinPort && port <= IPEndPoint.MaxPort,
@@ -51,9 +51,9 @@ namespace NUnit.Engine.Communication.Transports.Tcp
 
         public void WaitForStop()
         {
-            lock( _theLock )
+            lock (_theLock)
             {
-                Monitor.Wait( _theLock );
+                Monitor.Wait(_theLock);
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgentTcpProxy.cs
+++ b/src/NUnitEngine/nunit.engine/Communication/Transports/Tcp/TestAgentTcpProxy.cs
@@ -19,7 +19,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
         public TestAgentTcpProxy(Socket socket, Guid id)
         {
            _socket = socket;
-            Id = id;
+           Id = id;
         }
 
         public Guid Id { get; }

--- a/src/NUnitEngine/nunit.engine/IProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/IProjectService.cs
@@ -21,7 +21,7 @@ namespace NUnit.Engine.Services
 
         /// <summary>
         /// Expands a TestPackage based on a known project format, populating it
-        /// with the project contents and any settings the project provides. 
+        /// with the project contents and any settings the project provides.
         /// Note that the package file path must be checked to ensure that it is
         /// a known project format before calling this method.
         /// </summary>

--- a/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/AggregatingTestRunner.cs
@@ -23,7 +23,7 @@ namespace NUnit.Engine.Runners
         // AggregatingTestRunners.
         //
         // AggregatingTestRunner is used in the engine/runner process as well as in agent
-        // processes. It may be called with a TestPackage that specifies a single 
+        // processes. It may be called with a TestPackage that specifies a single
         // assembly, multiple assemblies, a single project, multiple projects or
         // a mix of projects and assemblies. Each file passed is handled by
         // a single runner.
@@ -154,7 +154,8 @@ namespace NUnit.Engine.Runners
                 RunTestsInParallel(listener, filter, results, disposeRunners);
             }
 
-            if (disposeRunners) Runners.Clear();
+            if (disposeRunners)
+                Runners.Clear();
 
             return ResultHelper.Merge(results);
         }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -24,9 +24,9 @@ namespace NUnit.Engine.Runners
         // implement ITestEngineRunner.
         //
         // Explore and execution results from MasterTestRunner are
-        // returned as XmlNodes, created from the internal 
+        // returned as XmlNodes, created from the internal
         // TestEngineResult representation.
-        // 
+        //
         // MasterTestRunner is responsible for creating the test-run
         // element, which wraps all the individual assembly and project
         // results.
@@ -48,8 +48,10 @@ namespace NUnit.Engine.Runners
 
         public MasterTestRunner(IServiceLocator services, TestPackage package)
         {
-            if (services == null) throw new ArgumentNullException("services");
-            if (package == null) throw new ArgumentNullException("package");
+            if (services == null)
+                throw new ArgumentNullException("services");
+            if (package == null)
+                throw new ArgumentNullException("package");
 
             _services = services;
             TestPackage = package;
@@ -149,7 +151,6 @@ namespace NUnit.Engine.Runners
             return RunTests(listener, filter).Xml;
         }
 
-
         /// <summary>
         /// Start a run of the tests in the loaded TestPackage. The tests are run
         /// asynchronously and the listener interface is notified as it progresses.
@@ -181,7 +182,7 @@ namespace NUnit.Engine.Runners
                 // notifications needed by some runners. In fact, such a bug is present in the
                 // NUnit framework through release 3.12 and motivated the following code.
                 //
-                // We try to make up for the potential problem here by notifying the listeners 
+                // We try to make up for the potential problem here by notifying the listeners
                 // of the completion of every pending WorkItem, that is, one that started but
                 // never sent a completion event.
 
@@ -269,14 +270,15 @@ namespace NUnit.Engine.Runners
         // allows the lower-level runners to be completely ignorant of projects
         private TestEngineResult PrepareResult(TestEngineResult result)
         {
-            if (result == null) throw new ArgumentNullException("result");
+            if (result == null)
+                throw new ArgumentNullException("result");
 
             // See if we have any projects to deal with. At this point,
             // any subpackage, which itself has subpackages, is a project
             // we expanded.
             bool hasProjects = false;
-                foreach (var p in TestPackage.SubPackages)
-                    hasProjects |= p.HasSubPackages();
+            foreach (var p in TestPackage.SubPackages)
+                hasProjects |= p.HasSubPackages();
 
             // If no Projects, there's nothing to do
             if (!hasProjects)
@@ -306,7 +308,7 @@ namespace NUnit.Engine.Runners
                 {
                     // This is a project, create an intermediate result
                     var projectResult = new TestEngineResult();
-                    
+
                     // Now move any children of this project under it. As noted
                     // above, we must rely on ordering here because (1) the
                     // fullname attribute is not reliable on all nunit framework
@@ -315,7 +317,7 @@ namespace NUnit.Engine.Runners
                     int numChildren = subPackage.SubPackages.Count;
                     while (numChildren-- > 0)
                         projectResult.Add(result.XmlNodes[nextTest++]);
-                    
+
                     topLevelResult.Add(projectResult.MakeProjectResult(subPackage).Xml);
                 }
                 else
@@ -324,13 +326,14 @@ namespace NUnit.Engine.Runners
                     topLevelResult.Add(result.XmlNodes[nextTest++]);
                 }
             }
-            
+
             return topLevelResult;
         }
 
         private void EnsurePackagesAreExpanded(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException("package");
+            if (package == null)
+                throw new ArgumentNullException("package");
 
             foreach (var subPackage in package.SubPackages)
             {
@@ -345,7 +348,8 @@ namespace NUnit.Engine.Runners
 
         private bool IsProjectPackage(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException("package");
+            if (package == null)
+                throw new ArgumentNullException("package");
 
             return
                 _projectService != null
@@ -361,7 +365,7 @@ namespace NUnit.Engine.Runners
 
         private static ObsoletePackageSetting[] ObsoleteSettings = new ObsoletePackageSetting[]
         {
-            new ObsoletePackageSetting() { OldKey = "RuntimeFramework", NewKey = "RequestedRuntimeFramework"}
+            new ObsoletePackageSetting() { OldKey = "RuntimeFramework", NewKey = "RequestedRuntimeFramework" }
         };
 
         // Any Errors thrown from this method indicate that the client
@@ -369,7 +373,7 @@ namespace NUnit.Engine.Runners
         private void ValidatePackageSettings()
         {
 #if NETFRAMEWORK  // TODO: How do we validate runtime framework for .NET Standard 2.0?
-            var frameworkSetting = TestPackage.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
+            var frameworkSetting = TestPackage.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, string.Empty);
             var runAsX86 = TestPackage.GetSetting(EnginePackageSettings.RunAsX86, false);
 
             foreach (var entry in ObsoleteSettings)
@@ -400,7 +404,8 @@ namespace NUnit.Engine.Runners
         /// <returns>The count of test cases</returns>
         private int CountTests(TestFilter filter)
         {
-            if (!IsPackageLoaded) return 0;
+            if (!IsPackageLoaded)
+                return 0;
 
             return GetEngineRunner().CountTestCases(filter);
         }
@@ -425,7 +430,7 @@ namespace NUnit.Engine.Runners
                 _eventDispatcher.Listeners.Add(extension);
 
             IsTestRunning = true;
-            
+
             string clrVersion;
             string engineVersion;
 

--- a/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MultipleTestProcessRunner.cs
@@ -25,9 +25,8 @@ namespace NUnit.Engine.Runners
             _processorCount = processorCount <= 0
                 ? Environment.ProcessorCount
                 : processorCount;
-
         }
-        
+
         public override int LevelOfParallelism
         {
             get

--- a/src/NUnitEngine/nunit.engine/Runners/NotRunnableTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/NotRunnableTestRunner.cs
@@ -128,6 +128,7 @@ namespace NUnit.Engine.Runners
     {
         public UnmanagedExecutableTestRunner(string assemblyPath)
             : base(assemblyPath, "Unmanaged libraries or applications are not supported")
-        { }
+        {
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ProcessRunner.cs
@@ -57,7 +57,7 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult.</returns>
         protected override TestEngineResult LoadPackage()
         {
-            Guard.OperationValid(TestPackage!=null, "Calling LoadPackage with null TestPackage");
+            Guard.OperationValid(TestPackage != null, "Calling LoadPackage with null TestPackage");
 
             log.Info("Loading " + TestPackage.Name);
             Unload();
@@ -258,7 +258,7 @@ namespace NUnit.Engine.Runners
                 _remoteRunner = _agent.CreateRunner(TestPackage);
         }
 
-        TestEngineResult CreateFailedResult(Exception e)
+        private TestEngineResult CreateFailedResult(Exception e)
         {
             var suite = XmlHelper.CreateTopLevelElement("test-suite");
             XmlHelper.AddAttribute(suite, "type", "Assembly");

--- a/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
@@ -17,7 +17,7 @@ namespace NUnit.Engine.Runners
             Listeners = new List<ITestEventListener>();
         }
 
-        public IList<ITestEventListener>Listeners { get; private set; }
+        public IList<ITestEventListener> Listeners { get; private set; }
 
         public void OnTestEvent(string report)
         {

--- a/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/WorkItemTracker.cs
@@ -11,16 +11,16 @@ namespace NUnit.Engine.Runners
 {
     /// <summary>
     /// Test Frameworks, don't always handle cancellation. Those that do may
-    /// not always handle it correctly. In fact, even NUnit itself, through 
+    /// not always handle it correctly. In fact, even NUnit itself, through
     /// at least release 3.12, fails to cancel a test that's in an infinite
     /// loop. In addition, it's possible for user code to defeat cancellation,
     /// even forced cancellation or kill.
-    /// 
+    ///
     /// The engine needs to protect itself from such problems by assuring that
     /// any test for which cancellation is requested is fully cancelled, with
     /// nothing left behind. Further, it needs to generate notifications to
     /// tell the runner what happened.
-    /// 
+    ///
     /// WorkItemTracker examines test events and keeps track of those tests
     /// that have started but not yet finished. It implements ITestEventListener
     /// in order to capture events. It allows waiting for all items to complete.
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Runners
                 if (other == null)
                     return -1;
 
-                return  _order.CompareTo(other._order) * -1;
+                return _order.CompareTo(other._order) * -1;
             }
         }
 

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -148,7 +148,7 @@ namespace NUnit.Engine
         /// Returns true if the current framework matches the
         /// one supplied as an argument. Both the RuntimeType
         /// and the version must match.
-        /// 
+        ///
         /// Two RuntimeTypes match if they are equal, if either one
         /// is RuntimeType.Any or if one is RuntimeType.Net and
         /// the other is RuntimeType.Mono.
@@ -188,7 +188,8 @@ namespace NUnit.Engine
             for (int i = 0; i < 4; i++)
             {
                 string? dir = Path.GetDirectoryName(prefix);
-                if (string.IsNullOrEmpty(dir)) break;
+                if (string.IsNullOrEmpty(dir))
+                    break;
 
                 prefix = dir;
             }

--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -15,7 +15,7 @@ namespace NUnit.Engine.Services
         public AgentProcess(TestAgency agency, TestPackage package, Guid agentId)
         {
             // Get target runtime
-            string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");
+            string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, string.Empty);
             log.Debug($"TargetRuntime = {runtimeSetting}");
             TargetRuntime = RuntimeFramework.Parse(runtimeSetting);
 

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
@@ -29,14 +29,16 @@ namespace NUnit.Engine.Services
 
             public static AgentRecord Starting(Process process)
             {
-                if (process is null) throw new ArgumentNullException(nameof(process));
+                if (process is null)
+                    throw new ArgumentNullException(nameof(process));
 
                 return new AgentRecord(process, agent: null);
             }
 
             public AgentRecord Ready(ITestAgent agent)
             {
-                if (agent is null) throw new ArgumentNullException(nameof(agent));
+                if (agent is null)
+                    throw new ArgumentNullException(nameof(agent));
 
                 return new AgentRecord(Process, agent);
             }

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -15,10 +15,10 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class ProjectService : Service, IProjectService
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(ProjectService));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(ProjectService));
 
-        IEnumerable<ExtensionNode>? _extensionNodes;
-        ExtensionService? _extensionService;
+        private IEnumerable<ExtensionNode>? _extensionNodes;
+        private ExtensionService? _extensionService;
 
         public bool CanLoadFrom(string path)
         {

--- a/src/NUnitEngine/nunit.engine/Services/ResultService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultService.cs
@@ -10,7 +10,7 @@ namespace NUnit.Engine.Services
 {
     public class ResultService : Service, IResultService
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(ResultService));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(ResultService));
 
         private readonly string[] BUILT_IN_FORMATS = new string[] { "nunit3", "cases", "user" };
         private IEnumerable<ExtensionNode>? _extensionNodes;

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -49,7 +49,7 @@ namespace NUnit.Engine.Services
         /// <param name="outputPath"></param>
         public void CheckWritability(string outputPath)
         {
-            using ( new StreamWriter( outputPath, false ) )
+            using (new StreamWriter(outputPath, false))
             {
                 // We don't need to check if the XSLT file exists,
                 // that would have thrown in the constructor
@@ -58,7 +58,7 @@ namespace NUnit.Engine.Services
 
         public void WriteResultFile(XmlNode result, TextWriter writer)
         {
-            using (var xmlWriter = XmlWriter.Create(writer, new XmlWriterSettings {Indent = true, ConformanceLevel = ConformanceLevel.Auto}))
+            using (var xmlWriter = XmlWriter.Create(writer, new XmlWriterSettings { Indent = true, ConformanceLevel = ConformanceLevel.Auto }))
             {
                 _transform.Transform(result, xmlWriter);
             }
@@ -66,7 +66,7 @@ namespace NUnit.Engine.Services
 
         public void WriteResultFile(XmlNode result, string outputPath)
         {
-            using (var xmlWriter = XmlWriter.Create(outputPath, new XmlWriterSettings {Indent = true, ConformanceLevel = ConformanceLevel.Auto}))
+            using (var xmlWriter = XmlWriter.Create(outputPath, new XmlWriterSettings { Indent = true, ConformanceLevel = ConformanceLevel.Auto }))
             {
                 _transform.Transform(result, xmlWriter);
             }

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -15,7 +15,7 @@ namespace NUnit.Engine.Services
 {
     public class RuntimeFrameworkService : Service, IRuntimeFrameworkService, IAvailableRuntimes
     {
-        static readonly Logger log = InternalTrace.GetLogger(typeof(RuntimeFrameworkService));
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(RuntimeFrameworkService));
 
         private List<RuntimeFramework> _availableRuntimes = new List<RuntimeFramework>();
         private List<RuntimeFramework> _availableX86Runtimes = new List<RuntimeFramework>();
@@ -130,7 +130,7 @@ namespace NUnit.Engine.Services
             IRuntimeFramework currentFramework = CurrentFramework;
             log.Debug("Current framework is " + currentFramework);
 
-            string frameworkSetting = package.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
+            string frameworkSetting = package.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, string.Empty);
             bool runAsX86 = package.GetSetting(EnginePackageSettings.RunAsX86, false);
 
             if (frameworkSetting.Length > 0)
@@ -150,7 +150,7 @@ namespace NUnit.Engine.Services
 
             log.Debug($"No specific framework requested for {package.Name}");
 
-            string imageTargetFrameworkNameSetting = package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, "");
+            string imageTargetFrameworkNameSetting = package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty);
             Runtime targetRuntime;
             Version targetVersion;
 
@@ -305,7 +305,8 @@ namespace NUnit.Engine.Services
             for (int i = 0; i < 4; i++)
             {
                 string? dir = Path.GetDirectoryName(prefix);
-                if (string.IsNullOrEmpty(dir)) break;
+                if (string.IsNullOrEmpty(dir))
+                    break;
 
                 prefix = dir;
             }
@@ -358,12 +359,13 @@ namespace NUnit.Engine.Services
 
                     // Collect the highest version required
                     Version v = subPackage.GetSetting(EnginePackageSettings.ImageRuntimeVersion, new Version(0, 0));
-                    if (v > targetVersion) targetVersion = v;
+                    if (v > targetVersion)
+                        targetVersion = v;
 
                     // Collect highest framework name
                     // TODO: This assumes lexical ordering is valid - check it
-                    string fn = subPackage.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, "");
-                    if (fn != "")
+                    string fn = subPackage.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty);
+                    if (fn != string.Empty)
                     {
                         if (frameworkName == null || fn.CompareTo(frameworkName) < 0)
                             frameworkName = fn;

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetFxRuntimeLocator.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeLocators/NetFxRuntimeLocator.cs
@@ -26,7 +26,8 @@ namespace NUnit.Engine.Services.RuntimeLocators
                     if (name.StartsWith("v") && name != "v4.0") // v4.0 is a duplicate, legacy key
                     {
                         var versionKey = key.OpenSubKey(name);
-                        if (versionKey == null) continue;
+                        if (versionKey == null)
+                            continue;
 
                         if (name.StartsWith("v4", StringComparison.Ordinal))
                         {
@@ -88,7 +89,8 @@ namespace NUnit.Engine.Services.RuntimeLocators
             foreach (string profile in new string[] { "Full", "Client" })
             {
                 var profileKey = versionKey.OpenSubKey(profile);
-                if (profileKey == null) continue;
+                if (profileKey == null)
+                    continue;
 
                 if (CheckInstallDword(profileKey))
                 {
@@ -98,7 +100,6 @@ namespace NUnit.Engine.Services.RuntimeLocators
                     foreach (var entry in ReleaseTable)
                         if (release >= entry.Release)
                             yield return new RuntimeFramework(Runtime.Net, entry.Version);
-
 
                     yield break;     //If full profile found don't check for client profile
                 }

--- a/src/NUnitEngine/nunit.engine/Services/Service.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Service.cs
@@ -47,6 +47,8 @@ namespace NUnit.Engine.Services
 
         protected bool _disposed = false;
 
-        protected virtual void Dispose(bool disposing) { }
+        protected virtual void Dispose(bool disposing)
+        {
+        }
     }
 }

--- a/src/NUnitEngine/nunit.engine/Services/ServiceContext.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceContext.cs
@@ -19,7 +19,10 @@ namespace NUnit.Engine
 
         public ServiceManager ServiceManager { get; }
 
-        public int ServiceCount { get { return ServiceManager.ServiceCount; } }
+        public int ServiceCount
+        {
+            get { return ServiceManager.ServiceCount; }
+        }
 
         public void Add(IService service)
         {
@@ -27,7 +30,8 @@ namespace NUnit.Engine
             service.ServiceContext = this;
         }
 
-        public T GetService<T>() where T : class
+        public T GetService<T>()
+            where T : class
         {
             return (T)ServiceManager.GetService(typeof(T));
         }

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -15,22 +15,25 @@ namespace NUnit.Engine.Services
         private List<IService> _services = new List<IService>();
         private Dictionary<Type, IService> _serviceIndex = new Dictionary<Type, IService>();
 
-        static Logger log = InternalTrace.GetLogger(typeof(ServiceManager));
+        private static Logger log = InternalTrace.GetLogger(typeof(ServiceManager));
 
         public bool ServicesInitialized { get; private set; }
 
-        public int ServiceCount { get { return _services.Count; } }
+        public int ServiceCount
+        {
+            get { return _services.Count; }
+        }
 
-        public IService GetService( Type serviceType )
+        public IService GetService(Type serviceType)
         {
             IService? theService = null;
 
             if (_serviceIndex.ContainsKey(serviceType))
                 theService = _serviceIndex[serviceType];
             else
-                foreach( IService service in _services )
+                foreach (IService service in _services)
                 {
-                    if( serviceType.IsInstanceOfType( service ) )
+                    if (serviceType.IsInstanceOfType(service))
                     {
                         _serviceIndex[serviceType] = service;
                         theService = service;
@@ -58,7 +61,7 @@ namespace NUnit.Engine.Services
 
         public void StartServices()
         {
-            foreach( IService service in _services )
+            foreach (IService service in _services)
             {
                 if (service.Status == ServiceStatus.Stopped)
                 {
@@ -73,7 +76,7 @@ namespace NUnit.Engine.Services
                     catch (Exception ex)
                     {
                         // TODO: Should we pass this exception through?
-                        log.Error("Failed to initialize " + name );
+                        log.Error("Failed to initialize " + name);
                         log.Error(ex.ToString());
                         throw;
                     }

--- a/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestAgency.cs
@@ -56,7 +56,7 @@ namespace NUnit.Engine.Services
                 throw new InvalidOperationException("TestAgency needs to be Started first");
 
             // Target Runtime must be specified by this point
-            string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, "");
+            string runtimeSetting = package.GetSetting(EnginePackageSettings.TargetRuntimeFramework, string.Empty);
             Guard.OperationValid(runtimeSetting.Length > 0, "LaunchAgentProcess called with no runtime specified");
             bool runAsX86 = package.GetSetting(EnginePackageSettings.RunAsX86, false);
 
@@ -74,7 +74,7 @@ namespace NUnit.Engine.Services
 
             var agentId = Guid.NewGuid();
             var agentProcess = new AgentProcess(this, package, agentId);
-            var agentName = targetRuntime.Id + (runAsX86 ? "-x86" : "") + "-agent";
+            var agentName = targetRuntime.Id + (runAsX86 ? "-x86" : string.Empty) + "-agent";
             package.AddSetting("SelectedAgentName", agentName);
 
             agentProcess.Exited += (sender, e) => OnAgentExit((Process)sender!, agentId);

--- a/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestFilterBuilder.cs
@@ -49,7 +49,6 @@ namespace NUnit.Engine
                     filter.Append("</or>");
             }
 
-
             if (_whereClause != null)
                 filter.Append(TestSelectionParser.Parse(_whereClause));
 

--- a/src/NUnitEngine/nunit.engine/Services/TestRunnerFactory.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestRunnerFactory.cs
@@ -50,7 +50,7 @@ namespace NUnit.Engine.Services
             if (ServiceContext == null)
                 throw new InvalidOperationException("ServiceContext not set.");
 
-            if (package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, "").StartsWith("Unmanaged,"))
+            if (package.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, string.Empty).StartsWith("Unmanaged,"))
                 return new UnmanagedExecutableTestRunner(package.FullName ?? "Package Suite");
 
 #if NETFRAMEWORK

--- a/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
@@ -198,7 +198,8 @@ namespace NUnit.Engine
         {
             Token op = Expect(LPAREN, NOT_OP);
 
-            if (op == NOT_OP) Expect(LPAREN);
+            if (op == NOT_OP)
+                Expect(LPAREN);
 
             string result = ParseFilterExpression();
 

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -18,9 +18,13 @@ namespace NUnit.Engine
 
     public class Token
     {
-        public Token(TokenKind kind) : this(kind, string.Empty) { }
+        public Token(TokenKind kind) : this(kind, string.Empty)
+        {
+        }
 
-        public Token(TokenKind kind, char ch) : this(kind, ch.ToString()) { }
+        public Token(TokenKind kind, char ch) : this(kind, ch.ToString())
+        {
+        }
 
         public Token(TokenKind kind, string text)
         {
@@ -136,7 +140,7 @@ namespace NUnit.Engine
                 case '=':
                 case '!':
                     GetChar();
-                    foreach(string dbl in DOUBLE_CHAR_SYMBOLS)
+                    foreach (string dbl in DOUBLE_CHAR_SYMBOLS)
                         if (ch == dbl[0] && NextChar == dbl[1])
                         {
                             GetChar();

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -34,7 +34,7 @@ namespace NUnit.Engine
         {
             get
             {
-                if(!Services.ServiceManager.ServicesInitialized)
+                if (!Services.ServiceManager.ServicesInitialized)
                     Initialize();
 
                 return Services;
@@ -54,7 +54,7 @@ namespace NUnit.Engine
         /// </summary>
         public void Initialize()
         {
-            if(InternalTraceLevel != InternalTraceLevel.Off && !InternalTrace.Initialized)
+            if (InternalTraceLevel != InternalTraceLevel.Off && !InternalTrace.Initialized)
             {
                 var logName = string.Format("InternalTrace.{0}.log", Process.GetCurrentProcess().Id);
                 InternalTrace.Initialize(Path.Combine(WorkDirectory, logName), InternalTraceLevel);
@@ -88,7 +88,7 @@ namespace NUnit.Engine
         /// <returns>An ITestRunner.</returns>
         public ITestRunner GetRunner(TestPackage package)
         {
-            if(!Services.ServiceManager.ServicesInitialized)
+            if (!Services.ServiceManager.ServicesInitialized)
                 Initialize();
 
             return new Runners.MasterTestRunner(Services, package);

--- a/src/StyleCop.Analyzers.globalconfig
+++ b/src/StyleCop.Analyzers.globalconfig
@@ -1,0 +1,614 @@
+################################################################################
+#
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files#global-analyzerconfig
+# https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2019
+#
+################################################################################
+
+# Top level entry required to mark this as a global AnalyzerConfig file
+is_global = true
+
+############################################################################################
+# Style Analysis
+############################################################################################
+stylecop.naming.allowCommonHungarianPrefixes = false;
+stylecop.naming.allowedHungarianPrefixes =
+stylecop.naming.allowedNamespaceComponents
+stylecop.naming.includeInferredTupleElementNames = true
+stylecop.naming.tupleElementNameCasing = camelCase
+
+stylecop.layout.allowConsecutiveUsings = true
+stylecop.layout.allowDoWhileOnClosingBrace = false
+
+stylecop.documentation.documentExposedElements = true
+stylecop.documentation.documentInternalElements = false
+stylecop.documentation.documentPrivateElements = false
+stylecop.documentation.documentPrivateFields = false
+stylecop.documentation.documentInterfaces = false
+stylecop.documentation.documentationCulture = en-US
+stylecop.documentation.excludeFromPunctuationCheck =
+stylecop.documentation.fileNamingConvention = stylecop
+stylecop.documentation.xmlHeader = false
+
+# XML comment analysis disabled
+dotnet_diagnostic.SA0001.severity = none
+
+# Invalid settings file
+dotnet_diagnostic.SA0002.severity = none
+
+# Keywords should be spaced correctly
+dotnet_diagnostic.SA1000.severity = warning
+
+# Commas should be spaced correctly
+dotnet_diagnostic.SA1001.severity = warning
+
+# Semicolons should be spaced correctly
+dotnet_diagnostic.SA1002.severity = warning
+
+# Symbols should be spaced correctly
+dotnet_diagnostic.SA1003.severity = warning
+
+# Documentation lines should begin with single space
+dotnet_diagnostic.SA1004.severity = none
+
+# Single line comments should begin with single space
+dotnet_diagnostic.SA1005.severity = none
+
+# Preprocessor keywords should not be preceded by space
+dotnet_diagnostic.SA1006.severity = warning
+
+# Operator keyword should be followed by space
+dotnet_diagnostic.SA1007.severity = warning
+
+# Opening parenthesis should be spaced correctly
+dotnet_diagnostic.SA1008.severity = warning
+
+# Closing parenthesis should be spaced correctly
+dotnet_diagnostic.SA1009.severity = warning
+
+# Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = warning
+
+# Closing square brackets should be spaced correctly
+dotnet_diagnostic.SA1011.severity = warning
+
+# Opening braces should be spaced correctly
+dotnet_diagnostic.SA1012.severity = warning
+
+# Closing braces should be spaced correctly
+dotnet_diagnostic.SA1013.severity = warning
+
+# Opening generic brackets should be spaced correctly
+dotnet_diagnostic.SA1014.severity = warning
+
+# Closing generic brackets should be spaced correctly
+dotnet_diagnostic.SA1015.severity = warning
+
+# Opening attribute brackets should be spaced correctly
+dotnet_diagnostic.SA1016.severity = warning
+
+# Closing attribute brackets should be spaced correctly
+dotnet_diagnostic.SA1017.severity = warning
+
+# Nullable type symbols should be spaced correctly
+dotnet_diagnostic.SA1018.severity = warning
+
+# Member access symbols should be spaced correctly
+dotnet_diagnostic.SA1019.severity = warning
+
+# Increment decrement symbols should be spaced correctly
+dotnet_diagnostic.SA1020.severity = warning
+
+# Negative signs should be spaced correctly
+dotnet_diagnostic.SA1021.severity = warning
+
+# Positive signs should be spaced correctly
+dotnet_diagnostic.SA1022.severity = warning
+
+# Dereference and access of symbols should be spaced correctly
+dotnet_diagnostic.SA1023.severity = warning
+
+# Colons should be spaced correctly
+dotnet_diagnostic.SA1024.severity = warning
+
+# Code should not contain multiple whitespace in a row
+dotnet_diagnostic.SA1025.severity = warning
+
+# Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+dotnet_diagnostic.SA1026.severity = warning
+
+# Use tabs correctly
+dotnet_diagnostic.SA1027.severity = warning
+
+# Code should not contain trailing whitespace
+dotnet_diagnostic.SA1028.severity = warning
+
+# Do not prefix calls with base unless local implementation exists
+dotnet_diagnostic.SA1100.severity = none
+
+# Prefix local calls with this
+dotnet_diagnostic.SA1101.severity = none
+
+# Do not prefix local member with this
+dotnet_diagnostic.SX1101.severity = none
+
+# Query clause should follow previous clause
+dotnet_diagnostic.SA1102.severity = warning
+
+# Query clauses should be on separate lines or all on one line
+dotnet_diagnostic.SA1103.severity = warning
+
+# Query clause should begin on new line when previous clause spans multiple lines
+dotnet_diagnostic.SA1104.severity = warning
+
+# Query clauses spanning multiple lines should begin on own line
+dotnet_diagnostic.SA1105.severity = warning
+
+# Code should not contain empty statements
+dotnet_diagnostic.SA1106.severity = none
+
+# Code should not contain multiple statements on one line
+dotnet_diagnostic.SA1107.severity = warning
+
+# Block statements should not contain embedded comments
+dotnet_diagnostic.SA1108.severity = none
+
+# Block statements should not contain embedded regions
+dotnet_diagnostic.SA1109.severity = warning
+
+# Opening parenthesis or bracket should be on declaration line
+dotnet_diagnostic.SA1110.severity = none
+
+# Closing parenthesis should be on line of last parameter
+dotnet_diagnostic.SA1111.severity = none
+
+# Closing parenthesis should be on line of opening parenthesis
+dotnet_diagnostic.SA1112.severity = none
+
+# Comma should be on the same line as previous parameter
+dotnet_diagnostic.SA1113.severity = none
+
+# Parameter list should follow declaration
+dotnet_diagnostic.SA1114.severity = none
+
+# Parameter should follow comma
+dotnet_diagnostic.SA1115.severity = none
+
+# Split parameters should start on line after declaration
+dotnet_diagnostic.SA1116.severity = none
+
+# Parameters should be on same line or separate lines
+dotnet_diagnostic.SA1117.severity = none
+
+# Parameter should not span multiple lines
+dotnet_diagnostic.SA1118.severity = none
+
+# Statement should not use unnecessary parenthesis
+dotnet_diagnostic.SA1119.severity = none
+
+# Comments should contain text
+dotnet_diagnostic.SA1120.severity = none
+
+# Use built-in type alias
+dotnet_diagnostic.SA1121.severity = none
+
+# Use string.Empty for empty strings
+dotnet_diagnostic.SA1122.severity = warning
+
+# Do not place regions within elements
+dotnet_diagnostic.SA1123.severity = none
+
+# Do not use regions
+dotnet_diagnostic.SA1124.severity = none
+
+# Use shorthand for nullable types
+dotnet_diagnostic.SA1125.severity = none
+
+# Prefix calls correctly
+dotnet_diagnostic.SA1126.severity = none
+
+# Generic type constraints should be on their own line
+dotnet_diagnostic.SA1127.severity = warning
+
+# Put constructor initializers on their own line
+dotnet_diagnostic.SA1128.severity = none
+
+# Do not use default value type constructor
+dotnet_diagnostic.SA1129.severity = none
+
+# Use lambda syntax
+dotnet_diagnostic.SA1130.severity = none
+
+# Use readable conditions
+dotnet_diagnostic.SA1131.severity = none
+
+# Do not combine fields
+dotnet_diagnostic.SA1132.severity = none
+
+# Do not combine attributes
+dotnet_diagnostic.SA1133.severity = none
+
+# Attributes should not share line
+dotnet_diagnostic.SA1134.severity = none
+
+# Using directives should be qualified
+dotnet_diagnostic.SA1135.severity = none
+
+# Enum values should be on separate lines
+dotnet_diagnostic.SA1136.severity = none
+
+# Elements should have the same indentation
+dotnet_diagnostic.SA1137.severity = warning
+
+# Use literal suffix notation instead of casting
+dotnet_diagnostic.SA1139.severity = none
+
+# Using directives should be placed correctly
+dotnet_diagnostic.SA1200.severity = none
+
+# Elements should appear in the correct order
+dotnet_diagnostic.SA1201.severity = none
+
+# Elements should be ordered by access
+dotnet_diagnostic.SA1202.severity = none
+
+# Constants should appear before fields
+dotnet_diagnostic.SA1203.severity = none
+
+# Static elements should appear before instance elements
+dotnet_diagnostic.SA1204.severity = none
+
+# Partial elements should declare access
+dotnet_diagnostic.SA1205.severity = none
+
+# Declaration keywords should follow order
+dotnet_diagnostic.SA1206.severity = none
+
+# Protected should come before internal
+dotnet_diagnostic.SA1207.severity = none
+
+# System using directives should be placed before other using directives
+dotnet_diagnostic.SA1208.severity = none
+
+# Using alias directives should be placed after other using directives
+dotnet_diagnostic.SA1209.severity = none
+
+# Using directives should be ordered alphabetically by namespace
+dotnet_diagnostic.SA1210.severity = none
+
+# Using alias directives should be ordered alphabetically by alias name
+dotnet_diagnostic.SA1211.severity = none
+
+# Property accessors should follow order
+dotnet_diagnostic.SA1212.severity = none
+
+# Event accessors should follow order
+dotnet_diagnostic.SA1213.severity = none
+
+# Readonly fields should appear before non-readonly fields
+dotnet_diagnostic.SA1214.severity = none
+
+# Using static directives should be placed at the correct location
+dotnet_diagnostic.SA1216.severity = none
+
+# Using static directives should be ordered alphabetically
+dotnet_diagnostic.SA1217.severity = none
+
+# Element should begin with upper-case letter
+dotnet_diagnostic.SA1300.severity = none
+
+# Element should begin with lower-case letter
+dotnet_diagnostic.SA1301.severity = none
+
+# Interface names should begin with I
+dotnet_diagnostic.SA1302.severity = none
+
+# Const field names should begin with upper-case letter
+dotnet_diagnostic.SA1303.severity = none
+
+# Non-private readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1304.severity = none
+
+# Field names should not use Hungarian notation
+dotnet_diagnostic.SA1305.severity = none
+
+# Field names should begin with lower-case letter
+dotnet_diagnostic.SA1306.severity = none
+
+# Accessible fields should begin with upper-case letter
+dotnet_diagnostic.SA1307.severity = none
+
+# Variable names should not be prefixed
+dotnet_diagnostic.SA1308.severity = none
+
+# Field names should not begin with underscore
+dotnet_diagnostic.SA1309.severity = none
+
+# Field names should not contain underscore
+dotnet_diagnostic.SA1310.severity = none
+
+# Static readonly fields should begin with upper-case letter
+dotnet_diagnostic.SA1311.severity = none
+
+# Variable names should begin with lower-case letter
+dotnet_diagnostic.SA1312.severity = none
+
+# Parameter names should begin with lower-case letter
+dotnet_diagnostic.SA1313.severity = none
+
+# Type parameter names should begin with T
+dotnet_diagnostic.SA1314.severity = warning
+
+# Tuple element names should use correct casing
+dotnet_diagnostic.SA1316.severity = none
+
+# Access modifier should be declared
+dotnet_diagnostic.SA1400.severity = warning
+
+# Fields should be private
+dotnet_diagnostic.SA1401.severity = none
+
+# File may only contain a single type
+dotnet_diagnostic.SA1402.severity = none
+
+# File may only contain a single namespace
+dotnet_diagnostic.SA1403.severity = none
+
+# Code analysis suppression should have justification
+dotnet_diagnostic.SA1404.severity = none
+
+# Debug.Assert should provide message text
+dotnet_diagnostic.SA1405.severity = none
+
+# Debug.Fail should provide message text
+dotnet_diagnostic.SA1406.severity = none
+
+# Arithmetic expressions should declare precedence
+dotnet_diagnostic.SA1407.severity = none
+
+# Conditional expressions should declare precedence
+dotnet_diagnostic.SA1408.severity = none
+
+# Remove unnecessary code
+dotnet_diagnostic.SA1409.severity = none
+
+# Remove delegate parenthesis when possible
+dotnet_diagnostic.SA1410.severity = none
+
+# Attribute constructor should not use unnecessary parenthesis
+dotnet_diagnostic.SA1411.severity = none
+
+# Store files as UTF-8 with byte order mark
+dotnet_diagnostic.SA1412.severity = none
+
+# Use trailing comma in multi-line initializers
+dotnet_diagnostic.SA1413.severity = none
+
+# Tuple types in signatures should have element names
+dotnet_diagnostic.SA1414.severity = none
+
+# Braces for multi-line statements should not share line
+dotnet_diagnostic.SA1500.severity = warning
+
+# Statement should not be on a single line
+dotnet_diagnostic.SA1501.severity = warning
+
+# Element should not be on a single line
+dotnet_diagnostic.SA1502.severity = warning
+
+# Braces should not be omitted
+dotnet_diagnostic.SA1503.severity = none
+
+# All accessors should be single-line or multi-line
+dotnet_diagnostic.SA1504.severity = none
+
+# Opening braces should not be followed by blank line
+dotnet_diagnostic.SA1505.severity = warning
+
+# Element documentation headers should not be followed by blank line
+dotnet_diagnostic.SA1506.severity = warning
+
+# Code should not contain multiple blank lines in a row
+dotnet_diagnostic.SA1507.severity = warning
+
+# Closing braces should not be preceded by blank line
+dotnet_diagnostic.SA1508.severity = warning
+
+# Opening braces should not be preceded by blank line
+dotnet_diagnostic.SA1509.severity = warning
+
+# Chained statement blocks should not be preceded by blank line
+dotnet_diagnostic.SA1510.severity = warning
+
+# While-do footer should not be preceded by blank line
+dotnet_diagnostic.SA1511.severity = none
+
+# Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = none
+
+# Closing brace should be followed by blank line
+dotnet_diagnostic.SA1513.severity = none
+
+# Element documentation header should be preceded by blank line
+dotnet_diagnostic.SA1514.severity = none
+
+# Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = none
+
+# Elements should be separated by blank line
+dotnet_diagnostic.SA1516.severity = none
+
+# Code should not contain blank lines at start of file
+dotnet_diagnostic.SA1517.severity = warning
+
+# Use line endings correctly at end of file
+dotnet_diagnostic.SA1518.severity = warning
+
+# Braces should not be omitted from multi-line child statement
+dotnet_diagnostic.SA1519.severity = none
+
+# Use braces consistently
+dotnet_diagnostic.SA1520.severity = none
+
+# Elements should be documented
+dotnet_diagnostic.SA1600.severity = none
+
+# Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = none
+
+# Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = none
+
+# Documentation should contain valid XML
+dotnet_diagnostic.SA1603.severity = none
+
+# Element documentation should have summary
+dotnet_diagnostic.SA1604.severity = none
+
+# Partial element documentation should have summary
+dotnet_diagnostic.SA1605.severity = none
+
+# Element documentation should have summary text
+dotnet_diagnostic.SA1606.severity = none
+
+# Partial element documentation should have summary text
+dotnet_diagnostic.SA1607.severity = none
+
+# Element documentation should not have default summary
+dotnet_diagnostic.SA1608.severity = none
+
+# Property documentation should have value
+dotnet_diagnostic.SA1609.severity = none
+
+# Property documentation should have value text
+dotnet_diagnostic.SA1610.severity = none
+
+# Element parameters should be documented
+dotnet_diagnostic.SA1611.severity = none
+
+# Element parameter documentation should match element parameters
+dotnet_diagnostic.SA1612.severity = none
+
+# Element parameter documentation should declare parameter name
+dotnet_diagnostic.SA1613.severity = none
+
+# Element parameter documentation should have text
+dotnet_diagnostic.SA1614.severity = none
+
+# Element return value should be documented
+dotnet_diagnostic.SA1615.severity = none
+
+# Element return value documentation should have text
+dotnet_diagnostic.SA1616.severity = none
+
+# Void return value should not be documented
+dotnet_diagnostic.SA1617.severity = none
+
+# Generic type parameters should be documented
+dotnet_diagnostic.SA1618.severity = none
+
+# Generic type parameters should be documented partial class
+dotnet_diagnostic.SA1619.severity = none
+
+# Generic type parameter documentation should match type parameters
+dotnet_diagnostic.SA1620.severity = none
+
+# Generic type parameter documentation should declare parameter name
+dotnet_diagnostic.SA1621.severity = none
+
+# Generic type parameter documentation should have text
+dotnet_diagnostic.SA1622.severity = none
+
+# Property summary documentation should match accessors
+dotnet_diagnostic.SA1623.severity = none
+
+# Property summary documentation should omit accessor with restricted access
+dotnet_diagnostic.SA1624.severity = none
+
+# Element documentation should not be copied and pasted
+dotnet_diagnostic.SA1625.severity = none
+
+# Single-line comments should not use documentation style slashes
+dotnet_diagnostic.SA1626.severity = none
+
+# Documentation text should not be empty
+dotnet_diagnostic.SA1627.severity = none
+
+# Documentation text should begin with a capital letter
+dotnet_diagnostic.SA1628.severity = none
+
+# Documentation text should end with a period
+dotnet_diagnostic.SA1629.severity = none
+
+# Documentation text should contain whitespace
+dotnet_diagnostic.SA1630.severity = none
+
+# Documentation should meet character percentage
+dotnet_diagnostic.SA1631.severity = none
+
+# Documentation text should meet minimum character length
+dotnet_diagnostic.SA1632.severity = none
+
+# File should have header
+dotnet_diagnostic.SA1633.severity = none
+
+# File header should show copyright
+dotnet_diagnostic.SA1634.severity = none
+
+# File header should have copyright text
+dotnet_diagnostic.SA1635.severity = none
+
+# File header copyright text should match
+dotnet_diagnostic.SA1636.severity = none
+
+# File header should contain file name
+dotnet_diagnostic.SA1637.severity = none
+
+# File header file name documentation should match file name
+dotnet_diagnostic.SA1638.severity = none
+
+# File header should have summary
+dotnet_diagnostic.SA1639.severity = none
+
+# File header should have valid company text
+dotnet_diagnostic.SA1640.severity = none
+
+# File header company name text should match
+dotnet_diagnostic.SA1641.severity = none
+
+# Constructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1642.severity = none
+
+# Destructor summary documentation should begin with standard text
+dotnet_diagnostic.SA1643.severity = none
+
+# Documentation headers should not contain blank lines
+dotnet_diagnostic.SA1644.severity = none
+
+# Included documentation file does not exist
+dotnet_diagnostic.SA1645.severity = none
+
+# Included documentation XPath does not exist
+dotnet_diagnostic.SA1646.severity = none
+
+# Include node does not contain valid file and path
+dotnet_diagnostic.SA1647.severity = none
+
+# Inheritdoc should be used with inheriting class
+dotnet_diagnostic.SA1648.severity = none
+
+# File name should match first type name
+dotnet_diagnostic.SA1649.severity = none
+
+# Element documentation should be spelled correctly
+dotnet_diagnostic.SA1650.severity = none
+
+# Do not use placeholder elements
+dotnet_diagnostic.SA1651.severity = none
+
+# Field names should begin with underscore
+dotnet_diagnostic.SX1309.severity = none
+
+# Static field names should begin with underscore
+dotnet_diagnostic.SX1309S.severity = none
+

--- a/src/TestData/InvalidTestNames/InvalidTestNames.cs
+++ b/src/TestData/InvalidTestNames/InvalidTestNames.cs
@@ -15,7 +15,7 @@ namespace InvalidTestNames
         // Generates test name TestContainsInvalidCharacter("\uffff");
         [TestCase(char.MaxValue)]
         public void TestNameContainsInvalidChar(char c)
-        { 
+        {
             Console.WriteLine($"Test for char {c}");
         }
     }

--- a/src/TestData/NUnit3.0.1/Class1.cs
+++ b/src/TestData/NUnit3.0.1/Class1.cs
@@ -8,6 +8,9 @@ namespace NUnit.Engine.TestData
     public class NUnit_3_0_1_Test
     {
         [Test]
-        public void Test() { Assert.Pass("test passes"); }
+        public void Test()
+        {
+            Assert.Pass("test passes");
+        }
     }
 }

--- a/src/TestData/NUnit3.0/NUnit_3_0_Test.cs
+++ b/src/TestData/NUnit3.0/NUnit_3_0_Test.cs
@@ -8,6 +8,9 @@ namespace NUnit.Engine.TestData
     public class NUnit_3_0_Test
     {
         [Test]
-        public void Test() { Assert.Pass("test passes"); }
+        public void Test()
+        {
+            Assert.Pass("test passes");
+        }
     }
 }

--- a/src/TestData/NUnit3.10/NUnit_3_10_Test.cs
+++ b/src/TestData/NUnit3.10/NUnit_3_10_Test.cs
@@ -8,6 +8,9 @@ namespace NUnit.Engine.TestData
     public class NUnit_3_10_Test
     {
         [Test]
-        public void Test() { Assert.Pass("test passes"); }
+        public void Test()
+        {
+            Assert.Pass("test passes");
+        }
     }
 }

--- a/src/TestData/NUnit3.2/NUnit_3_2_Test.cs
+++ b/src/TestData/NUnit3.2/NUnit_3_2_Test.cs
@@ -8,6 +8,9 @@ namespace NUnit.Engine.TestData
     public class NUnit_3_2_Test
     {
         [Test]
-        public void Test() { Assert.Pass("test passes"); }
+        public void Test()
+        {
+            Assert.Pass("test passes");
+        }
     }
 }

--- a/src/TestData/WpfApp/Program.cs
+++ b/src/TestData/WpfApp/Program.cs
@@ -12,6 +12,8 @@ namespace WpfApp
 {
     internal class Program
     {
-        static void Main() { }
+        private static void Main()
+        {
+        }
     }
 }

--- a/src/TestData/mock-assembly/AccessesCurrentTestContextDuringDiscovery.cs
+++ b/src/TestData/mock-assembly/AccessesCurrentTestContextDuringDiscovery.cs
@@ -16,9 +16,13 @@ namespace NUnit.TestData
         }
 
         [TestCaseSource(nameof(TestCases))]
-        public void Access_by_TestCaseSource(int arg) { }
+        public void Access_by_TestCaseSource(int arg)
+        {
+        }
 
         [Test]
-        public void Access_by_ValueSource([ValueSource(nameof(TestCases))] int arg) { }
+        public void Access_by_ValueSource([ValueSource(nameof(TestCases))] int arg)
+        {
+        }
     }
 }

--- a/src/TestData/mock-assembly/MockAssembly.cs
+++ b/src/TestData/mock-assembly/MockAssembly.cs
@@ -119,10 +119,14 @@ namespace NUnit.TestData
             [Test(Description="Mock Test #1")]
             [Category("MockCategory")]
             [Property("Severity", "Critical")]
-            public void TestWithDescription() { }
+            public void TestWithDescription()
+            {
+            }
 
             [Test]
-            protected static void NonPublicTest() { }
+            protected static void NonPublicTest()
+            {
+            }
 
             [Test]
             public void FailingTest()
@@ -138,13 +142,19 @@ namespace NUnit.TestData
             }
 
             [Test, Ignore("Ignore Message")]
-            public void IgnoreTest() { }
+            public void IgnoreTest()
+            {
+            }
 
             [Test, Explicit]
-            public void ExplicitTest() { }
+            public void ExplicitTest()
+            {
+            }
 
             [Test]
-            public void NotRunnableTest( int a, int b) { }
+            public void NotRunnableTest(int a, int b)
+            {
+            }
 
             [Test]
             public void InconclusiveTest()
@@ -175,7 +185,8 @@ namespace NUnit.TestData
 
             [Test]
             public virtual void TestCase()
-            {}
+            {
+            }
         }
     }
 
@@ -201,16 +212,22 @@ namespace NUnit.TestData
         public const int Suites = 1;
 
         [Test]
-        public void Test1() { }
+        public void Test1()
+        {
+        }
 
         [Test]
-        public void Test2() { }
+        public void Test2()
+        {
+        }
 
         [Test]
-        public void Test3() { }
+        public void Test3()
+        {
+        }
     }
 
-    [TestFixture,Explicit]
+    [TestFixture, Explicit]
     public class ExplicitFixture
     {
         public const int Tests = 2;
@@ -218,10 +235,14 @@ namespace NUnit.TestData
         public const int Nodes = Tests + Suites;
 
         [Test]
-        public void Test1() { }
+        public void Test1()
+        {
+        }
 
         [Test]
-        public void Test2() { }
+        public void Test2()
+        {
+        }
     }
 
     [TestFixture]
@@ -230,10 +251,14 @@ namespace NUnit.TestData
         public const int Tests = 1;
         public const int Suites = 1;
 
-        public BadFixture(int val) { }
+        public BadFixture(int val)
+        {
+        }
 
         [Test]
-        public void SomeTest() { }
+        public void SomeTest()
+        {
+        }
     }
 
     [TestFixture]
@@ -246,7 +271,7 @@ namespace NUnit.TestData
         [TestCase(9, 11, ExpectedResult=20)]
         public int MethodWithParameters(int x, int y)
         {
-            return x+y;
+            return x + y;
         }
 
         [TestCase(2, 4)]
@@ -263,13 +288,19 @@ namespace NUnit.TestData
         public const int Tests = 4;
         public const int Suites = 3;
 
-        public ParameterizedFixture(int num) { }
+        public ParameterizedFixture(int num)
+        {
+        }
 
         [Test]
-        public void Test1() { }
+        public void Test1()
+        {
+        }
 
         [Test]
-        public void Test2() { }
+        public void Test2()
+        {
+        }
     }
 
     public class GenericFixtureConstants
@@ -282,13 +313,19 @@ namespace NUnit.TestData
     [TestFixture(11.5)]
     public class GenericFixture<T>
     {
-        public GenericFixture(T num){ }
+        public GenericFixture(T num)
+        {
+        }
 
         [Test]
-        public void Test1() { }
+        public void Test1()
+        {
+        }
 
         [Test]
-        public void Test2() { }
+        public void Test2()
+        {
+        }
     }
 
     [TestFixture]
@@ -298,10 +335,14 @@ namespace NUnit.TestData
         public const int Tests = 2;
 
         [Test]
-        public void Test1() { }
+        public void Test1()
+        {
+        }
 
         [Test]
-        public void Test2() { }
+        public void Test2()
+        {
+        }
 
         public void Dispose()
         {
@@ -316,10 +357,14 @@ namespace NUnit.TestData
         public const int Tests = 2;
 
         [Test]
-        public void Test1() { }
+        public void Test1()
+        {
+        }
 
         [Test]
-        public void Test2() { }
+        public void Test2()
+        {
+        }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
@@ -347,14 +392,18 @@ namespace NUnit.TestData
         public class Fixture1
         {
             [Test]
-            public void Test1() { }
+            public void Test1()
+            {
+            }
         }
 
         [TestFixture]
         public class Fixture2
         {
             [Test]
-            public void Test1() { }
+            public void Test1()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Partly addresses #1590 

Settings are taken from nunit framework project.

With the following exceptions:
1. Braces are optional as per your preferences.
2. The this. prefix is not defined yet.
    We can either leave it, or enforce the use of 'this.' or deny the the use of 'this.'.
    The latter has my preference.
