### PR TITLE
Update metadata for NuGet package

### DIFF
--- a/nuget/runners/nunit.console-runner.nuspec
+++ b/nuget/runners/nunit.console-runner.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>NUnit.ConsoleRunner</id>
-    <title>NUnit Console Runner Version 3 (No Extensions)</title>
+    <title>NUnit Console Runner Version 4 (No Extensions)</title>
     <version>$version$</version>
     <authors>Charlie Poole, Rob Prouse</authors>
     <owners>Charlie Poole, Rob Prouse</owners>
@@ -12,9 +12,9 @@
     <iconUrl>https://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_256.png</iconUrl>
     <icon>images\nunit_256.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>Console runner for the NUnit 3 unit-testing framework, without any extensions.</summary>
+    <summary>Console runner for the NUnit unit-testing framework, without any extensions.</summary>
     <description>
-      This package includes the nunit3-console runner and test engine for version 3 of the NUnit unit-testing framework.
+      This package includes the nunit-console runner and test engine for the NUnit unit-testing framework.
 
       Any extensions, if needed, may be installed as separate packages.
     </description>


### PR DESCRIPTION
Fixes #1767

Updates the metadata to match [nunit.console-runner-with-extensions.nuspec](https://github.com/nunit/nunit-console/blob/9793a79387c25269a6fca017d2b53958a627ccd2/nuget/runners/nunit.console-runner-with-extensions.nuspec)