### PR TITLE
Improvements to the ExtensionManager

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,8 @@
         <NSubstitutePublicKey>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</NSubstitutePublicKey>
     </PropertyGroup>
 
-    <!-- Common package metadata -->
+    <!-- Common package metadata, may be overridden in individual projects -->
+    <!-- Each project should supply properties for PackageId, Title and Description -->
     <PropertyGroup>
         <PackageOutputPath>$(MSBuildThisFileDirectory)..\package</PackageOutputPath>
         <IncludeSymbols>true</IncludeSymbols>
@@ -46,6 +47,8 @@
         <PackageIcon>nunit_256.png</PackageIcon>
         <PackageIconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</PackageIconUrl>
         <PackageReleaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</PackageReleaseNotes>
+        <RepositoryUrl>https://github.com/NUnit/nunit-console</RepositoryUrl>
+        <ReleaseNotes>https://docs.nunit.org/articles/nunit/release-notes/console-and-engine.html</ReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
@@ -17,6 +17,15 @@ namespace NUnit.Engine.Drivers
     /// </summary>
     public class DriverService : IDriverService
     {
+#if NETFRAMEWORK
+        private const string TYPE_EXTENSION_PATH = "/NUnit/Engine/TypeExtensions/";
+
+        private static readonly Assembly THIS_ASSEMBLY = typeof(DriverService).Assembly;
+        private static readonly bool RUNNING_UNDER_CHOCOLATEY =
+            System.IO.File.Exists(Path.Combine(Path.GetDirectoryName(THIS_ASSEMBLY.Location)!, "VERIFICATION.txt"));
+        private static readonly string PACKAGE_PREFIX = RUNNING_UNDER_CHOCOLATEY ? "nunit-extension-" : "NUnit.Extension.";
+#endif
+
         private static readonly Logger log = InternalTrace.GetLogger("DriverService");
 
         private static readonly char[] CommaSeparator = [','];
@@ -28,11 +37,14 @@ namespace NUnit.Engine.Drivers
             _factories.Add(new NUnit3DriverFactory());
 
 #if NETFRAMEWORK // TODO: Restore extensibility to .NET 8.0 build
-            var thisAssembly = Assembly.GetExecutingAssembly();
-            var extensionManager = new ExtensionManager("/NUnit/Engine/TypeExtensions/");
+            var extensionManager = new ExtensionManager()
+            {
+                TypeExtensionPath = TYPE_EXTENSION_PATH,
+                PackagePrefixes = [PACKAGE_PREFIX]
+            };
 
-            extensionManager.FindExtensionPoints(thisAssembly);
-            extensionManager.FindExtensionAssemblies(thisAssembly);
+            extensionManager.FindExtensionPoints(THIS_ASSEMBLY);
+            extensionManager.FindExtensionAssemblies(THIS_ASSEMBLY);
 
             foreach (IDriverFactory factory in extensionManager.GetExtensions<IDriverFactory>())
                 _factories.Add(factory);
@@ -41,7 +53,6 @@ namespace NUnit.Engine.Drivers
             if (node is not null)
                 _factories.Add(new NUnit2DriverFactory(node));
 #endif
-
         }
 
         /// <summary>

--- a/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/DriverService.cs
@@ -29,7 +29,7 @@ namespace NUnit.Engine.Drivers
 
 #if NETFRAMEWORK // TODO: Restore extensibility to .NET 8.0 build
             var thisAssembly = Assembly.GetExecutingAssembly();
-            var extensionManager = new ExtensionManager();
+            var extensionManager = new ExtensionManager("/NUnit/Engine/TypeExtensions/");
 
             extensionManager.FindExtensionPoints(thisAssembly);
             extensionManager.FindExtensionAssemblies(thisAssembly);

--- a/src/NUnitCommon/nunit.agent.core/nunit.agent.core.csproj
+++ b/src/NUnitCommon/nunit.agent.core/nunit.agent.core.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <PackageId>NUnit.Agent.Core</PackageId>
+    <Title>Agent Core</Title>
     <Description>Contains Types used by agents.</Description>
   </PropertyGroup>
 

--- a/src/NUnitCommon/nunit.common/nunit.common.csproj
+++ b/src/NUnitCommon/nunit.common/nunit.common.csproj
@@ -7,6 +7,7 @@
 
   <PropertyGroup>
     <PackageId>NUnit.Common</PackageId>
+    <Title>NUnit Shared Types</Title>
     <Description>Contains Types used by both the engine and agents.</Description>
   </PropertyGroup>
 

