### PR TITLE
Port 1570 to V4; drop --teamcity option

### DIFF
--- a/cake/package-tests.cake
+++ b/cake/package-tests.cake
@@ -475,7 +475,7 @@ StandardRunnerTests.Add(new PackageTest(1, "V2ResultWriterTest_Net462")
 StandardRunnerTests.Add(new PackageTest(1, "TeamCityListenerTest")
 {
     Description = "Run mock-assembly with --teamcity enabled",
-    Arguments = "testdata/net462/mock-assembly.dll --teamcity",
+    Arguments = "testdata/net462/mock-assembly.dll --enable NUnit.Engine.Listeners.TeamCityEventListener",
     ExpectedResult = new MockAssemblyExpectedResult("net-4.6.2"),
     ExtensionsNeeded = new[] { Extensions.TeamCityEventListener }
 });

--- a/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/CommandLineTests.cs
@@ -274,6 +274,9 @@ namespace NUnit.ConsoleRunner
         [TestCase("--test-name-format")]
         [TestCase("--param")]
         [TestCase("--encoding")]
+        [TestCase("--extensionDirectory")]
+        [TestCase("--enable")]
+        [TestCase("--disable")]
 #if NETFRAMEWORK
         [TestCase("--framework")]
 #endif

--- a/src/NUnitConsole/nunit4-console.tests/ConsoleRunnerTests.cs
+++ b/src/NUnitConsole/nunit4-console.tests/ConsoleRunnerTests.cs
@@ -46,10 +46,10 @@ namespace NUnit.ConsoleRunner
         }
 
         [Test]
-        public void ThrowsRequiredExtensionExceptionWhenTeamcityOptionIsSpecifiedButNotAvailable()
+        public void ThrowsRequiredExtensionExceptionWhenExtensionIsEnabledButNotAvailable()
         {
             var ex = Assert.Throws<RequiredExtensionException>(
-                () => new ConsoleRunner(_testEngine, ConsoleMocks.Options("mock-assembly.dll", "--teamcity"), new ColorConsoleWriter()));
+                () => new ConsoleRunner(_testEngine, ConsoleMocks.Options("mock-assembly.dll", $"--enable=NUnit.Engine.Listeners.TeamCityEventListener"), new ColorConsoleWriter()));
 
             Assert.That(ex, Has.Message.EqualTo("Required extension 'NUnit.Engine.Listeners.TeamCityEventListener' is not installed."));
         }

--- a/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleOptions.cs
@@ -310,9 +310,6 @@ namespace NUnit.ConsoleRunner
             this.Add("trace=", "Set internal trace {LEVEL}.\nValues: Off, Error, Warning, Info, Verbose (Debug)",
                 v => InternalTraceLevel = parser.RequiredValue(v, "--trace", "Off", "Error", "Warning", "Info", "Verbose", "Debug"));
 
-            this.Add("teamcity", "Turns on use of TeamCity service messages. TeamCity engine extension is required.",
-                v => EnableExtensions.Add("NUnit.Engine.Listeners.TeamCityEventListener"));
-
             this.Add("enable=", "Enables the specified extension. May be repeated.", v =>
             {
                 string extension = parser.RequiredValue(v, "--enable");

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -96,6 +96,7 @@ namespace NUnit.ConsoleRunner
                     throw new RequiredExtensionException(typeName);
 
                 EnableExtension(typeName);
+                Console.WriteLine($"Enabled extension {typeName}");
             }
 
             // Also enable TeamCity extension under TeamCity, if it is installed


### PR DESCRIPTION
Issue #1570 was pretty much already taken care of in V4, but a few changes were missing.

The --teamcity option had not yet been removed, as promised in #878. It has now been removed.