### PR TITLE
Add lock around Launchers property initialization.

### DIFF
--- a/package-tests.cake
+++ b/package-tests.cake
@@ -153,21 +153,21 @@ if (dotnetX86Available)
 StandardRunnerTests.Add(new PackageTest(1, "Net462PlusNet462Test")
 {
     Description = "Run two copies of mock-assembly together",
-    Arguments = "testdata/net462/mock-assembly.dll testdata/net462/mock-assembly.dll --agents:1",
+    Arguments = "testdata/net462/mock-assembly.dll testdata/net462/mock-assembly.dll",
     ExpectedResult = new MockAssemblyExpectedResult("net-4.6.2", "net-4.6.2")
 });
 
 StandardRunnerTests.Add(new PackageTest(1, "Net60PlusNet80Test")
 {
     Description = "Run mock-assembly under .NET6.0 and 8.0 together",
-    Arguments = "testdata/net6.0/mock-assembly.dll testdata/net8.0/mock-assembly.dll --agents:1",
+    Arguments = "testdata/net6.0/mock-assembly.dll testdata/net8.0/mock-assembly.dll",
     ExpectedResult = new MockAssemblyExpectedResult("netcore-6.0", "netcore-8.0")
 });
 
 StandardRunnerTests.Add(new PackageTest(1, "Net462PlusNet60Test")
 {
     Description = "Run mock-assembly under .Net Framework 4.6.2 and .Net 6.0 together",
-    Arguments = "testdata/net462/mock-assembly.dll testdata/net6.0/mock-assembly.dll --agents:1",
+    Arguments = "testdata/net462/mock-assembly.dll testdata/net6.0/mock-assembly.dll",
     ExpectedResult = new MockAssemblyExpectedResult("net-4.6.2", "netcore-6.0")
 });
 


### PR DESCRIPTION
Fixes #1685 

The fix is to add a lock inside the `Launchers` property for the initialization of the list of agents.

Drop limitation for 1 agent in package-test.cake

@CharliePoole Although this works, I don't like private properties.
Can we initialize the field in StartService instead, then we don't need a lock.
I didn't do it yet as you might have had a good reason for not doing it there.
