### PR TITLE
Enable Minimum .NET Analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,8 @@ indent_size = 4
 [*.{proj,csproj,vcxproj,xproj,json,config,nuspec,xml,yml}]
 indent_style = space
 indent_size = 2
+
+[*.cs]
+# This relates to classes that have finalizers, but we should not have any finalizer
+# CA1816: Dispose methods should call SuppressFinalize
+dotnet_diagnostic.CA1816.severity = none

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,9 @@
         <LangVersion>12</LangVersion>
         <Features>strict</Features>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisMode>Minimum</AnalysisMode>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <Version Condition="'$(Version)'==''">4.0.0.0</Version>
         <OutputPath>$(MSBuildThisFileDirectory)\..\bin\$(Configuration)\</OutputPath>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/src/NUnitCommon/nunit.agent.core.tests/AgentOptionTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/AgentOptionTests.cs
@@ -25,7 +25,7 @@ namespace NUnit.Agents
             var options = new AgentOptions();
             var prop = typeof(AgentOptions).GetProperty(propertyName);
             Assert.That(prop, Is.Not.Null, $"Property {propertyName} does not exist");
-            Assert.That(prop.GetValue(options, new object[0]), Is.EqualTo(defaultValue));
+            Assert.That(prop.GetValue(options, Array.Empty<object>()), Is.EqualTo(defaultValue));
         }
 
         static readonly Guid AGENT_GUID = Guid.NewGuid();
@@ -53,7 +53,7 @@ namespace NUnit.Agents
             var options = new AgentOptions(option);
             var prop = typeof(AgentOptions).GetProperty(propertyName);
             Assert.That(prop, Is.Not.Null, $"Property {propertyName} does not exist");
-            Assert.That(prop.GetValue(options, new object[0]), Is.EqualTo(expectedValue));
+            Assert.That(prop.GetValue(options, Array.Empty<object>()), Is.EqualTo(expectedValue));
         }
 
         [Test]

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/DomainManagerTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/DomainManagerTests.cs
@@ -71,7 +71,7 @@ namespace NUnit.Engine.Runners
         public void CanUnloadDomain()
         {
             var domain = _domainManager.CreateDomain(_package);
-            _domainManager.Unload(domain);
+            DomainManager.Unload(domain);
 
             CheckDomainIsUnloaded(domain);
         }
@@ -80,14 +80,14 @@ namespace NUnit.Engine.Runners
         public void UnloadingTwiceThrowsNUnitEngineUnloadException()
         {
             var domain = _domainManager.CreateDomain(_package);
-            _domainManager.Unload(domain);
+            DomainManager.Unload(domain);
 
-            Assert.That(() => _domainManager.Unload(domain), Throws.TypeOf<NUnitEngineUnloadException>());
+            Assert.That(() => DomainManager.Unload(domain), Throws.TypeOf<NUnitEngineUnloadException>());
 
             CheckDomainIsUnloaded(domain);
         }
 
-        private void CheckDomainIsUnloaded(AppDomain domain)
+        private static void CheckDomainIsUnloaded(AppDomain domain)
         {
             // HACK: Either the Assert will succeed or the
             // exception should be thrown.

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerTests.cs
@@ -91,26 +91,26 @@ namespace NUnit.Engine.Runners
                 Assert.That(_runner.IsPackageLoaded, Is.False, "Package should not be loaded automatically");
         }
 
-        private void CheckBasicResult(TestEngineResult result)
+        private static void CheckBasicResult(TestEngineResult result)
         {
             foreach (var node in result.XmlNodes)
                 CheckBasicResult(node);
         }
 
-        private void CheckBasicResult(XmlNode node)
+        private static void CheckBasicResult(XmlNode node)
         {
             Assert.That(node.Name, Is.EqualTo("test-suite"));
             Assert.That(node.GetAttribute("testcasecount", 0), Is.EqualTo(MockAssembly.Tests));
             Assert.That(node.GetAttribute("runstate"), Is.EqualTo("Runnable"));
         }
 
-        private void CheckRunResult(TestEngineResult result)
+        private static void CheckRunResult(TestEngineResult result)
         {
             foreach (var node in result.XmlNodes)
                 CheckRunResult(node);
         }
 
