### PR TITLE
Handle prerelease dotnet runtimes correctly

### DIFF
--- a/src/NUnitEngine/nunit.engine.core.tests/DotNetHelperTests.cs
+++ b/src/NUnitEngine/nunit.engine.core.tests/DotNetHelperTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using NUnit.Framework;
+using System.Linq;
+
+namespace NUnit.Engine
+{
+    public static class DotNetHelperTests
+    {
+        [Test]
+        public static void CanGetInstallDirectory([Values] bool x86)
+        {
+            string path = DotNet.GetInstallDirectory(x86);
+            Assert.That(Directory.Exists(path));
+            Assert.That(File.Exists(Path.Combine(path, OS.IsWindows ? "dotnet.exe" : "dotnet")));
+        }
+
+        [Test]
+        public static void CanGetExecutable([Values] bool x86)
+        {
+            string path = DotNet.GetDotnetExecutable(x86);
+            Assert.That(File.Exists(path));
+            Assert.That(Path.GetFileName(path), Is.EqualTo(OS.IsWindows ? "dotnet.exe" : "dotnet"));
+        }
+
+        [Test]
+        public static void CanIssueDotNetCommand([Values] bool x86)
+        {
+            var output = DotNet.DotnetCommand("--help", x86);
+            Assert.That(output.Count(), Is.GreaterThan(0));
+        }
+
+        [TestCaseSource(nameof(RuntimeCases))]
+        public static void CanParseInputLine(string line, string name, string packageVersion, string path,
+            bool isPreRelease, Version version, string suffix)
+        {
+            DotNet.RuntimeInfo runtime = DotNet.RuntimeInfo.Parse(line);
+            Assert.That(runtime.Name, Is.EqualTo(name));
+            Assert.That(runtime.PackageVersion, Is.EqualTo(packageVersion));
+            Assert.That(runtime.Path, Is.EqualTo(path));
+            Assert.That(runtime.IsPreRelease, Is.EqualTo(isPreRelease));
+            Assert.That(runtime.Version, Is.EqualTo(version));
+            Assert.That(runtime.PreReleaseSuffix, Is.EqualTo(suffix));
+        }
+
+        static TestCaseData[] RuntimeCases = [
+            new TestCaseData("Microsoft.NETCore.App 8.0.22 [C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App]",
+                "Microsoft.NETCore.App", "8.0.22", "C:\\Program Files\\dotnet\\shared\\Microsoft.NETCore.App",
+                false, new Version(8,0,22), null),
+            new TestCaseData("Microsoft.WindowsDesktop.App 9.0.11 [C:\\Program Files\\dotnet\\shared\\Microsoft.WindowsDesktop.App]",
+                "Microsoft.WindowsDesktop.App", "9.0.11", "C:\\Program Files\\dotnet\\shared\\Microsoft.WindowsDesktop.App",
+                false, new Version(9,0,11), null),
+            new TestCaseData("Microsoft.AspNetCore.App 7.0.20 [C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App]",
+                "Microsoft.AspNetCore.App", "7.0.20", "C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App",
+                false, new Version(7,0,20), null),
+            new TestCaseData("Microsoft.AspNetCore.App 9.0.0-rc.2.24474.3 [C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App]",
+                "Microsoft.AspNetCore.App", "9.0.0-rc.2.24474.3", "C:\\Program Files\\dotnet\\shared\\Microsoft.AspNetCore.App",
+                true, new Version(9,0,0), "rc.2.24474.3")];
+
+        [TestCase("Microsoft.NETCore.App", "8.0.0", "8.0.22")]
+        [TestCase("Microsoft.NETCore.App", "8.0.0.0", "8.0.22")]
+        [TestCase("Microsoft.NETCore.App", "8.0.0.100", "8.0.22")]
+        [TestCase("Microsoft.NETCore.App", "8.0.100", "9.0.11")]
+        [TestCase("Microsoft.AspNetCore.App", "5.0.0", "8.0.22")] // Rather than 8.0.2
+        [TestCase("Microsoft.AspNetCore.App", "7.0.0", "8.0.22")] // Rather than 8.0.2
+        [TestCase("Microsoft.AspNetCore.App", "8.0.0", "8.0.22")] // Rather than 8.0.2
+        [TestCase("Microsoft.WindowsDesktop.App", "9.0.0", "9.0.11")] // Rather than the pre-release version
+        [TestCase("Microsoft.WindowsDesktop.App", "10.0.0", "10.0.0-rc.2.25502.107")]
+        public static void FindBestRuntimeTests(string runtimeName, string targetVersion, string expectedVersion)
+        {
+            var availableRuntimes = SimulatedListRuntimesOutput.Where(r => r.Name == runtimeName);
+            Assert.That(DotNet.FindBestRuntime(new Version(targetVersion), availableRuntimes, out DotNet.RuntimeInfo bestRuntime));
+            Assert.That(bestRuntime, Is.Not.Null);
+            Assert.That(bestRuntime.PackageVersion, Is.EqualTo(expectedVersion));
+        }
+
+        static DotNet.RuntimeInfo[] SimulatedListRuntimesOutput = [
+            DotNet.RuntimeInfo.Parse(@"Microsoft.AspNetCore.App 8.0.2 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.AspNetCore.App 8.0.22 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.AspNetCore.App 9.0.0-rc.2.24474.3 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.AspNetCore.App 9.0.11 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.AspNetCore.App 10.0.0-rc.2.25502.107 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.AspNetCore.App 10.0.0 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.NETCore.App 8.0.22 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.NETCore.App 9.0.0-rc.2.24473.5 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.NETCore.App 9.0.11 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.NETCore.App 10.0.0-rc.2.25502.107 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.NETCore.App 10.0.0 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.WindowsDesktop.App 8.0.22 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.WindowsDesktop.App 9.0.0-rc.2.24474.4 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.WindowsDesktop.App 9.0.11 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]"),
+            DotNet.RuntimeInfo.Parse(@"Microsoft.WindowsDesktop.App 10.0.0-rc.2.25502.107 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]") ];
+            //DotNet.RuntimeInfo.Parse(@"Microsoft.WindowsDesktop.App 10.0.0 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]") ];
+    }
+}