--- a/src/NUnitCommon/nunit.extensibility.api/nunit.extensibility.api.csproj
+++ b/src/NUnitCommon/nunit.extensibility.api/nunit.extensibility.api.csproj
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <PackageId>NUnit.Extensibility.Api</PackageId>
+    <Title>NUnit Extensibility Api</Title>
     <Description>Contains the Types required for creating an NUnit extension of any kind.</Description>
   </PropertyGroup>
   

--- a/src/NUnitCommon/nunit.extensibility.tests/ExtensionManagerTests.cs
+++ b/src/NUnitCommon/nunit.extensibility.tests/ExtensionManagerTests.cs
@@ -44,7 +44,7 @@ namespace NUnit.Extensibility
         };
 
         private ExtensionManager _extensionManager;
-        private static string? _defaultTestExtensionPath;
+        private string _defaultTestExtensionPath;
 
         private string[] _expectedExtensionPointPaths;
         private Type[] _expectedExtensionPointTypes;
@@ -87,7 +87,7 @@ namespace NUnit.Extensibility
         [SetUp]
         public void CreateExtensionManager()
         {
-            _extensionManager = new ExtensionManager(_defaultTestExtensionPath);
+            _extensionManager = new ExtensionManager() { TypeExtensionPath = _defaultTestExtensionPath };
 
             // Find actual extension points.
             _extensionManager.FindExtensionPoints(typeof(ExtensionManager).Assembly);

--- a/src/NUnitCommon/nunit.extensibility/ExtensibilityException.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensibilityException.cs
@@ -6,31 +6,31 @@ using System.Runtime.Serialization;
 namespace NUnit.Extensibility
 {
     /// <summary>
-    /// NUnitEngineException is thrown when the engine has been
-    /// called with improper values or when a particular facility
+    /// ExtensibilityException is thrown when the extensibility features
+    /// are used with improper values or when a particular feature
     /// is not available.
     /// </summary>
     [Serializable]
-    public class NUnitExtensibilityException : Exception
+    public class ExtensibilityException : Exception
     {
         /// <summary>
         /// Construct with a message
         /// </summary>
-        public NUnitExtensibilityException(string message) : base(message)
+        public ExtensibilityException(string message) : base(message)
         {
         }
 
         /// <summary>
         /// Construct with a message and inner exception
         /// </summary>
-        public NUnitExtensibilityException(string message, Exception? innerException) : base(message, innerException)
+        public ExtensibilityException(string message, Exception? innerException) : base(message, innerException)
         {
         }
 
         /// <summary>
         /// Serialization constructor
         /// </summary>
-        public NUnitExtensibilityException(SerializationInfo info, StreamingContext context) : base(info, context)
+        public ExtensibilityException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
@@ -103,7 +103,7 @@ namespace NUnit.Extensibility
                 foreach (ExtensionPointAttribute attr in assembly.GetCustomAttributes(typeof(ExtensionPointAttribute), false))
                 {
                     if (_extensionPointIndex.ContainsKey(attr.Path))
-                        throw new NUnitExtensibilityException($"The Path {attr.Path} is already in use for another extension point.");
+                        throw new ExtensibilityException($"The Path {attr.Path} is already in use for another extension point.");
 
                     var ep = new ExtensionPoint(attr.Path, attr.Type)
                     {
@@ -123,7 +123,7 @@ namespace NUnit.Extensibility
                         string path = attr.Path ?? "/NUnit/Engine/TypeExtensions/" + type.Name;
 
                         if (_extensionPointIndex.ContainsKey(path))
-                            throw new NUnitExtensibilityException($"The Path {attr.Path} is already in use for another extension point.");
+                            throw new ExtensibilityException($"The Path {attr.Path} is already in use for another extension point.");
 
                         var ep = new ExtensionPoint(path, type)
                         {
@@ -535,7 +535,7 @@ namespace NUnit.Extensibility
                 {
                     ep = DeduceExtensionPointFromType(extensionType);
                     if (ep is null)
-                        throw new NUnitExtensibilityException($"Unable to deduce ExtensionPoint for Type {extensionType.FullName}. Specify Path on ExtensionAttribute to resolve.");
+                        throw new ExtensibilityException($"Unable to deduce ExtensionPoint for Type {extensionType.FullName}. Specify Path on ExtensionAttribute to resolve.");
 
                     node.Path = ep.Path;
                 }
@@ -546,7 +546,7 @@ namespace NUnit.Extensibility
                     // TODO: Remove need for the cast
                     ep = GetExtensionPoint(node.Path) as ExtensionPoint;
                     if (ep is null)
-                        throw new NUnitExtensibilityException($"Unable to locate ExtensionPoint for Type {extensionType.FullName}. The Path {node.Path} cannot be found.");
+                        throw new ExtensibilityException($"Unable to locate ExtensionPoint for Type {extensionType.FullName}. The Path {node.Path} cannot be found.");
                 }
 
                 ep.Install(node);

--- a/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionManager.cs
@@ -22,6 +22,10 @@ namespace NUnit.Extensibility
     /// </remarks>
     public class ExtensionManager
     {
+        // Default path prefix for Type Extensions if the caller does not supply
+        // it as an argument to the constructor.
+        public const string DEFAULT_TYPE_EXTENSION_PATH = "/NUnit/Extensibility/TypeExtensions/";
+
         private static readonly Version CURRENT_ENGINE_VERSION = Assembly.GetExecutingAssembly().GetName().Version ?? new Version();
         private static readonly string EXTENSION_ATTRIBUTE = typeof(ExtensionAttribute).FullName.ShouldNotBeNull();
         private static readonly string EXTENSION_PROPERTY_ATTRIBUTE = typeof(ExtensionPropertyAttribute).FullName.ShouldNotBeNull();
@@ -30,6 +34,7 @@ namespace NUnit.Extensibility
 
         private static readonly Logger log = InternalTrace.GetLogger(typeof(ExtensionManager));
 
+        private readonly string _typeExtensionPath;
         private readonly IFileSystem _fileSystem;
         private readonly IDirectoryFinder _directoryFinder;
 
@@ -52,18 +57,19 @@ namespace NUnit.Extensibility
         // used to ignore duplicate calls to FindExtensionAssemblies.
         private readonly List<string> _extensionDirectories = new List<string>();
 
-        public ExtensionManager()
-            : this(new FileSystem())
+        public ExtensionManager(string? typeExtensionPath = null)
+            : this(typeExtensionPath, new FileSystem())
         {
         }
 
-        public ExtensionManager(IFileSystem fileSystem)
-            : this(fileSystem, new DirectoryFinder(fileSystem))
+        public ExtensionManager(string? typeExtensionPath, IFileSystem fileSystem)
+            : this(typeExtensionPath, fileSystem, new DirectoryFinder(fileSystem))
         {
         }
 
-        public ExtensionManager(IFileSystem fileSystem, IDirectoryFinder directoryFinder)
+        public ExtensionManager(string? typeExtensionPath, IFileSystem fileSystem, IDirectoryFinder directoryFinder)
         {
+            _typeExtensionPath = typeExtensionPath ?? DEFAULT_TYPE_EXTENSION_PATH;
             _fileSystem = fileSystem;
             _directoryFinder = directoryFinder;
         }
@@ -120,7 +126,7 @@ namespace NUnit.Extensibility
                 {
                     foreach (TypeExtensionPointAttribute attr in type.GetCustomAttributes(typeof(TypeExtensionPointAttribute), false))
                     {
-                        string path = attr.Path ?? "/NUnit/Engine/TypeExtensions/" + type.Name;
+                        string path = attr.Path ?? _typeExtensionPath + type.Name;
 
                         if (_extensionPointIndex.ContainsKey(path))
                             throw new ExtensibilityException($"The Path {attr.Path} is already in use for another extension point.");

--- a/src/NUnitCommon/nunit.extensibility/ExtensionPoint.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionPoint.cs
@@ -64,7 +64,7 @@ namespace NUnit.Extensibility
         public void Install(ExtensionNode node)
         {
             if (node.Path != Path)
-                throw new NUnitExtensibilityException($"Non-matching extension path. Expected {Path} but got {node.Path}.");
+                throw new ExtensibilityException($"Non-matching extension path. Expected {Path} but got {node.Path}.");
 
             // TODO: Verify that the type is correct using Cecil or Reflection
             // depending on whether the assembly is pre-loaded. For now, it's not

--- a/src/NUnitCommon/nunit.extensibility/ExtensionWrapper.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionWrapper.cs
@@ -35,7 +35,7 @@ namespace NUnit.Extensibility
                 case "/NUnit/Engine/TypeExtensions/IResultWriter":
                     return new ResultWriterWrapper(extension);
                 default:
-                    throw new NUnitExtensibilityException($"No wrapper available for extension path {path}");
+                    throw new ExtensibilityException($"No wrapper available for extension path {path}");
             }
         }
 

--- a/src/NUnitCommon/nunit.extensibility/nunit.extensibility.csproj
+++ b/src/NUnitCommon/nunit.extensibility/nunit.extensibility.csproj
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <PackageId>NUnit.Extensibility</PackageId>
+    <Title>NUnit Extensibility</Title>
     <Description>Contains implementation of the NUnit extensibility model.</Description>
   </PropertyGroup>
 

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using NUnit.Extensibility;
 using NUnit.FileSystemAccess;
@@ -16,24 +17,41 @@ namespace NUnit.Engine.Services
     {
         private const string ENGINE_TYPE_EXTENSION_PATH = "/NUnit/Engine/TypeExtensions/";
 
+        private static readonly Assembly THIS_ASSEMBLY = typeof(ExtensionService).Assembly;
+        private static readonly bool RUNNING_UNDER_CHOCOLATEY =
+            System.IO.File.Exists(Path.Combine(Path.GetDirectoryName(THIS_ASSEMBLY.Location)!, "VERIFICATION.txt"));
+        private static readonly string PACKAGE_PREFIX = RUNNING_UNDER_CHOCOLATEY ? "nunit-extension-" : "NUnit.Extension.";
+
         // The Extension Manager is available internally to allow direct
         // access to ExtensionPoints and ExtensionNodes.
         internal readonly ExtensionManager _extensionManager;
 
         public ExtensionService()
         {
-            _extensionManager = new ExtensionManager(ENGINE_TYPE_EXTENSION_PATH);
+            _extensionManager = new ExtensionManager
+            {
+                TypeExtensionPath = ENGINE_TYPE_EXTENSION_PATH,
+                PackagePrefixes = [PACKAGE_PREFIX]
+            };
         }
 
         internal ExtensionService(IFileSystem fileSystem)
             : this(fileSystem, new DirectoryFinder(fileSystem))
         {
-            _extensionManager = new ExtensionManager(ENGINE_TYPE_EXTENSION_PATH, fileSystem);
+            _extensionManager = new ExtensionManager(fileSystem)
+            {
+                TypeExtensionPath = ENGINE_TYPE_EXTENSION_PATH,
+                PackagePrefixes = [PACKAGE_PREFIX]
+            };
         }
 
         internal ExtensionService(IFileSystem fileSystem, IDirectoryFinder directoryFinder)
         {
-            _extensionManager = new ExtensionManager(ENGINE_TYPE_EXTENSION_PATH, fileSystem, directoryFinder);
+            _extensionManager = new ExtensionManager(fileSystem, directoryFinder)
+            {
+                TypeExtensionPath = ENGINE_TYPE_EXTENSION_PATH,
+                PackagePrefixes = [PACKAGE_PREFIX]
+            };
         }
 
         #region IExtensionService Implementation

--- a/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
+++ b/src/NUnitEngine/nunit.engine/Services/ExtensionService.cs
@@ -14,24 +14,26 @@ namespace NUnit.Engine.Services
     /// </summary>
     public class ExtensionService : Service, IExtensionService
     {
+        private const string ENGINE_TYPE_EXTENSION_PATH = "/NUnit/Engine/TypeExtensions/";
+
         // The Extension Manager is available internally to allow direct
         // access to ExtensionPoints and ExtensionNodes.
         internal readonly ExtensionManager _extensionManager;
 
         public ExtensionService()
         {
-            _extensionManager = new ExtensionManager();
+            _extensionManager = new ExtensionManager(ENGINE_TYPE_EXTENSION_PATH);
         }
 
         internal ExtensionService(IFileSystem fileSystem)
             : this(fileSystem, new DirectoryFinder(fileSystem))
         {
-            _extensionManager = new ExtensionManager(fileSystem);
+            _extensionManager = new ExtensionManager(ENGINE_TYPE_EXTENSION_PATH, fileSystem);
         }
 
         internal ExtensionService(IFileSystem fileSystem, IDirectoryFinder directoryFinder)
         {
-            _extensionManager = new ExtensionManager(fileSystem, directoryFinder);
+            _extensionManager = new ExtensionManager(ENGINE_TYPE_EXTENSION_PATH, fileSystem, directoryFinder);
         }
 
         #region IExtensionService Implementation


### PR DESCRIPTION
Fixes #1744 

This PR adds parameters to the `ExtensionManager` to control two aspects of it's behavior:

1. The default Path used for extension points defined by the `TypeExtensionAttribute`. This was previously hard-coded as "/NUnit/Engine/TypeExtensions/<TYPE>" but is now set by `ExtensionService` and `DriverService` when creating the manager.

2. The prefixes used for recognizing extensions stored in standard locations relative to the engine. This was previously hard-coded as well, using "NUnit.Extension.*" for nuget and "nunit-extension-*" for chocolatey. It is now set by the callers creating the manager.

The intent of this change is to make it easier for extensions not using the standard package naming to be located and installed. It enables use of `ExtensionManager` by additional NUnit components, i.e. other than the engine itself and potentially by third parties.

`ExtensionManager` is a somewhat low-level API and for most usage will probably be wrapped by a higher-level interface, which takes responsibility for creating the manager and setting parameters correctly. That's precisely the relationship between our `ExtensionService` and `ExtensionManager`.