### PR TITLE
Ensure path to exe is quoted when running dotnet agents

### DIFF
--- a/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
+++ b/src/NUnitEngine/nunit.engine/Services/AgentProcess.cs
@@ -64,7 +64,7 @@ namespace NUnit.Engine.Services
             else if (TargetRuntime.Runtime == RuntimeType.NetCore)
             {
                 StartInfo.FileName = "dotnet";
-                StartInfo.Arguments = $"{AgentExePath} {AgentArgs}";
+                StartInfo.Arguments = $"\"{AgentExePath}\" {AgentArgs}";
                 StartInfo.LoadUserProfile = loadUserProfile;
 
                 // TODO: Remove the windows limitation and the use of a hard-coded path.


### PR DESCRIPTION
Fixes #1401