--- a/src/NUnitEngine/nunit.engine.core/DotNetHelper.cs
+++ b/src/NUnitEngine/nunit.engine.core/DotNetHelper.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
 
 namespace NUnit.Engine
 {
@@ -34,20 +36,73 @@ namespace NUnit.Engine
         private static Lazy<List<RuntimeInfo>> _x64Runtimes = new Lazy<List<RuntimeInfo>>(() => [.. GetAllRuntimes(x86: false)]);
         private static Lazy<List<RuntimeInfo>> _x86Runtimes = new Lazy<List<RuntimeInfo>>(() => [.. GetAllRuntimes(x86: true)]);
 
+        /// <summary>
+        /// DotNet.RuntimeInfo holds information about a single installed runtime.
+        /// </summary>
         public class RuntimeInfo
         {
-            public string Name;
-            public Version Version;
-            public string Path;
+            /// <summary>
+            /// Gets the runtime name, e.g. Microsoft.NetCore.App, Microsoft.AspNetCore.App or Microsoft.WindowsDesktop.App.
+            /// </summary>
+            public string Name { get; }
 
-            public RuntimeInfo(string name, string version, string path)
-                : this(name, new Version(version), path) { }
+            /// <summary>
+            /// Gets the package version as a string, possibly including a pre-release suffix.
+            /// </summary>
+            public string PackageVersion { get; }
 
-            public RuntimeInfo(string name, Version version, string path)
+            /// <summary>
+            /// Gets the path to the directory containing assemblies for this runtime
+            /// </summary>
+            public string Path { get; }
+
+            /// <summary>
+            /// Gets a flag, which is true if this runtime is a pre-release, otherwise fales.
+            /// </summary>
+            public bool IsPreRelease { get; }
+
+            /// <summary>
+            /// Gets the three-part version of this  runtime.
+            /// </summary>
+            public Version Version { get; }
+
+            /// <summary>
+            /// Gets the pre-release suffix if IsPreRelease is true, otherwise null
+            /// </summary>
+            public string PreReleaseSuffix { get; }
+
+
+            /// <summary>
+            /// Constructs a Runtime instance.
+            /// </summary>
+            public RuntimeInfo(string name, string packageVersion, string path)
             {
                 Name = name;
-                Version = version;
+                PackageVersion = packageVersion;
                 Path = path;
+
+                int dash = PackageVersion.IndexOf('-');
+                IsPreRelease = dash > 0;
+
+                if (IsPreRelease)
+                {
+                    Version = new Version(packageVersion.Substring(0, dash));
+                    PreReleaseSuffix = packageVersion.Substring(dash + 1);
+                }
+                else
+                    Version = new Version(packageVersion);
+            }
+
+            /// <summary>
+            /// Parses a single line from the --list-runtimes display to create 
+            /// an instance of DotNet.RuntimeInfo.
+            /// </summary>
+            /// <param name="line">Line from execution of dotnet --list-runtimes</param>
+            /// <returns>A DotNet.RuntimeInfo</returns>
+            public static RuntimeInfo Parse(string line)
+            {
+                string[] parts = line.Trim().Split([' '], 3);
+                return new RuntimeInfo(parts[0], parts[1], parts[2].Trim(['[', ']']));
             }
         }
 
@@ -55,7 +110,6 @@ namespace NUnit.Engine
         /// Get the correct install directory, depending on whether we need X86 or X64 architecture.
         /// </summary>
         /// <param name="x86">Flag indicating whether the X86 architecture is needed</param>
-        /// <returns></returns>
         public static string GetInstallDirectory(bool x86) => x86
             ? _x86InstallDirectory.Value : _x64InstallDirectory.Value;
 
@@ -63,25 +117,57 @@ namespace NUnit.Engine
         /// Get the correct dotnet.exe, depending on whether we need X86 or X64 architecture.
         /// </summary>
         /// <param name="x86">Flag indicating whether the X86 architecture is needed</param>
-        /// <returns></returns>
-        public static string GetDotnetExecutable(bool x86) => Path.Combine(GetInstallDirectory(x86), OS.IsWindows ? "dotnet.exe" : "dotnet");
+        public static string GetDotnetExecutable(bool x86) => 
+            Path.Combine(GetInstallDirectory(x86), OS.IsWindows ? "dotnet.exe" : "dotnet");
 
+        /// <summary>
+        /// Gets an enumeration of all installed runtimes matching the specified name and x86 flag.
+        /// </summary>
+        /// <param name="name">Name of the requested runtime</param>
+        /// <param name="x86">Flag indicating whether the X86 architecture is needed</param>
         public static IEnumerable<RuntimeInfo> GetRuntimes(string name, bool x86)
         {
             var runtimes = x86 ? _x86Runtimes.Value : _x64Runtimes.Value;
             return runtimes.Where(r => r.Name == name);
         }
 
+        /// <summary>
+        /// Finds the "best" runtime for a particular asssembly version among those installed.
+        /// May return null, if no suitable runtime is available.
+        /// </summary>
+        /// <param name="targetVersion">The version of assembly sought.</param>
+        /// <param name="name">Name of the requested runtime</param>
+        /// <param name="x86">Flag indicating whether the X86 architecture is needed</param>
+        /// <param name="bestRuntime">Output variable set to the runtime that was found or null</param>
+        /// <returns>True if a runtime was found, otherwise false</returns>
+        public static bool FindBestRuntime(Version targetVersion, string name, bool x86, out RuntimeInfo bestRuntime) =>
+            FindBestRuntime(targetVersion, GetRuntimes(name, x86), out bestRuntime);
+
+        // Internal method used to facilitate testing
+        internal static bool FindBestRuntime(Version targetVersion, IEnumerable<RuntimeInfo> availableRuntimes, out RuntimeInfo bestRuntime)
+        {
+            bestRuntime = null;
+
+            if (targetVersion is null)
+                return false;
+
+            foreach (var candidate in availableRuntimes)
+            {
+                if (candidate.Version >= targetVersion)
+                    if (bestRuntime is null || candidate.Version.Major == bestRuntime.Version.Major)
+                        bestRuntime = candidate;
+            }
+
+            return bestRuntime is not null;
+        }
+
         private static IEnumerable<RuntimeInfo> GetAllRuntimes(bool x86)
         {
             foreach (string line in DotnetCommand("--list-runtimes", x86: x86))
-            {
-                string[] parts = line.Trim().Split([' '], 3);
-                yield return new RuntimeInfo(parts[0], parts[1], parts[2].Trim(['[', ']']));
-            }
+                yield return RuntimeInfo.Parse(line);
         }
 
-        private static IEnumerable<string> DotnetCommand(string arguments, bool x86 = false)
+        internal static IEnumerable<string> DotnetCommand(string arguments, bool x86 = false)
         {
             var process = new Process
             {

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyResolver.cs
@@ -53,19 +53,19 @@ namespace NUnit.Engine.Internal
             // Initialize the list of ResolutionStrategies in the best order depending on
             // what we learned.
             ResolutionStrategies = new List<ResolutionStrategy>();
-            
+
             if (tryWindowsDesktopFirst)
-                ResolutionStrategies.Add(new WindowsDesktopStrategy());
+                ResolutionStrategies.Add(new WindowsDesktopStrategy(false));
             if (tryAspNetCoreFirst)
-                ResolutionStrategies.Add(new AspNetCoreStrategy());
+                ResolutionStrategies.Add(new AspNetCoreStrategy(false));
 
             ResolutionStrategies.Add(new TrustedPlatformAssembliesStrategy());
             ResolutionStrategies.Add(new RuntimeLibrariesStrategy(loadContext, testAssemblyPath));
 
             if (!tryWindowsDesktopFirst)
-                ResolutionStrategies.Add(new WindowsDesktopStrategy());
+                ResolutionStrategies.Add(new WindowsDesktopStrategy(false));
             if (!tryAspNetCoreFirst)
-                ResolutionStrategies.Add(new AspNetCoreStrategy());
+                ResolutionStrategies.Add(new AspNetCoreStrategy(false));
         }
 
         public void Dispose()
@@ -89,162 +89,146 @@ namespace NUnit.Engine.Internal
             log.Info("Cannot resolve assembly '{0}'", assemblyName);
             return null;
         }
+    }
 