-        private void CheckRunResult(XmlNode result)
+        private static void CheckRunResult(XmlNode result)
         {
             CheckBasicResult(result);
             Assert.That(result.GetAttribute("passed", 0), Is.EqualTo(MockAssembly.PassedInAttribute));

--- a/src/NUnitCommon/nunit.agent.core/Agents/RemoteTestAgent.cs
+++ b/src/NUnitCommon/nunit.agent.core/Agents/RemoteTestAgent.cs
@@ -26,8 +26,6 @@ namespace NUnit.Engine.Agents
 
         public ITestAgentTransport? Transport;
 
-        public int ProcessId => System.Diagnostics.Process.GetCurrentProcess().Id;
-
         public override bool Start()
         {
             Guard.OperationValid(Transport != null, "Transport must be set before calling Start().");

--- a/src/NUnitCommon/nunit.agent.core/Communication/Transports/Tcp/TestAgentTcpTransport.cs
+++ b/src/NUnitCommon/nunit.agent.core/Communication/Transports/Tcp/TestAgentTcpTransport.cs
@@ -17,6 +17,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
     public class TestAgentTcpTransport : ITestAgentTransport, ITestEventListener
     {
         private static readonly Logger log = InternalTrace.GetLogger(typeof(TestAgentTcpTransport));
+        private static readonly char[] PortSeparator = [':'];
 
         private readonly string _agencyUrl;
         private Socket? _clientSocket;
@@ -30,7 +31,7 @@ namespace NUnit.Engine.Communication.Transports.Tcp
             Guard.ArgumentNotNullOrEmpty(serverUrl, nameof(serverUrl));
             _agencyUrl = serverUrl;
 
-            var parts = serverUrl.Split(new char[] { ':' });
+            var parts = serverUrl.Split(PortSeparator);
             Guard.ArgumentValid(parts.Length == 2, "Invalid server address specified. Must be a valid endpoint including the port number", nameof(serverUrl));
             ServerEndPoint = new IPEndPoint(IPAddress.Parse(parts[0]), int.Parse(parts[1]));
         }

--- a/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
@@ -19,7 +19,7 @@ namespace NUnit.Engine.Drivers
 
         private static readonly char[] CommaSeparator = [','];
 
-        readonly IList<IDriverFactory> _factories = new List<IDriverFactory>();
+        readonly List<IDriverFactory> _factories = new List<IDriverFactory>();
 
         public DriverService()
         {

--- a/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
@@ -17,6 +17,8 @@ namespace NUnit.Engine.Drivers
     {
         static readonly Logger log = InternalTrace.GetLogger("DriverService");
 
+        private static readonly char[] CommaSeparator = [','];
+
         readonly IList<IDriverFactory> _factories = new List<IDriverFactory>();
 
         public DriverService()
@@ -63,7 +65,7 @@ namespace NUnit.Engine.Drivers
                 // any true Portable assembly would have a Profile as part of its name.
                 var platform = targetFramework == ".NETPortable,Version=v5.0"
                     ? ".NETStandard"
-                    : targetFramework.Split(new char[] { ',' })[0];
+                    : targetFramework.Split(CommaSeparator)[0];
 
                 if (platform == "Silverlight" || platform == ".NETPortable" || platform == ".NETStandard" || platform == ".NETCompactFramework")
                     if (skipNonTestAssemblies)

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnit2DriverFactory.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnit2DriverFactory.cs
@@ -45,7 +45,7 @@ namespace NUnit.Engine.Drivers
         public IFrameworkDriver GetDriver(AppDomain domain, string id, AssemblyName reference)
         {
             if (!IsSupportedTestFramework(reference))
-                throw new ArgumentException("Invalid framework", "reference");
+                throw new ArgumentException("Invalid framework", nameof(reference));
 
             if (!_resolverInstalled)
             {

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnit3DriverFactory.cs
@@ -31,7 +31,7 @@ namespace NUnit.Engine.Drivers
         public IFrameworkDriver GetDriver(AppDomain domain, string id, AssemblyName reference)
         {
             Guard.ArgumentNotNullOrEmpty(id, nameof(id));
-            Guard.ArgumentValid(IsSupportedTestFramework(reference), "Invalid framework", "reference");
+            Guard.ArgumentValid(IsSupportedTestFramework(reference), "Invalid framework", nameof(reference));
 
             log.Info("Using NUnitFrameworkDriver");
             return new NUnitFrameworkDriver(domain, id, reference);

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
@@ -55,8 +55,7 @@ namespace NUnit.Engine.Drivers
                 _testAssemblyPath = testAssemblyPath;
 
                 // Normally, the caller should check for an invalid requested runtime, but we make sure here
-                var requestedRuntime = settings.ContainsKey(EnginePackageSettings.RequestedRuntimeFramework)
-                    ? settings[EnginePackageSettings.RequestedRuntimeFramework] : null;
+                settings.TryGetValue(EnginePackageSettings.RequestedRuntimeFramework, out object? requestedRuntime);
 
                 var idPrefix = _driverId + "-";
 

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
@@ -48,7 +48,7 @@ namespace NUnit.Engine.Drivers
 
             public string Load(string testAssemblyPath, IDictionary<string, object> settings)
             {
-                Guard.ArgumentValid(File.Exists(testAssemblyPath), "Framework driver called with a file name that doesn't exist.", "testAssemblyPath");
+                Guard.ArgumentValid(File.Exists(testAssemblyPath), "Framework driver called with a file name that doesn't exist.", nameof(testAssemblyPath));
 
                 log.Info($"Loading {testAssemblyPath} - see separate log file");
 

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
@@ -17,9 +17,9 @@ namespace NUnit.Engine.Drivers
         static readonly Version MINIMUM_NUNIT_VERSION = new(3, 2, 0);
         static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkDriver));
 
+#if NETFRAMEWORK
         readonly NUnitFrameworkApi _api;
 
-#if NETFRAMEWORK
         /// <summary>
         /// Construct an NUnitFrameworkDriver
         /// </summary>
@@ -82,6 +82,8 @@ namespace NUnit.Engine.Drivers
                 : new NUnitFrameworkApi2009(testDomain, ID, nunitRef);
         }
 #else
+        readonly NUnitFrameworkApi2018 _api;
+
         /// <summary>
         /// Construct an NUnitFrameworkDriver
         /// </summary>

--- a/src/NUnitCommon/nunit.agent.core/NUnitAgent.cs
+++ b/src/NUnitCommon/nunit.agent.core/NUnitAgent.cs
@@ -19,7 +19,11 @@ namespace NUnit.Agents
     {
         static Process? AgencyProcess;
         static RemoteTestAgent? Agent;
+#if NET6_0_OR_GREATER
+        static readonly int _pid = Environment.ProcessId;
+#else
         static readonly int _pid = Process.GetCurrentProcess().Id;
+#endif
         static readonly Logger log = InternalTrace.GetLogger(typeof(TestAgent));
 
         /// <summary>

--- a/src/NUnitCommon/nunit.agent.core/RunTestsCallbackHandler.cs
+++ b/src/NUnitCommon/nunit.agent.core/RunTestsCallbackHandler.cs
@@ -41,7 +41,7 @@ namespace NUnit.Engine
             _listener.OnTestEvent(state);
         }
 
-        private bool IsFinalResult(string eventArgument)
+        private static bool IsFinalResult(string eventArgument)
         {
             // TODO: If we add a prefix to the final result in the next framework
             // release, then we can immediately recognize the final result but we

--- a/src/NUnitCommon/nunit.agent.core/Runners/DomainManager.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/DomainManager.cs
@@ -59,7 +59,7 @@ namespace NUnit.Engine.Runners
         }
 
         // Made separate and internal for testing
-        AppDomainSetup CreateAppDomainSetup(TestPackage package)
+        static AppDomainSetup CreateAppDomainSetup(TestPackage package)
         {
             AppDomainSetup setup = new AppDomainSetup();
 
@@ -99,7 +99,7 @@ namespace NUnit.Engine.Runners
             return setup;
         }
 
-        public void Unload(AppDomain domain)
+        public static void Unload(AppDomain domain)
         {
             new DomainUnloader(domain).Unload();
         }

--- a/src/NUnitCommon/nunit.agent.core/Runners/TestDomainRunner.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/TestDomainRunner.cs
@@ -30,7 +30,7 @@ namespace NUnit.Engine.Runners
         {
             if (this.TestDomain != null)
             {
-                _domainManager.Unload(this.TestDomain);
+                DomainManager.Unload(this.TestDomain);
                 this.TestDomain = null;
             }
         }

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
@@ -91,7 +91,7 @@ namespace NUnit.Engine.Internal
 
         private Assembly? OnResolving(AssemblyLoadContext loadContext, AssemblyName assemblyName)
         {
-            if (loadContext == null) throw new ArgumentNullException("context");
+            Guard.ArgumentNotNull(loadContext, nameof(loadContext));
 
             Assembly? loadedAssembly;
             foreach (var strategy in ResolutionStrategies)

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
@@ -304,7 +304,7 @@ namespace NUnit.Engine.Internal
             int len = 0;
             foreach (char c in text)
             {
-                if (VERSION_CHARS.IndexOf(c) >= 0)
+                if (VERSION_CHARS.Contains(c))
                     len++;
                 else
                     break;

--- a/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
+++ b/src/NUnitCommon/nunit.agent.core/TestAssemblyResolver.cs
@@ -152,7 +152,7 @@ namespace NUnit.Engine.Internal
         public class RuntimeLibrariesStrategy : ResolutionStrategy
         {
             private DependencyContext? _dependencyContext;
-            private readonly ICompilationAssemblyResolver _assemblyResolver;
+            private readonly CompositeCompilationAssemblyResolver _assemblyResolver;
 
             public RuntimeLibrariesStrategy(AssemblyLoadContext loadContext, string testAssemblyPath)
             {

--- a/src/NUnitCommon/nunit.common.tests/FileSystemAccess/DirectoryFinderTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/FileSystemAccess/DirectoryFinderTests.cs
@@ -441,7 +441,7 @@ namespace NUnit.Engine.Internal
         {
             var finder = new DirectoryFinder(Substitute.For<IFileSystem>());
 
-            Assert.That(() => finder.GetDirectories((IDirectory)null!, "notused"), Throws.ArgumentNullException.With.Message.Contains(" startDirectory "));
+            Assert.That(() => finder.GetDirectories((IDirectory)null!, "notused"), Throws.ArgumentNullException.With.Message.Contains("startDirectory"));
         }
 
         [Test]
@@ -449,7 +449,7 @@ namespace NUnit.Engine.Internal
         {
             var finder = new DirectoryFinder(Substitute.For<IFileSystem>());
 
-            Assert.That(() => finder.GetDirectories(Substitute.For<IDirectory>(), null!), Throws.ArgumentNullException.With.Message.Contains(" pattern "));
+            Assert.That(() => finder.GetDirectories(Substitute.For<IDirectory>(), null!), Throws.ArgumentNullException.With.Message.Contains("pattern"));
         }
 
         [Test]
@@ -594,7 +594,7 @@ namespace NUnit.Engine.Internal
         {
             var finder = new DirectoryFinder(Substitute.For<IFileSystem>());
 
-            Assert.That(() => finder.GetFiles((IDirectory)null!, "notused"), Throws.ArgumentNullException.With.Message.Contains(" startDirectory "));
+            Assert.That(() => finder.GetFiles((IDirectory)null!, "notused"), Throws.ArgumentNullException.With.Message.Contains("startDirectory"));
         }
 
         [Test]
@@ -602,7 +602,7 @@ namespace NUnit.Engine.Internal
         {
             var finder = new DirectoryFinder(Substitute.For<IFileSystem>());
 
-            Assert.That(() => finder.GetDirectories(Substitute.For<IDirectory>(), null!), Throws.ArgumentNullException.With.Message.Contains(" pattern "));
+            Assert.That(() => finder.GetDirectories(Substitute.For<IDirectory>(), null!), Throws.ArgumentNullException.With.Message.Contains("pattern"));
         }
 
         [Test]
@@ -610,7 +610,7 @@ namespace NUnit.Engine.Internal
         {
             var finder = new DirectoryFinder(Substitute.For<IFileSystem>());
 
-            Assert.That(() => finder.GetFiles(Substitute.For<IDirectory>(), string.Empty), Throws.ArgumentException.With.Message.Contains(" pattern "));
+            Assert.That(() => finder.GetFiles(Substitute.For<IDirectory>(), string.Empty), Throws.ArgumentException.With.Message.Contains("pattern"));
         }
 
         private static string CreateAbsolutePath(IEnumerable<string> parts)

--- a/src/NUnitCommon/nunit.common.tests/FileSystemAccess/FileSystemTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/FileSystemAccess/FileSystemTests.cs
@@ -38,7 +38,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
         [Test]
         public void GetFile()
         {
-            var path = this.GetTestFileLocation();
+            var path = GetTestFileLocation();
             var parent = SIO.Path.GetDirectoryName(path);
             var fileSystem = new FileSystem();
 
@@ -66,7 +66,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
         [Test]
         public void Exists_FileExists()
         {
-            var path = this.GetTestFileLocation();
+            var path = GetTestFileLocation();
             var file = new File(path);
             var fileSystem = new FileSystem();
 
@@ -78,7 +78,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
         [Test]
         public void Exists_FileDoesNotExist()
         {
-            var path = this.GetTestFileLocation();
+            var path = GetTestFileLocation();
             while (SIO.File.Exists(path))
             {
                 path += "x";
@@ -137,7 +137,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
             Assert.That(() => fileSystem.Exists((IDirectory)null!), Throws.ArgumentNullException);
         }
 
-        private string GetTestFileLocation()
+        private static string GetTestFileLocation()
         {
             return Assembly.GetAssembly(typeof(FileTests))!.Location;
         }

--- a/src/NUnitCommon/nunit.common.tests/FileSystemAccess/FileTests.cs
+++ b/src/NUnitCommon/nunit.common.tests/FileSystemAccess/FileTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
         [Test]
         public void Init()
         {
-            var path = this.GetTestFileLocation();
+            var path = GetTestFileLocation();
             var parent = SIO.Path.GetDirectoryName(path);
 
             var file = new File(path);
@@ -37,7 +37,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
                 Assert.Ignore("This test does not make sense on systems where System.IO.Path.GetInvalidPathChars() returns an empty array.");
             }
 
-            var path = SIO.Path.GetInvalidPathChars()[SIO.Path.GetInvalidPathChars().Length-1] + this.GetTestFileLocation();
+            var path = SIO.Path.GetInvalidPathChars()[SIO.Path.GetInvalidPathChars().Length-1] + GetTestFileLocation();
 
             Assert.That(() => new File(path), Throws.ArgumentException);
         }
@@ -51,7 +51,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
             }
 
             char invalidCharThatIsNotInInvalidPathChars = SIO.Path.GetInvalidFileNameChars().Except(SIO.Path.GetInvalidPathChars()).First();
-            var path = this.GetTestFileLocation() + invalidCharThatIsNotInInvalidPathChars;
+            var path = GetTestFileLocation() + invalidCharThatIsNotInInvalidPathChars;
 
             Assert.That(() => new File(path), Throws.ArgumentException);
         }
@@ -65,7 +65,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
         [Test]
         public void Init_NonExistingFile()
         {
-            var path = this.GetTestFileLocation();
+            var path = GetTestFileLocation();
             while (SIO.File.Exists(path))
             {
                 path += "a";
@@ -87,7 +87,7 @@ namespace NUnit.Engine.Tests.Internal.FileSystemAccess.Default
             Assert.That(() => new File(path), Throws.ArgumentException);
         }
 
-        private string GetTestFileLocation()
+        private static string GetTestFileLocation()
         {
             return Assembly.GetAssembly(typeof(FileTests))!.Location;
         }

--- a/src/NUnitCommon/nunit.common/Communitcation/Protocols/BinarySerializationProtocol.cs
+++ b/src/NUnitCommon/nunit.common/Communitcation/Protocols/BinarySerializationProtocol.cs
@@ -94,7 +94,7 @@ namespace NUnit.Engine.Communication.Protocols
         /// A byte[] containing the message itself, without a prefixed
         /// length, serialized according to the protocol.
         /// </returns>
-        internal byte[] SerializeMessage(object message)
+        internal static byte[] SerializeMessage(object message)
         {
             using (var memoryStream = new MemoryStream())
             {

--- a/src/NUnitCommon/nunit.common/Guard.cs
+++ b/src/NUnitCommon/nunit.common/Guard.cs
@@ -20,7 +20,7 @@ namespace NUnit
         public static void ArgumentNotNull(object value, string name)
         {
             if (value == null)
-                throw new ArgumentNullException("Argument " + name + " must not be null", name);
+                throw new ArgumentNullException(name);
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace NUnit
             ArgumentNotNull(value, name);
 
             if (value == string.Empty)
-                throw new ArgumentException("Argument " + name +" must not be the empty string", name);
+                throw new ArgumentException("Argument " + name + " must not be the empty string", name);
         }
 
         /// <summary>

--- a/src/NUnitCommon/nunit.common/Modernization/StringExtensions.cs
+++ b/src/NUnitCommon/nunit.common/Modernization/StringExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+#if !NETSTANDARD2_1 && !NETCOREAPP2_0_OR_GREATER
+
+namespace NUnit.Common
+{
+    public static class StringExtensions
+    {
+        public static bool EndsWith(this string s, char c)
+        {
+            return s.Length > 0 && s[s.Length - 1] == c;
+        }
+
+        public static bool StartsWith(this string s, char c)
+        {
+            return s.Length > 0 && s[0] == c;
+        }
+
+        public static bool Contains(this string s, char c)
+        {
+            return s.IndexOf(c) >= 0;
+        }
+    }
+}
+
+#endif

--- a/src/NUnitCommon/nunit.common/PathUtils.cs
+++ b/src/NUnitCommon/nunit.common/PathUtils.cs
@@ -22,6 +22,8 @@ namespace NUnit
         protected static char DirectorySeparatorChar = Path.DirectorySeparatorChar;
         protected static char AltDirectorySeparatorChar = Path.AltDirectorySeparatorChar;
 
+        private static readonly char[] DirectorySeparators = [DirectorySeparatorChar, AltDirectorySeparatorChar];
+
         /// <summary>
         /// Returns a boolean indicating whether the specified path
         /// is that of an assembly - that is a dll or exe file.
@@ -95,7 +97,7 @@ namespace NUnit
         public static string Canonicalize( string path )
         {
             List<string> parts = new List<string>(
-                path.Split( DirectorySeparatorChar, AltDirectorySeparatorChar ) );
+                path.Split( DirectorySeparators ) );
 
             for( int index = 0; index < parts.Count; )
             {
@@ -254,9 +256,7 @@ namespace NUnit
 
         private static string[] SplitPath(string path)
         {
-            char[] separators = new char[] { PathUtils.DirectorySeparatorChar, PathUtils.AltDirectorySeparatorChar };
-
-            string[] trialSplit = path.Split(separators);
+            string[] trialSplit = path.Split(DirectorySeparators);
 
             int emptyEntries = 0;
             foreach (string piece in trialSplit)

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionWrapperTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionWrapperTests.cs
@@ -158,14 +158,14 @@ namespace NUnit.Extensibility
 
         public int IntProperty
         {
-            get => GetProperty<int>("IntProperty");
-            set => SetProperty("IntProperty", value);
+            get => GetProperty<int>(nameof(IntProperty));
+            set => SetProperty(nameof(IntProperty), value);
         }
 
         public string? StringProperty
         {
-            get => GetProperty<string>("StringProperty");
-            set => SetProperty("StringProperty", value);
+            get => GetProperty<string>(nameof(StringProperty));
+            set => SetProperty(nameof(StringProperty), value);
         }
     }
 

--- a/src/NUnitCommon/nunit.extensibility/AddinsFileEntry.cs
+++ b/src/NUnitCommon/nunit.extensibility/AddinsFileEntry.cs
@@ -25,8 +25,21 @@ namespace NUnit.Extensibility
         {
             LineNumber = lineNumber;
             RawText = rawText;
-            Text = rawText.Split(new char[] { '#' })[0].Trim()
-                .Replace(Path.DirectorySeparatorChar, '/');
+
+            // Remove comments and trim whitespace
+            int commentIndex = rawText.IndexOf('#');
+            if (commentIndex >= 0)
+            {
+                Text = rawText.Substring(0, commentIndex).Trim();
+            }
+            else
+            {
+                Text = rawText.Trim();
+            }
+
+            // Replace backslashes with slashes for consistency and
+            // to avoid issues with path separators on different platforms
+            Text = Text.Replace(Path.DirectorySeparatorChar, '/');
         }
 
         public override string ToString()

--- a/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
@@ -644,7 +644,7 @@ namespace NUnit.Extensibility
             //return true;
         }
 
-        private System.Runtime.Versioning.FrameworkName GetTargetRuntime(string filePath)
+        private static System.Runtime.Versioning.FrameworkName GetTargetRuntime(string filePath)
         {
             var assemblyDef = AssemblyDefinition.ReadAssembly(filePath);
             var frameworkName = assemblyDef.GetFrameworkName();

--- a/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
@@ -80,8 +80,8 @@ namespace NUnit.Extensibility
         /// <returns>A collection of values</returns>
         public IEnumerable<string> GetValues(string name)
         {
-            if (_properties.ContainsKey(name))
-                return _properties[name];
+            if (_properties.TryGetValue(name, out List<string>? value))
+                return value;
             else
                 return Enumerable.Empty<string>();
         }

--- a/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
@@ -460,7 +460,7 @@ namespace NUnit.ConsoleRunner
             Assert.That(options.ResultOutputSpecifications.Count, Is.EqualTo(0));
         }
 
-        private void DumpErrors()
+        private static void DumpErrors()
         {
         }
 

--- a/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
@@ -570,7 +570,8 @@ namespace NUnit.ConsoleRunner
             Assume.That(testListPath, Does.Exist);
             var options = ConsoleMocks.Options("--testlist=" + testListPath);
             Assert.That(options.ErrorMessages, Is.Empty);
-            Assert.That(options.TestList, Is.EqualTo(new[] {"AmazingTest"}));
+            string[] expected = new[] { "AmazingTest" };
+            Assert.That(options.TestList, Is.EqualTo(expected));
         }
 
         [Test]

--- a/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
@@ -724,7 +724,7 @@ namespace NUnit.ConsoleRunner
             ConsoleOptions options = ConsoleMocks.Options("--disable=NUnit.Engine.Listeners.TeamCityEventListener");
             Assert.That(options.DisableExtensions.Contains("NUnit.Engine.Listeners.TeamCityEventListener"));
         }
-        private static IFileSystem GetFileSystemContainingFile(string fileName)
+        private static VirtualFileSystem GetFileSystemContainingFile(string fileName)
         {
             var fileSystem = new VirtualFileSystem();
             fileSystem.SetupFile(Path.Combine(Environment.CurrentDirectory, fileName), new List<string>());

--- a/src/NUnitConsole/nunit4-console.tests/MakeTestPackageTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/MakeTestPackageTests.cs
@@ -72,7 +72,8 @@ namespace NUnit.ConsoleRunner
             Assert.That(settings.ContainsKey("TestParametersDictionary"), "TestParametersDictionary setting not included.");
             var paramDictionary = settings["TestParametersDictionary"] as IDictionary<string, string>;
             Assert.That(paramDictionary, Is.Not.Null);
-            Assert.That(paramDictionary.Keys, Is.EqualTo(new[] { "X", "Y" }));
+            string[] expectedKeys = new[] { "X", "Y" };
+            Assert.That(paramDictionary.Keys, Is.EqualTo(expectedKeys));
             Assert.That(paramDictionary["X"], Is.EqualTo("5"));
             Assert.That(paramDictionary["Y"], Is.EqualTo("7"));
 
@@ -109,7 +110,8 @@ namespace NUnit.ConsoleRunner
             var options = ConsoleMocks.Options("test.dll");
             var package = ConsoleRunner.MakeTestPackage(options);
 
-            Assert.That(package.Settings.Keys, Is.EquivalentTo(new string[] { "WorkDirectory", "DisposeRunners" }));
+            string[] expected = new string[] { "WorkDirectory", "DisposeRunners" };
+            Assert.That(package.Settings.Keys, Is.EquivalentTo(expected));
         }
 
     }

--- a/src/NUnitConsole/nunit4-console.tests/Options/TestNameParserTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/Options/TestNameParserTests.cs
@@ -20,7 +20,7 @@ namespace NUnit.ConsoleRunner.Options
         {
             string[] names = TestNameParser.Parse(name);
             Assert.That(names.Length, Is.EqualTo(1));
-            Assert.That(names[0], Is.EqualTo(name.Trim(new char[] { ' ', ',' })));
+            Assert.That(names[0], Is.EqualTo(name.Trim(' ', ',')));
         }
 
         [TestCase("Test.Namespace.Fixture.Method1", "Test.Namespace.Fixture.Method2")]

--- a/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ResultReporterTests.cs
@@ -187,7 +187,7 @@ namespace NUnit.ConsoleRunner
             return _report.ToString();
         }
 
-        private IList<string> GetReportLines(TestDelegate del)
+        private List<string> GetReportLines(TestDelegate del)
         {
             var rdr = new StringReader(GetReport(del));
 

--- a/src/NUnitConsole/nunit4-console.tests/VirtualFileSystem.cs
+++ b/src/NUnitConsole/nunit4-console.tests/VirtualFileSystem.cs
@@ -31,12 +31,16 @@ namespace NUnit.ConsoleRunner
             files[path] = new List<string>(lines);
         }
 
+        private static readonly char[] CommaSeparator = [','];
+        private static readonly char[] ColonSeparator = [':'];
+        private static readonly char[] NewLineSeparator = ['\n'];
+
         internal void SetupFiles(string files)
         {
-            foreach (var file in files.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var file in files.Split(CommaSeparator, StringSplitOptions.RemoveEmptyEntries))
             {
-                var fileParts = file.Split(':');
-                var lines = fileParts[1].Replace("\r\n", "\n").Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                var fileParts = file.Split(ColonSeparator);
+                var lines = fileParts[1].Replace("\r\n", "\n").Split(NewLineSeparator, StringSplitOptions.RemoveEmptyEntries);
                 SetupFile(fileParts[0], lines);
             }
         }

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using NUnit.Common;
 
 namespace NUnit.ConsoleRunner
 {
@@ -311,7 +312,7 @@ namespace NUnit.ConsoleRunner
             // Default
             this.Add("<>", v =>
             {
-                if (v.StartsWith("-") || v.StartsWith("/") && Path.DirectorySeparatorChar != '/')
+                if (v.StartsWith('-') || v.StartsWith('/') && Path.DirectorySeparatorChar != '/')
                     ErrorMessages.Add("Invalid argument: " + v);
                 else
                     InputFiles.Add(v);

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -112,7 +112,7 @@ namespace NUnit.ConsoleRunner
             get
             {
                 if (NoResultSpecified)
-                    return new OutputSpecification[0];
+                    return Array.Empty<OutputSpecification>();
 
                 if (resultOutputSpecifications.Count == 0)
                     resultOutputSpecifications.Add(

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -391,7 +391,7 @@ namespace NUnit.ConsoleRunner
 
         public IEnumerable<string> PreParse(IEnumerable<string> args)
         {
-            if (args == null) throw new ArgumentNullException(nameof(args));
+            Guard.ArgumentNotNull(args, nameof(args));
 
             if (++_nesting > 3)
             {

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -391,7 +391,7 @@ namespace NUnit.ConsoleRunner
 
         public IEnumerable<string> PreParse(IEnumerable<string> args)
         {
-            if (args == null) throw new ArgumentNullException("args");
+            if (args == null) throw new ArgumentNullException(nameof(args));
 
             if (++_nesting > 3)
             {

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -374,16 +374,16 @@ namespace NUnit.ConsoleRunner
             this.Add(prototype, description, action, isHidden);
         }
 
+#if NETFRAMEWORK
+        private static Action<string> NetFxOnlyOption(string optionName, Action<string> action) => action;
+#else
         private Action<string> NetFxOnlyOption(string optionName, Action<string> action)
         {
-#if NETFRAMEWORK
-            return action;
-#else
             return s => ErrorMessages.Add($"The {optionName} option is not available on this platform.");
-#endif
         }
+#endif
 
-        private void CheckOptionCombinations()
+        private static void CheckOptionCombinations()
         {
             // Add any validation of option combinations here
         }
@@ -466,7 +466,7 @@ namespace NUnit.ConsoleRunner
             return GetArgs(sb.ToString());
         }
 
-        private string? ExpandToFullPath(string path)
+        private static string? ExpandToFullPath(string path)
         {
             if (path == null) return null;
 

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -23,6 +23,8 @@ namespace NUnit.ConsoleRunner
     {
         static Logger log = InternalTrace.GetLogger(typeof(ConsoleRunner));
 
+        private static readonly char[] PathSeparator = [Path.PathSeparator];
+
         // Some operating systems truncate the return code to 8 bits, which
         // only allows us a maximum of 127 in the positive range. We limit
         // ourselves so as to stay in that range.
@@ -76,7 +78,7 @@ namespace NUnit.ConsoleRunner
 
             var extensionPath = Environment.GetEnvironmentVariable(NUNIT_EXTENSION_DIRECTORIES);
             if (!string.IsNullOrEmpty(extensionPath))
-                foreach (string extensionDirectory in extensionPath.Split(new[] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries))
+                foreach (string extensionDirectory in extensionPath.Split(PathSeparator, StringSplitOptions.RemoveEmptyEntries))
                     _extensionService.FindExtensionAssemblies(extensionDirectory);
 
             foreach (string extensionDirectory in _options.ExtensionDirectories)

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -370,30 +370,31 @@ namespace NUnit.ConsoleRunner
 
             _outWriter.WriteLine(ColorStyle.SectionHeader, "Installed Extensions");
 
-            foreach (var ep in _extensionService?.ExtensionPoints ?? new IExtensionPoint[0])
-            {
-                _outWriter.WriteLabelLine(INDENT4 + "Extension Point: ", ep.Path);
-                foreach (var node in ep.Extensions)
+            if (_extensionService?.ExtensionPoints != null)
+                foreach (var ep in _extensionService.ExtensionPoints)
                 {
-                    _outWriter.Write(INDENT6 + "Extension: ");
-                    _outWriter.Write(ColorStyle.Value, $"{node.TypeName}");
-                    _outWriter.WriteLine(node.Enabled ? "" : " (Disabled)");
-
-                    _outWriter.Write(INDENT8 + "Version: ");
-                    _outWriter.WriteLine(ColorStyle.Value, node.AssemblyVersion.ToString());
-
-                    _outWriter.Write(INDENT8 + "Path: ");
-                    _outWriter.WriteLine(ColorStyle.Value, node.AssemblyPath);
-
-                    foreach (var prop in node.PropertyNames)
+                    _outWriter.WriteLabelLine(INDENT4 + "Extension Point: ", ep.Path);
+                    foreach (var node in ep.Extensions)
                     {
-                        _outWriter.Write(INDENT8 + prop + ":");
-                        foreach (var val in node.GetValues(prop))
-                            _outWriter.Write(ColorStyle.Value, " " + val);
-                        _outWriter.WriteLine();
+                        _outWriter.Write(INDENT6 + "Extension: ");
+                        _outWriter.Write(ColorStyle.Value, $"{node.TypeName}");
+                        _outWriter.WriteLine(node.Enabled ? "" : " (Disabled)");
+
+                        _outWriter.Write(INDENT8 + "Version: ");
+                        _outWriter.WriteLine(ColorStyle.Value, node.AssemblyVersion.ToString());
+
+                        _outWriter.Write(INDENT8 + "Path: ");
+                        _outWriter.WriteLine(ColorStyle.Value, node.AssemblyPath);
+
+                        foreach (var prop in node.PropertyNames)
+                        {
+                            _outWriter.Write(INDENT8 + prop + ":");
+                            foreach (var val in node.GetValues(prop))
+                                _outWriter.Write(ColorStyle.Value, " " + val);
+                            _outWriter.WriteLine();
+                        }
                     }
                 }
-            }
 
             _outWriter.WriteLine();
         }

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -109,7 +109,7 @@ namespace NUnit.ConsoleRunner
                     DisableExtension(typeName);
         }
 
-        private bool RunningUnderTeamCity =>
+        private static bool RunningUnderTeamCity =>
             !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEAMCITY_PROJECT_NAME"));
 
         private bool IsExtensionInstalled(string typeName)
@@ -317,7 +317,7 @@ namespace NUnit.ConsoleRunner
             return ConsoleRunner.UNEXPECTED_ERROR;
         }
 
-        private void DisplayRuntimeEnvironment(ExtendedTextWriter OutWriter)
+        private static void DisplayRuntimeEnvironment(ExtendedTextWriter OutWriter)
         {
             OutWriter.WriteLine(ColorStyle.SectionHeader, "Runtime Environment");
             OutWriter.WriteLabelLine(INDENT4 + "OS Version: ", GetOSVersion());

--- a/src/NUnitConsole/nunit4-console/FileSystem.cs
+++ b/src/NUnitConsole/nunit4-console/FileSystem.cs
@@ -10,14 +10,14 @@ namespace NUnit.ConsoleRunner
     {
         public bool FileExists(string fileName)
         {
-            if (fileName == null) throw new ArgumentNullException(nameof(fileName));
+            Guard.ArgumentNotNull(fileName, nameof(fileName));
 
             return File.Exists(fileName);
         }
 
         public IEnumerable<string> ReadLines(string fileName)
         {
-            if (fileName == null) throw new ArgumentNullException(nameof(fileName));
+            Guard.ArgumentNotNull(fileName, nameof(fileName));
 
             using (var file = File.OpenText(fileName))
             {

--- a/src/NUnitConsole/nunit4-console/FileSystem.cs
+++ b/src/NUnitConsole/nunit4-console/FileSystem.cs
@@ -10,14 +10,14 @@ namespace NUnit.ConsoleRunner
     {
         public bool FileExists(string fileName)
         {
-            if (fileName == null) throw new ArgumentNullException("fileName");
+            if (fileName == null) throw new ArgumentNullException(nameof(fileName));
 
             return File.Exists(fileName);
         }
 
         public IEnumerable<string> ReadLines(string fileName)
         {
-            if (fileName == null) throw new ArgumentNullException("fileName");
+            if (fileName == null) throw new ArgumentNullException(nameof(fileName));
 
             using (var file = File.OpenText(fileName))
             {

--- a/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
@@ -62,7 +62,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public KeyValuePair<string, string>? RequiredKeyValue(string testParameterSpecification)
         {
-            var equalsIndex = testParameterSpecification.IndexOf("=");
+            var equalsIndex = testParameterSpecification.IndexOf('=');
 
             if (equalsIndex > 0 && equalsIndex < testParameterSpecification.Length - 1)
             {

--- a/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OptionParser.cs
@@ -82,7 +82,7 @@ namespace NUnit.ConsoleRunner.Options
             return null;
         }
 
-        private bool IsQuotedString(string value)
+        private static bool IsQuotedString(string value)
         {
             var length = value.Length;
             if (length > 2)

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -591,7 +591,7 @@ namespace NUnit.ConsoleRunner.Options
             return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
         }
 
-        private static void AddSeparators(string name, int end, ICollection<string> seps)
+        private static void AddSeparators(string name, int end, List<string> seps)
         {
             int start = -1;
             for (int i = end + 1; i < name.Length; ++i)
@@ -1158,7 +1158,7 @@ namespace NUnit.ConsoleRunner.Options
             return false;
         }
 
-        private static bool Unprocessed(ICollection<string> extra, Option? def, OptionContext c, string argument)
+        private static bool Unprocessed(List<string> extra, Option? def, OptionContext c, string argument)
         {
             if (def == null)
             {

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -1680,7 +1680,7 @@ namespace NUnit.ConsoleRunner.Options
             base.SetItem(index, item);
         }
 
-        bool ShouldWrapOption(Option item)
+        static bool ShouldWrapOption(Option item)
         {
             if (item == null)
                 return false;
@@ -2128,7 +2128,7 @@ namespace NUnit.ConsoleRunner.Options
             return commands;
         }
 
-        void AddNestedCommands(List<KeyValuePair<string, Command>> commands, string outer, CommandSet value)
+        static void AddNestedCommands(List<KeyValuePair<string, Command>> commands, string outer, CommandSet value)
         {
             foreach (var v in value)
             {

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -228,7 +228,11 @@ namespace NUnit.ConsoleRunner.Options
                         --end;
                         continuation = "-";
                     }
+#if NETFRAMEWORK
                     string line = self.Substring(start, end - start) + continuation;
+#else
+                    string line = string.Concat(self.AsSpan(start, end - start), continuation);
+#endif
                     yield return line;
                     start = end;
                     if (char.IsWhiteSpace(c))
@@ -1544,7 +1548,7 @@ namespace NUnit.ConsoleRunner.Options
                         }
                         else
                         {
-                            sb.Append(description.Substring(start, i - start));
+                            sb.Append(description, start, i - start);
                             start = -1;
                         }
                         break;

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -419,6 +419,8 @@ namespace NUnit.ConsoleRunner.Options
 
     public abstract class Option
     {
+        private static readonly char[] PipeSeparator = ['|'];
+
         readonly string prototype;
         readonly string? description;
         readonly string[] names;
@@ -450,7 +452,7 @@ namespace NUnit.ConsoleRunner.Options
                 // append GetHashCode() so that "duplicate" categories have distinct
                 // names, e.g. adding multiple "" categories should be valid.
                 ? new[] { prototype + this.GetHashCode() }
-                : prototype.Split('|');
+                : prototype.Split(PipeSeparator);
 
             if (this is OptionSet.Category || this is CommandOption)
                 return;
@@ -1482,13 +1484,15 @@ namespace NUnit.ConsoleRunner.Options
             o.Write(s);
         }
 
+        private static readonly char[] ColonSeparator = [':'];
+
         static string GetArgumentName(int index, int maxIndex, string? description)
         {
             var matches = Regex.Matches(description ?? "", @"(?<=(?<!\{)\{)[^{}]*(?=\}(?!\}))"); // ignore double braces 
             string argName = "";
             foreach (Match match in matches)
             {
-                var parts = match.Value.Split(':');
+                var parts = match.Value.Split(ColonSeparator);
                 // for maxIndex=1 it can be {foo} or {0:foo}
                 if (maxIndex == 1)
                 {
@@ -2049,6 +2053,8 @@ namespace NUnit.ConsoleRunner.Options
 
     public class HelpCommand : Command
     {
+        private static readonly string[] helpArgument = ["--help"];
+
         public HelpCommand()
             : base("help", help: "Show this message and exit")
         {
@@ -2095,7 +2101,7 @@ namespace NUnit.ConsoleRunner.Options
                 command.Options.WriteOptionDescriptions(CommandSet.Out);
                 return 0;
             }
-            return command.Invoke(new[] { "--help" });
+            return command.Invoke(helpArgument);
         }
 
         List<KeyValuePair<string, Command>> GetCommands()

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -777,7 +777,7 @@ namespace NUnit.ConsoleRunner.Options
 
 #if !PCL
 #if NET8_0_OR_GREATER
-        [Obsolete]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code. SYSLIB0051")]
 #endif
         protected OptionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
@@ -793,7 +793,7 @@ namespace NUnit.ConsoleRunner.Options
 
 #if !PCL
 #if NET8_0_OR_GREATER
-        [Obsolete]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code. SYSLIB0051")]
 #endif
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -198,7 +198,7 @@ namespace NUnit.ConsoleRunner.Options
         public static IEnumerable<string> WrappedLines(string self, IEnumerable<int> widths)
         {
             if (widths == null)
-                throw new ArgumentNullException("widths");
+                throw new ArgumentNullException(nameof(widths));
             return CreateWrappedLinesIterator(self, widths);
         }
 
@@ -330,7 +330,7 @@ namespace NUnit.ConsoleRunner.Options
             if (c.Option == null)
                 throw new InvalidOperationException("OptionContext.Option is null.");
             if (index >= c.Option.MaxValueCount)
-                throw new ArgumentOutOfRangeException("index");
+                throw new ArgumentOutOfRangeException(nameof(index));
             if (c.Option.OptionValueType == OptionValueType.Required &&
                     index >= values.Count)
                 throw new OptionException(string.Format(
@@ -442,11 +442,11 @@ namespace NUnit.ConsoleRunner.Options
         protected Option(string prototype, string? description, int maxValueCount, bool hidden)
         {
             if (prototype == null)
-                throw new ArgumentNullException("prototype");
+                throw new ArgumentNullException(nameof(prototype));
             if (prototype.Length == 0)
-                throw new ArgumentException("Cannot be the empty string.", "prototype");
+                throw new ArgumentException("Cannot be the empty string.", nameof(prototype));
             if (maxValueCount < 0)
-                throw new ArgumentOutOfRangeException("maxValueCount");
+                throw new ArgumentOutOfRangeException(nameof(maxValueCount));
 
             this.prototype = prototype;
             this.description = description;
@@ -467,17 +467,17 @@ namespace NUnit.ConsoleRunner.Options
                 throw new ArgumentException(
                         "Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
                             "OptionValueType.Optional.",
-                        "maxValueCount");
+                        nameof(maxValueCount));
             if (this.type == OptionValueType.None && maxValueCount > 1)
                 throw new ArgumentException(
                         string.Format("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
-                        "maxValueCount");
+                        nameof(maxValueCount));
             if (Array.IndexOf(names, "<>") >= 0 &&
                     ((names.Length == 1 && this.type != OptionValueType.None) ||
                      (names.Length > 1 && this.MaxValueCount > 1)))
                 throw new ArgumentException(
                         "The default option handler '<>' cannot require values.",
-                        "prototype");
+                        nameof(prototype));
         }
 
         public string Prototype { get { return prototype; } }
@@ -856,7 +856,7 @@ namespace NUnit.ConsoleRunner.Options
         protected Option? GetOptionForName(string option)
         {
             if (option == null)
-                throw new ArgumentNullException("option");
+                throw new ArgumentNullException(nameof(option));
             try
             {
                 return base[option];
@@ -893,7 +893,7 @@ namespace NUnit.ConsoleRunner.Options
         private void AddImpl(Option option)
         {
             if (option == null)
-                throw new ArgumentNullException("option");
+                throw new ArgumentNullException(nameof(option));
             List<string> added = new List<string>(option.Names.Length);
             try
             {
@@ -915,7 +915,7 @@ namespace NUnit.ConsoleRunner.Options
         public OptionSet Add(string header)
         {
             if (header == null)
-                throw new ArgumentNullException("header");
+                throw new ArgumentNullException(nameof(header));
             Add(new Category(header));
             return this;
         }
@@ -957,7 +957,7 @@ namespace NUnit.ConsoleRunner.Options
                 : base(prototype, description, count, hidden)
             {
                 if (action == null)
-                    throw new ArgumentNullException("action");
+                    throw new ArgumentNullException(nameof(action));
                 this.action = action;
             }
 
@@ -980,7 +980,7 @@ namespace NUnit.ConsoleRunner.Options
         public OptionSet Add(string prototype, string? description, Action<string> action, bool hidden)
         {
             if (action == null)
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             Option p = new ActionOption(prototype, description, 1,
                     delegate (OptionValueCollection v) { action(v[0]); }, hidden);
             base.Add(p);
@@ -1000,7 +1000,7 @@ namespace NUnit.ConsoleRunner.Options
         public OptionSet Add(string prototype, string? description, OptionAction<string, string> action, bool hidden)
         {
             if (action == null)
-                throw new ArgumentNullException("action");
+                throw new ArgumentNullException(nameof(action));
             Option p = new ActionOption(prototype, description, 2,
                     delegate (OptionValueCollection v) { action(v[0], v[1]); }, hidden);
             base.Add(p);
@@ -1015,7 +1015,7 @@ namespace NUnit.ConsoleRunner.Options
                 : base(prototype, description, 1)
             {
                 if (action == null)
-                    throw new ArgumentNullException("action");
+                    throw new ArgumentNullException(nameof(action));
                 this.action = action;
             }
 
@@ -1033,7 +1033,7 @@ namespace NUnit.ConsoleRunner.Options
                 : base(prototype, description, 2)
             {
                 if (action == null)
-                    throw new ArgumentNullException("action");
+                    throw new ArgumentNullException(nameof(action));
                 this.action = action;
             }
 
@@ -1068,7 +1068,7 @@ namespace NUnit.ConsoleRunner.Options
         public OptionSet Add(ArgumentSource source)
         {
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             sources.Add(source);
             return this;
         }
@@ -1081,7 +1081,7 @@ namespace NUnit.ConsoleRunner.Options
         public List<string> Parse(IEnumerable<string> arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException("arguments");
+                throw new ArgumentNullException(nameof(arguments));
             OptionContext c = CreateOptionContext();
             c.OptionIndex = -1;
             bool process = true;
@@ -1178,7 +1178,7 @@ namespace NUnit.ConsoleRunner.Options
         protected bool GetOptionParts(string argument, [NotNullWhen(true)] out string? flag, [NotNullWhen(true)] out string? name, out string? sep, out string? value)
         {
             if (argument == null)
-                throw new ArgumentNullException("argument");
+                throw new ArgumentNullException(nameof(argument));
 
             flag = name = sep = value = null;
             Match m = ValueOption.Match(argument);

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -184,6 +184,8 @@ using MessageLocalizerConverter = System.Func<string, string>;
 using MessageLocalizerConverter = System.Converter<string, string>;
 #endif
 
+using NUnit.Common;
+
 namespace NUnit.ConsoleRunner.Options
 {
     static class StringCoda
@@ -738,7 +740,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public override bool GetArguments(string value, [NotNullWhen(true)] out IEnumerable<string>? replacement)
         {
-            if (string.IsNullOrEmpty(value) || !value.StartsWith("@"))
+            if (string.IsNullOrEmpty(value) || !value.StartsWith('@'))
             {
                 replacement = null;
                 return false;

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -197,8 +197,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public static IEnumerable<string> WrappedLines(string self, IEnumerable<int> widths)
         {
-            if (widths == null)
-                throw new ArgumentNullException(nameof(widths));
+            Guard.ArgumentNotNull(widths, nameof(widths));
             return CreateWrappedLinesIterator(self, widths);
         }
 
@@ -441,8 +440,7 @@ namespace NUnit.ConsoleRunner.Options
 
         protected Option(string prototype, string? description, int maxValueCount, bool hidden)
         {
-            if (prototype == null)
-                throw new ArgumentNullException(nameof(prototype));
+            Guard.ArgumentNotNull(prototype, nameof(prototype));
             if (prototype.Length == 0)
                 throw new ArgumentException("Cannot be the empty string.", nameof(prototype));
             if (maxValueCount < 0)
@@ -843,8 +841,8 @@ namespace NUnit.ConsoleRunner.Options
 
         protected override string GetKeyForItem(Option item)
         {
-            if (item == null)
-                throw new ArgumentNullException("option");
+            Guard.ArgumentNotNull(item, nameof(item));
+
             if (item.Names != null && item.Names.Length > 0)
                 return item.Names[0];
             // This should never happen, as it's invalid for Option to be
@@ -855,8 +853,8 @@ namespace NUnit.ConsoleRunner.Options
         [Obsolete("Use KeyedCollection.this[string]")]
         protected Option? GetOptionForName(string option)
         {
-            if (option == null)
-                throw new ArgumentNullException(nameof(option));
+            Guard.ArgumentNotNull(option, nameof(option));
+
             try
             {
                 return base[option];
@@ -892,8 +890,8 @@ namespace NUnit.ConsoleRunner.Options
 
         private void AddImpl(Option option)
         {
-            if (option == null)
-                throw new ArgumentNullException(nameof(option));
+            Guard.ArgumentNotNull(option, nameof(option));
+
             List<string> added = new List<string>(option.Names.Length);
             try
             {
@@ -914,8 +912,8 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(string header)
         {
-            if (header == null)
-                throw new ArgumentNullException(nameof(header));
+            Guard.ArgumentNotNull(header, nameof(header));
+
             Add(new Category(header));
             return this;
         }
@@ -956,8 +954,8 @@ namespace NUnit.ConsoleRunner.Options
             public ActionOption(string prototype, string? description, int count, Action<OptionValueCollection> action, bool hidden)
                 : base(prototype, description, count, hidden)
             {
-                if (action == null)
-                    throw new ArgumentNullException(nameof(action));
+                Guard.ArgumentNotNull(action, nameof(action));
+
                 this.action = action;
             }
 
@@ -979,8 +977,8 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(string prototype, string? description, Action<string> action, bool hidden)
         {
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+            Guard.ArgumentNotNull(action, nameof(action));
+
             Option p = new ActionOption(prototype, description, 1,
                     delegate (OptionValueCollection v) { action(v[0]); }, hidden);
             base.Add(p);
@@ -999,8 +997,8 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(string prototype, string? description, OptionAction<string, string> action, bool hidden)
         {
-            if (action == null)
-                throw new ArgumentNullException(nameof(action));
+            Guard.ArgumentNotNull(action, nameof(action));
+
             Option p = new ActionOption(prototype, description, 2,
                     delegate (OptionValueCollection v) { action(v[0], v[1]); }, hidden);
             base.Add(p);
@@ -1014,8 +1012,8 @@ namespace NUnit.ConsoleRunner.Options
             public ActionOption(string prototype, string? description, Action<T> action)
                 : base(prototype, description, 1)
             {
-                if (action == null)
-                    throw new ArgumentNullException(nameof(action));
+                Guard.ArgumentNotNull(action, nameof(action));
+
                 this.action = action;
             }
 
@@ -1032,8 +1030,8 @@ namespace NUnit.ConsoleRunner.Options
             public ActionOption(string prototype, string? description, OptionAction<TKey, TValue> action)
                 : base(prototype, description, 2)
             {
-                if (action == null)
-                    throw new ArgumentNullException(nameof(action));
+                Guard.ArgumentNotNull(action, nameof(action));
+
                 this.action = action;
             }
 
@@ -1067,8 +1065,8 @@ namespace NUnit.ConsoleRunner.Options
 
         public OptionSet Add(ArgumentSource source)
         {
-            if (source == null)
-                throw new ArgumentNullException(nameof(source));
+            Guard.ArgumentNotNull(source, nameof(source));
+
             sources.Add(source);
             return this;
         }
@@ -1080,8 +1078,8 @@ namespace NUnit.ConsoleRunner.Options
 
         public List<string> Parse(IEnumerable<string> arguments)
         {
-            if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments));
+            Guard.ArgumentNotNull(arguments, nameof(arguments));
+
             OptionContext c = CreateOptionContext();
             c.OptionIndex = -1;
             bool process = true;
@@ -1177,8 +1175,7 @@ namespace NUnit.ConsoleRunner.Options
 
         protected bool GetOptionParts(string argument, [NotNullWhen(true)] out string? flag, [NotNullWhen(true)] out string? name, out string? sep, out string? value)
         {
-            if (argument == null)
-                throw new ArgumentNullException(nameof(argument));
+            Guard.ArgumentNotNull(argument, nameof(argument));
 
             flag = name = sep = value = null;
             Match m = ValueOption.Match(argument);
@@ -1626,10 +1623,10 @@ namespace NUnit.ConsoleRunner.Options
         // (see Option.ParsePrototype(), and thus it'll prevent Category
         // instances from being accidentally used as normal options.
         public CommandOption(Command command, string? commandName = null, bool hidden = false)
-            : base("=:Command:= " + (commandName ?? command?.Name), (commandName ?? command?.Name), maxValueCount: 0, hidden: hidden)
+            : base("=:Command:= " + (commandName ?? command.Name), (commandName ?? command.Name), maxValueCount: 0, hidden: hidden)
         {
-            if (command == null)
-                throw new ArgumentNullException(nameof(command));
+            Guard.ArgumentNotNull(command, nameof(command));
+
             Command = command;
             CommandName = commandName ?? command.Name;
         }
@@ -1731,12 +1728,9 @@ namespace NUnit.ConsoleRunner.Options
 
         public CommandSet(string suite, TextWriter output, TextWriter error, MessageLocalizerConverter? localizer = null)
         {
-            if (suite == null)
-                throw new ArgumentNullException(nameof(suite));
-            if (output == null)
-                throw new ArgumentNullException(nameof(output));
-            if (error == null)
-                throw new ArgumentNullException(nameof(error));
+            Guard.ArgumentNotNull(suite, nameof(suite));
+            Guard.ArgumentNotNull(output, nameof(output));
+            Guard.ArgumentNotNull(error, nameof(error));
 
             this.suite = suite;
             options = new CommandOptionSet(this, localizer);
@@ -1756,8 +1750,8 @@ namespace NUnit.ConsoleRunner.Options
 
         public new CommandSet Add(Command value)
         {
-            if (value == null)
-                throw new ArgumentNullException(nameof(value));
+            Guard.ArgumentNotNull(value, nameof(value));
+
             AddCommand(value);
             options.Add(new CommandOption(value));
             return this;
@@ -1860,8 +1854,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public CommandSet Add(CommandSet nestedCommands)
         {
-            if (nestedCommands == null)
-                throw new ArgumentNullException(nameof(nestedCommands));
+            Guard.ArgumentNotNull(nestedCommands, nameof(nestedCommands));
 
             if (NestedCommandSets == null)
             {
@@ -1962,8 +1955,7 @@ namespace NUnit.ConsoleRunner.Options
 
         public int Run(IEnumerable<string> arguments)
         {
-            if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments));
+            Guard.ArgumentNotNull(arguments, nameof(arguments));
 
             this.showHelp = false;
             if (help == null)

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -244,7 +244,7 @@ namespace NUnit.ConsoleRunner.Options
                 // '.' is any character, - is for a continuation
                 const string minWidth = ".-";
                 if (curWidth < minWidth.Length)
-                    throw new ArgumentOutOfRangeException("widths",
+                    throw new ArgumentOutOfRangeException(nameof(curWidth),
                             string.Format("Element must be >= {0}, was {1}.", minWidth.Length, curWidth));
                 return curWidth;
             }
@@ -598,14 +598,14 @@ namespace NUnit.ConsoleRunner.Options
                         if (start != -1)
                             throw new ArgumentException(
                                     string.Format("Ill-formed name/value separator found in \"{0}\".", name),
-                                    "prototype");
+                                    nameof(name));
                         start = i + 1;
                         break;
                     case '}':
                         if (start == -1)
                             throw new ArgumentException(
                                     string.Format("Ill-formed name/value separator found in \"{0}\".", name),
-                                    "prototype");
+                                    nameof(name));
                         seps.Add(name.Substring(start, i - start));
                         start = -1;
                         break;
@@ -618,7 +618,7 @@ namespace NUnit.ConsoleRunner.Options
             if (start != -1)
                 throw new ArgumentException(
                         string.Format("Ill-formed name/value separator found in \"{0}\".", name),
-                        "prototype");
+                        nameof(name));
         }
 
         public void Invoke(OptionContext c)

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -328,8 +328,7 @@ namespace NUnit.ConsoleRunner.Options
         {
             if (c.Option == null)
                 throw new InvalidOperationException("OptionContext.Option is null.");
-            if (index >= c.Option.MaxValueCount)
-                throw new ArgumentOutOfRangeException(nameof(index));
+            Guard.ArgumentInRange(index < c.Option.MaxValueCount, "Index must be less than MaxValueCount.", nameof(index));
             if (c.Option.OptionValueType == OptionValueType.Required &&
                     index >= values.Count)
                 throw new OptionException(string.Format(
@@ -441,10 +440,8 @@ namespace NUnit.ConsoleRunner.Options
         protected Option(string prototype, string? description, int maxValueCount, bool hidden)
         {
             Guard.ArgumentNotNull(prototype, nameof(prototype));
-            if (prototype.Length == 0)
-                throw new ArgumentException("Cannot be the empty string.", nameof(prototype));
-            if (maxValueCount < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxValueCount));
+            Guard.ArgumentValid(prototype.Length > 0, nameof(prototype), "Cannot be the empty string.");
+            Guard.ArgumentInRange(maxValueCount >= 0, "MaxValueCount must be greater or equal to zero", nameof(maxValueCount));
 
             this.prototype = prototype;
             this.description = description;

--- a/src/NUnitConsole/nunit4-console/Options/Options.cs
+++ b/src/NUnitConsole/nunit4-console/Options/Options.cs
@@ -1538,7 +1538,7 @@ namespace NUnit.ConsoleRunner.Options
                             if ((i + 1) == description.Length || description[i + 1] != '}')
                                 throw new InvalidOperationException("Invalid option description: " + description);
                             ++i;
-                            sb.Append("}");
+                            sb.Append('}');
                         }
                         else
                         {

--- a/src/NUnitConsole/nunit4-console/Options/OutputSpecification.cs
+++ b/src/NUnitConsole/nunit4-console/Options/OutputSpecification.cs
@@ -12,6 +12,9 @@ namespace NUnit.ConsoleRunner.Options
     /// </summary>
     public class OutputSpecification
     {
+        private static readonly char[] SemicolonSeparator = [';'];
+        private static readonly char[] EqualsSeparator = ['='];
+
         /// <summary>
         /// Construct an OutputSpecification from an option value.
         /// </summary>
@@ -22,12 +25,12 @@ namespace NUnit.ConsoleRunner.Options
             if (spec == null)
                 throw new ArgumentNullException(nameof(spec), "Output spec may not be null");
 
-            string[] parts = spec.Split(';');
+            string[] parts = spec.Split(SemicolonSeparator);
             this.OutputPath = parts[0];
 
             for (int i = 1; i < parts.Length; i++)
             {
-                string[] opt = parts[i].Split('=');
+                string[] opt = parts[i].Split(EqualsSeparator);
 
                 if (opt.Length != 2)
                     throw new ArgumentException($"Invalid output specification: {spec}");

--- a/src/NUnitConsole/nunit4-console/TestEventHandler.cs
+++ b/src/NUnitConsole/nunit4-console/TestEventHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Xml;
+using NUnit.Common;
 using NUnit.Engine;
 using NUnit.TextDisplay;
 
@@ -167,7 +168,7 @@ namespace NUnit.ConsoleRunner
             _outWriter.Write(color, text);
 
             // If the text we just wrote did not have a new line, flag that we should eventually emit one.
-            if (!text.EndsWith("\n"))
+            if (!text.EndsWith('\n'))
             {
                 _wantNewLine = true;
             }

--- a/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Api/TestPackageTests.cs
@@ -14,7 +14,7 @@ namespace NUnit.Engine.Api
 
         public TestPackageTests(string fileNames)
         {
-            _fileNames = fileNames.Split(new char[] { ',' });
+            _fileNames = fileNames.Split(',');
             _package = new TestPackage(_fileNames);
         }
 

--- a/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Services/ResultServiceTests.cs
@@ -37,7 +37,8 @@ namespace NUnit.Engine.Services
         [Test]
         public void AvailableFormats()
         {
-            Assert.That(_resultService.Formats, Is.EquivalentTo(new string[] { "nunit3", "cases", "user" }));
+            string[] expected = new string[] { "nunit3", "cases", "user" };
+            Assert.That(_resultService.Formats, Is.EquivalentTo(expected));
         }
 
         [TestCase("nunit3", null, ExpectedResult = "NUnit3XmlResultWriter")]

--- a/src/NUnitEngine/nunit.engine.tests/TestData.cs
+++ b/src/NUnitEngine/nunit.engine.tests/TestData.cs
@@ -23,7 +23,7 @@ namespace NUnit.Engine
             VerifyFilePath("testdata/" + CURRENT_RUNTIME + "/notest-assembly.dll");
         }
 
-        private void VerifyFilePath(string path)
+        private static void VerifyFilePath(string path)
         {
             path = Path.GetFullPath(path);
             Assert.That(File.Exists(path), $"File not found at {path}");

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -364,11 +364,12 @@ namespace NUnit.Engine.Runners
             new ObsoletePackageSetting() { OldKey = "RuntimeFramework", NewKey = "RequestedRuntimeFramework"}
         };
 
+#if NETFRAMEWORK
         // Any Errors thrown from this method indicate that the client
         // runner is putting invalid values into the package.
         private void ValidatePackageSettings()
         {
-#if NETFRAMEWORK  // TODO: How do we validate runtime framework for .NET Standard 2.0?
+            // TODO: How do we validate runtime framework for .NET Standard 2.0?
             var frameworkSetting = TestPackage.GetSetting(EnginePackageSettings.RequestedRuntimeFramework, "");
             var runAsX86 = TestPackage.GetSetting(EnginePackageSettings.RunAsX86, false);
 
@@ -379,8 +380,13 @@ namespace NUnit.Engine.Runners
                 if (TestPackage.Settings.ContainsKey(oldKey) && !TestPackage.Settings.ContainsKey(newKey))
                     TestPackage.Settings[newKey] = TestPackage.Settings[oldKey];
             }
-#endif
         }
+#else
+        private static void ValidatePackageSettings()
+        {
+            // No settings to validate in .NET Core
+        }
+#endif
 
         /// <summary>
         /// Unload any loaded TestPackage.

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -48,8 +48,8 @@ namespace NUnit.Engine.Runners
 
         public MasterTestRunner(IServiceLocator services, TestPackage package)
         {
-            if (services == null) throw new ArgumentNullException("services");
-            if (package == null) throw new ArgumentNullException("package");
+            if (services == null) throw new ArgumentNullException(nameof(services));
+            if (package == null) throw new ArgumentNullException(nameof(package));
 
             _services = services;
             TestPackage = package;
@@ -269,7 +269,7 @@ namespace NUnit.Engine.Runners
         // allows the lower-level runners to be completely ignorant of projects
         private TestEngineResult PrepareResult(TestEngineResult result)
         {
-            if (result == null) throw new ArgumentNullException("result");
+            if (result == null) throw new ArgumentNullException(nameof(result));
 
             // See if we have any projects to deal with. At this point,
             // any subpackage, which itself has subpackages, is a project
@@ -330,7 +330,7 @@ namespace NUnit.Engine.Runners
 
         private void EnsurePackagesAreExpanded(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException("package");
+            if (package == null) throw new ArgumentNullException(nameof(package));
 
             foreach (var subPackage in package.SubPackages)
             {
@@ -345,7 +345,7 @@ namespace NUnit.Engine.Runners
 
         private bool IsProjectPackage(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException("package");
+            if (package == null) throw new ArgumentNullException(nameof(package));
 
             return
                 _projectService != null

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -377,8 +377,8 @@ namespace NUnit.Engine.Runners
             {
                 var oldKey = entry.OldKey;
                 var newKey = entry.NewKey;
-                if (TestPackage.Settings.ContainsKey(oldKey) && !TestPackage.Settings.ContainsKey(newKey))
-                    TestPackage.Settings[newKey] = TestPackage.Settings[oldKey];
+                if (TestPackage.Settings.TryGetValue(oldKey, out object? value) && !TestPackage.Settings.ContainsKey(newKey))
+                    TestPackage.Settings[newKey] = value;
             }
         }
 #else

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -48,8 +48,8 @@ namespace NUnit.Engine.Runners
 
         public MasterTestRunner(IServiceLocator services, TestPackage package)
         {
-            if (services == null) throw new ArgumentNullException(nameof(services));
-            if (package == null) throw new ArgumentNullException(nameof(package));
+            Guard.ArgumentNotNull(services, nameof(services));
+            Guard.ArgumentNotNull(package, nameof(package));
 
             _services = services;
             TestPackage = package;
@@ -269,7 +269,7 @@ namespace NUnit.Engine.Runners
         // allows the lower-level runners to be completely ignorant of projects
         private TestEngineResult PrepareResult(TestEngineResult result)
         {
-            if (result == null) throw new ArgumentNullException(nameof(result));
+            Guard.ArgumentNotNull(result, nameof(result));
 
             // See if we have any projects to deal with. At this point,
             // any subpackage, which itself has subpackages, is a project
@@ -330,7 +330,7 @@ namespace NUnit.Engine.Runners
 
         private void EnsurePackagesAreExpanded(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException(nameof(package));
+            Guard.ArgumentNotNull(package, nameof(package));
 
             foreach (var subPackage in package.SubPackages)
             {
@@ -345,7 +345,7 @@ namespace NUnit.Engine.Runners
 
         private bool IsProjectPackage(TestPackage package)
         {
-            if (package == null) throw new ArgumentNullException(nameof(package));
+            Guard.ArgumentNotNull(package, nameof(package));
 
             return
                 _projectService != null

--- a/src/NUnitEngine/nunit.engine/Runners/ParallelTaskWorkerPool.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/ParallelTaskWorkerPool.cs
@@ -18,7 +18,7 @@ namespace NUnit.Engine.Runners
 
         public ParallelTaskWorkerPool(int maxThreads)
         {
-            Guard.ArgumentValid(maxThreads >= 1, "Number of threads must be greater than zero.", "maxThreads");
+            Guard.ArgumentValid(maxThreads >= 1, "Number of threads must be greater than zero.", nameof(maxThreads));
 
             _maxThreads = maxThreads;
             _tasks = new Queue<ITestExecutionTask>();

--- a/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/TestEventDispatcher.cs
@@ -32,8 +32,8 @@ namespace NUnit.Engine.Runners
             }
         }
 
-#if NET8_0
-        [Obsolete]
+#if NET5_0_OR_GREATER
+        [Obsolete("This Remoting API is not supported and throws PlatformNotSupportedException. SYSLIB0010")]
 #endif
         public override object InitializeLifetimeService()
         {

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -52,7 +52,7 @@ namespace NUnit.Engine
             FrameworkName = new FrameworkName(runtime.FrameworkIdentifier, FrameworkVersion);
         }
 
-        private bool IsValidFrameworkVersion(Version v)
+        private static bool IsValidFrameworkVersion(Version v)
         {
             // All known framework versions have either two components or
             // three. If three, then the Build is currently less than 3.

--- a/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
+++ b/src/NUnitEngine/nunit.engine/RuntimeFramework.cs
@@ -63,6 +63,8 @@ namespace NUnit.Engine
 
         #region IRuntimeFramework Implementation
 
+        private static readonly char[] RuntimeFrameworkSeparator = ['-'];
+
         /// <summary>
         /// Gets the unique Id for this runtime, such as "net-4.5"
         /// </summary>
@@ -106,7 +108,7 @@ namespace NUnit.Engine
         {
             Guard.ArgumentNotNullOrEmpty(s, nameof(s));
 
-            string[] parts = s.Split(new char[] { '-' });
+            string[] parts = s.Split(RuntimeFrameworkSeparator);
             Guard.ArgumentValid(parts.Length == 2 && parts[0].Length > 0 && parts[1].Length > 0, "RuntimeFramework id not in correct format", nameof(s));
 
             var runtime = Runtime.Parse(parts[0]);

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
@@ -41,7 +41,7 @@ namespace NUnit.Engine.Services
                 return new AgentRecord(Process, agent);
             }
 
-            public AgentRecord Terminated()
+            public static AgentRecord Terminated()
             {
                 return new AgentRecord(process: null, agent: null);
             }

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.AgentRecord.cs
@@ -29,14 +29,14 @@ namespace NUnit.Engine.Services
 
             public static AgentRecord Starting(Process process)
             {
-                if (process is null) throw new ArgumentNullException(nameof(process));
+                Guard.ArgumentNotNull(process, nameof(process));
 
                 return new AgentRecord(process, agent: null);
             }
 
             public AgentRecord Ready(ITestAgent agent)
             {
-                if (agent is null) throw new ArgumentNullException(nameof(agent));
+                Guard.ArgumentNotNull(agent, nameof(agent));
 
                 return new AgentRecord(Process, agent);
             }

--- a/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentStore.cs
@@ -76,12 +76,12 @@ namespace NUnit.Engine.Services
         {
             lock (_agentsById)
             {
-                if (!_agentsById.TryGetValue(agentId, out var record))
+                if (!_agentsById.ContainsKey(agentId))
                 {
                     throw new ArgumentException($"An entry for agent {agentId} must exist in order to mark it as terminated.", nameof(agentId));
                 }
 
-                _agentsById[agentId] = record.Terminated();
+                _agentsById[agentId] = AgentRecord.Terminated();
             }
         }
     }

--- a/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ProjectService.cs
@@ -81,7 +81,7 @@ namespace NUnit.Engine.Services
             log.Debug($"Expanding package {package.Name}");
 
             Guard.ArgumentNotNull(package, "package");
-            Guard.ArgumentValid(package.SubPackages.Count == 0, "Package is already expanded", "package");
+            Guard.ArgumentValid(package.SubPackages.Count == 0, "Package is already expanded", nameof(package));
 
             string path = package.FullName!;
             if (!File.Exists(path))
@@ -95,7 +95,7 @@ namespace NUnit.Engine.Services
             if (activeConfig == null)
                 activeConfig = project.ActiveConfigName;
             else
-                Guard.ArgumentValid(project.ConfigNames.Contains(activeConfig), $"Requested configuration {activeConfig} was not found", "package");
+                Guard.ArgumentValid(project.ConfigNames.Contains(activeConfig), $"Requested configuration {activeConfig} was not found", nameof(package));
 
             TestPackage tempPackage = project.GetTestPackage(activeConfig);
             log.Debug("Got temp package");

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -46,7 +46,7 @@ namespace NUnit.Engine.Services
             }
         }
 
-        private XmlNode GetStubResult()
+        private static XmlNode GetStubResult()
         {
             var doc = new XmlDocument();
             var test = doc.CreateElement("test-run");

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/NUnit3XmlResultWriter.cs
@@ -46,7 +46,7 @@ namespace NUnit.Engine.Services
             }
         }
 
-        private static XmlNode GetStubResult()
+        private static XmlDocument GetStubResult()
         {
             var doc = new XmlDocument();
             var test = doc.CreateElement("test-run");

--- a/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ResultWriters/XmlTransformResultWriter.cs
@@ -22,7 +22,7 @@ namespace NUnit.Engine.Services
             Guard.ArgumentValid(
                 !string.IsNullOrEmpty(_xsltFile),
                 "Argument to XmlTransformWriter must be a non-empty string",
-                "args");
+                nameof(args));
 
             try
             {

--- a/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/RuntimeFrameworkService.cs
@@ -277,7 +277,7 @@ namespace NUnit.Engine.Services
                     "GetDisplayName", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.ExactBinding);
                 if (getDisplayNameMethod != null)
                 {
-                    string displayName = (string)getDisplayNameMethod.Invoke(null, new object[0])!;
+                    string displayName = (string)getDisplayNameMethod.Invoke(null, Array.Empty<object>())!;
 
                     int space = displayName.IndexOf(' ');
                     if (space >= 3) // Minimum length of a version

--- a/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ServiceManager.cs
@@ -23,11 +23,7 @@ namespace NUnit.Engine.Services
 
         public IService GetService( Type serviceType )
         {
-            IService? theService = null;
-
-            if (_serviceIndex.ContainsKey(serviceType))
-                theService = _serviceIndex[serviceType];
-            else
+            if (!_serviceIndex.TryGetValue(serviceType, out IService? theService))
                 foreach( IService service in _services )
                 {
                     if( serviceType.IsInstanceOfType( service ) )

--- a/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
@@ -234,7 +234,7 @@ namespace NUnit.Engine
             throw InvalidTokenError(token);
         }
 
-        private static Exception InvalidTokenError(Token token)
+        private static TestSelectionParserException InvalidTokenError(Token token)
         {
             return new TestSelectionParserException(string.Format(
                 "Unexpected token '{0}' at position {1} in selection expression.", token.Text, token.Pos));

--- a/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
+++ b/src/NUnitEngine/nunit.engine/Services/TestSelectionParser.cs
@@ -234,7 +234,7 @@ namespace NUnit.Engine
             throw InvalidTokenError(token);
         }
 
-        private Exception InvalidTokenError(Token token)
+        private static Exception InvalidTokenError(Token token)
         {
             return new TestSelectionParserException(string.Format(
                 "Unexpected token '{0}' at position {1} in selection expression.", token.Text, token.Pos));

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -87,8 +87,7 @@ namespace NUnit.Engine
 
         public Tokenizer(string input)
         {
-            if (input == null)
-                throw new ArgumentNullException(nameof(input));
+            Guard.ArgumentNotNull(input, nameof(input));
 
             _input = input;
             _index = 0;

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -154,7 +154,7 @@ namespace NUnit.Engine
             }
         }
 
-        private bool IsWordChar(char c)
+        private static bool IsWordChar(char c)
         {
             if (char.IsWhiteSpace(c) || c == EOF_CHAR)
                 return false;

--- a/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
+++ b/src/NUnitEngine/nunit.engine/Services/Tokenizer.cs
@@ -88,7 +88,7 @@ namespace NUnit.Engine
         public Tokenizer(string input)
         {
             if (input == null)
-                throw new ArgumentNullException("input");
+                throw new ArgumentNullException(nameof(input));
 
             _input = input;
             _index = 0;

--- a/src/NUnitEngine/nunit.engine/TestEngine.cs
+++ b/src/NUnitEngine/nunit.engine/TestEngine.cs
@@ -56,7 +56,12 @@ namespace NUnit.Engine
         {
             if(InternalTraceLevel != InternalTraceLevel.Off && !InternalTrace.Initialized)
             {
-                var logName = string.Format("InternalTrace.{0}.log", Process.GetCurrentProcess().Id);
+#if NET6_0_OR_GREATER
+                int id = Environment.ProcessId;
+#else
+                int id = Process.GetCurrentProcess().Id;
+#endif
+                var logName = string.Format("InternalTrace.{0}.log", id);
                 InternalTrace.Initialize(Path.Combine(WorkDirectory, logName), InternalTraceLevel);
             }
 

--- a/src/TestData/mock-assembly/MockAssembly.cs
+++ b/src/TestData/mock-assembly/MockAssembly.cs
@@ -158,7 +158,7 @@ namespace NUnit.TestData
                 MethodThrowsException();
             }
 
-            private void MethodThrowsException()
+            private static void MethodThrowsException()
             {
                 throw new Exception("Intentional Exception");
             }


### PR DESCRIPTION
Partly addresses #1590

Not sure why some of these rules are enabled in the minimum ruleset.

I did them per rule so we can decided if we want to have that rule or make our own set.