-        #region Nested ResolutionStrategy Classes
+    public abstract class ResolutionStrategy
+    {
+        public abstract bool TryToResolve(
+            AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly);
+    }
 
-        public abstract class ResolutionStrategy
+    public class TrustedPlatformAssembliesStrategy : ResolutionStrategy
+    {
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(TrustedPlatformAssembliesStrategy));
+
+        public override bool TryToResolve(
+            AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
         {
-            public abstract bool TryToResolve(
-                AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly);
+            return TryLoadFromTrustedPlatformAssemblies(loadContext, assemblyName, out loadedAssembly);
         }
 
-        public class TrustedPlatformAssembliesStrategy : ResolutionStrategy
+        private static bool TryLoadFromTrustedPlatformAssemblies(
+            AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
         {
-            public override bool TryToResolve(
-                AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
+            // https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing
+            loadedAssembly = null;
+            var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+            if (string.IsNullOrEmpty(trustedAssemblies))
             {
-                return TryLoadFromTrustedPlatformAssemblies(loadContext, assemblyName, out loadedAssembly);
+                return false;
             }
 
-            private static bool TryLoadFromTrustedPlatformAssemblies(
-                AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
+            var separator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ";" : ":";
+            foreach (var assemblyPath in trustedAssemblies.Split(separator))
             {
-                // https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing
-                loadedAssembly = null;
-                var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
-                if (string.IsNullOrEmpty(trustedAssemblies))
+                var fileName = Path.GetFileNameWithoutExtension(assemblyPath);
+                if (FileMatchesAssembly(fileName) && File.Exists(assemblyPath))
                 {
-                    return false;
-                }
+                    loadedAssembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+                    log.Info("'{0}' assembly is loaded from trusted path '{1}'", assemblyPath, loadedAssembly.Location);
 
-                var separator = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ";" : ":";
-                foreach (var assemblyPath in trustedAssemblies.Split(separator))
+                    return true;
+                }
+            }
+
+            return false;
+
+            bool FileMatchesAssembly(string fileName) =>
+                string.Equals(fileName, assemblyName.Name, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+
+    public class RuntimeLibrariesStrategy : ResolutionStrategy
+    {
+        private static readonly Logger log = InternalTrace.GetLogger(typeof(RuntimeLibrariesStrategy));
+
+        private readonly DependencyContext _dependencyContext;
+        private readonly CompositeCompilationAssemblyResolver _assemblyResolver;
+
+        public RuntimeLibrariesStrategy(AssemblyLoadContext loadContext, string testAssemblyPath)
+        {
+            _dependencyContext = DependencyContext.Load(loadContext.LoadFromAssemblyPath(testAssemblyPath));
+
+            _assemblyResolver = new CompositeCompilationAssemblyResolver(
+            [
+                new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(testAssemblyPath)),
+                new ReferenceAssemblyPathResolver(),
+                new PackageCompilationAssemblyResolver()
+            ]);
+        }
+
+        public override bool TryToResolve(
+            AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
+        {
+            foreach (var library in _dependencyContext.RuntimeLibraries)
+            {
+                var wrapper = new CompilationLibrary(
+                    library.Type,
+                    library.Name,
+                    library.Version,
+                    library.Hash,
+                    library.RuntimeAssemblyGroups.SelectMany(g => g.AssetPaths),
+                    library.Dependencies,
+                    library.Serviceable);
+
+                var assemblies = new List<string>();
+                _assemblyResolver.TryResolveAssemblyPaths(wrapper, assemblies);
+
+                foreach (var assemblyPath in assemblies)
                 {
-                    var fileName = Path.GetFileNameWithoutExtension(assemblyPath);
-                    if (FileMatchesAssembly(fileName) && File.Exists(assemblyPath))
+                    if (assemblyName.Name == Path.GetFileNameWithoutExtension(assemblyPath))
                     {
                         loadedAssembly = loadContext.LoadFromAssemblyPath(assemblyPath);
-                        log.Info("'{0}' assembly is loaded from trusted path '{1}'", assemblyPath, loadedAssembly.Location);
+                        log.Info("'{0}' ({1}) assembly is loaded from runtime libraries {2} dependencies",
+                            assemblyName,
+                            loadedAssembly.Location,
+                            library.Name);
 
                         return true;
                     }
                 }
+            }
 
+            loadedAssembly = null;
+            return false;
+        }
+    }
+
+    public class AdditionalRuntimesStrategy : ResolutionStrategy
+    {
+        private string _runtimeName;
+        private bool _x86;
+
+        public AdditionalRuntimesStrategy(string runtimeName, bool x86)
+        {
+            _runtimeName = runtimeName;
+            _x86 = x86;
+        }
+
+        public override bool TryToResolve(AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
+        {
+            loadedAssembly = null;
+
+            if (!DotNet.FindBestRuntime(assemblyName.Version, _runtimeName, _x86, out DotNet.RuntimeInfo runtime))
                 return false;
 
-                bool FileMatchesAssembly(string fileName) =>
-                    string.Equals(fileName, assemblyName.Name, StringComparison.InvariantCultureIgnoreCase);
-            }
-        }
-
-        public class RuntimeLibrariesStrategy : ResolutionStrategy
-        {
-            private readonly DependencyContext _dependencyContext;
-            private readonly CompositeCompilationAssemblyResolver _assemblyResolver;
-
-            public RuntimeLibrariesStrategy(AssemblyLoadContext loadContext, string testAssemblyPath)
-            {
-                _dependencyContext = DependencyContext.Load(loadContext.LoadFromAssemblyPath(testAssemblyPath));
-
-                _assemblyResolver = new CompositeCompilationAssemblyResolver(
-                [
-                    new AppBaseCompilationAssemblyResolver(Path.GetDirectoryName(testAssemblyPath)),
-                    new ReferenceAssemblyPathResolver(),
-                    new PackageCompilationAssemblyResolver()
-                ]);
-            }
-
-            public override bool TryToResolve(
-                AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
-            {
-                foreach (var library in _dependencyContext.RuntimeLibraries)
-                {
-                    var wrapper = new CompilationLibrary(
-                        library.Type,
-                        library.Name,
-                        library.Version,
-                        library.Hash,
-                        library.RuntimeAssemblyGroups.SelectMany(g => g.AssetPaths),
-                        library.Dependencies,
-                        library.Serviceable);
-
-                    var assemblies = new List<string>();
-                    _assemblyResolver.TryResolveAssemblyPaths(wrapper, assemblies);
-
-                    foreach (var assemblyPath in assemblies)
-                    {
-                        if (assemblyName.Name == Path.GetFileNameWithoutExtension(assemblyPath))
-                        {
-                            loadedAssembly = loadContext.LoadFromAssemblyPath(assemblyPath);
-                            log.Info("'{0}' ({1}) assembly is loaded from runtime libraries {2} dependencies",
-                                assemblyName,
-                                loadedAssembly.Location,
-                                library.Name);
-
-                            return true;
-                        }
-                    }
-                }
-
-                loadedAssembly = null;
+            string candidate = Path.Combine(runtime.Path, runtime.Version.ToString(), assemblyName.Name + ".dll");
+            if (!File.Exists(candidate))
                 return false;
-            }
+
+            loadedAssembly = loadContext.LoadFromAssemblyPath(candidate);
+            return true;
         }
+    }
 
-        public class AdditionalRuntimesStrategy : ResolutionStrategy
-        {
-            private readonly IEnumerable<DotNet.RuntimeInfo> _additionalRuntimes;
+    public class WindowsDesktopStrategy : AdditionalRuntimesStrategy
+    {
+        public WindowsDesktopStrategy(bool x86) : base("Microsoft.WindowsDesktop.App", x86) { }
+    }
 
-            public AdditionalRuntimesStrategy(string runtimeName)
-            {
-                _additionalRuntimes = DotNet.GetRuntimes(runtimeName, !Environment.Is64BitProcess);
-            }
-
-            public override bool TryToResolve(AssemblyLoadContext loadContext, AssemblyName assemblyName, out Assembly loadedAssembly)
-            {
-                loadedAssembly = null;
-
-                if (!FindBestRuntime(assemblyName, out DotNet.RuntimeInfo runtime))
-                    return false;
-
-                string candidate = Path.Combine(runtime.Path, runtime.Version.ToString(), assemblyName.Name + ".dll");
-                if (!File.Exists(candidate))
-                    return false;
-
-                loadedAssembly = loadContext.LoadFromAssemblyPath(candidate);
-                return true;
-            }
-
-            private bool FindBestRuntime(AssemblyName assemblyName, out DotNet.RuntimeInfo bestRuntime)
-            {
-                bestRuntime = null;
-                var targetVersion = assemblyName.Version;
-
-                if (targetVersion is null)
-                    return false;
-
-                foreach (var candidate in _additionalRuntimes)
-                {
-                    if (candidate.Version >= targetVersion)
-                        if (bestRuntime is null || bestRuntime.Version > candidate.Version)
-                            bestRuntime = candidate;
-                }
-
-                return bestRuntime is not null;
-            }
-        }
-
-        public class WindowsDesktopStrategy : AdditionalRuntimesStrategy
-        {
-            public WindowsDesktopStrategy() : base("Microsoft.WindowsDesktop.App") { }
-        }
-
-        public class AspNetCoreStrategy : AdditionalRuntimesStrategy
-        {
-            public AspNetCoreStrategy() : base("Microsoft.AspNetCore.App") { }
-        }
-
-        #endregion
+    public class AspNetCoreStrategy : AdditionalRuntimesStrategy
+    {
+        public AspNetCoreStrategy(bool x86) : base("Microsoft.AspNetCore.App", x86) { }
     }
 }
 #endif


### PR DESCRIPTION
Corrects the fix to already closed issue #1779, which causes an error when a prerelease version is encountered in the output of `dotnet --list-runtimes`. The error no longer occurs.