### PR TITLE
Eliminate use of our custom AssemblyLoadContext

### DIFF
--- a/NetCoreTests.nunit
+++ b/NetCoreTests.nunit
@@ -1,11 +1,9 @@
 ﻿<NUnitProject>
   <Settings processModel="Default" domainUsage="Default" />
   <Config name="Debug" appbase="bin/Debug">
-      <assembly path="testdata/net6.0/mock-assembly.dll" />
       <assembly path="testdata/net8.0/mock-assembly.dll" />
   </Config>
   <Config name="Release" appbase="bin/Release">
-      <assembly path="testdata/net6.0/mock-assembly.dll" />
       <assembly path="testdata/net8.0/mock-assembly.dll" />
   </Config>
 </NUnitProject>

--- a/package-tests.cake
+++ b/package-tests.cake
@@ -261,14 +261,14 @@ public static class PackageTests
         AllLists.Add(new PackageTest(1, "Net60WPFTest")
         {
             Description = "Run test using WPF targeting .NET 6.0",
-            Arguments = "testdata/net6.0-windows/WpfTest.dll",
+            Arguments = "testdata/net6.0-windows/WpfTest.dll --trace:Debug",
             ExpectedResult = new ExpectedResult("Passed") { Assemblies = new[] { new ExpectedAssemblyResult("WpfTest.dll", "netcore-6.0") } }
         });
 
         AllLists.Add(new PackageTest(1, "Net80WPFTest")
         {
             Description = "Run test using WPF targeting .NET 8.0",
-            Arguments = "testdata/net8.0-windows/WpfTest.dll",
+            Arguments = "testdata/net8.0-windows/WpfTest.dll --trace:Debug",
             ExpectedResult = new ExpectedResult("Passed") { Assemblies = new[] { new ExpectedAssemblyResult("WpfTest.dll", "netcore-8.0") } }
         });
 
@@ -314,9 +314,9 @@ public static class PackageTests
 
         NetCoreRunnerTests.Add(new PackageTest(1, "NUnitProjectTest")
         {
-            Description= "Run NUnit project with mock-assembly.dll targeting .NET 6.0 and 8.0",
+            Description= "Run NUnit project with mock-assembly.dll targeting 8.0",
             Arguments="../../NetCoreTests.nunit --config=Release",
-            ExpectedResult = new MockAssemblyExpectedResult("netcore-6.0", "netcore-8.0"),
+            ExpectedResult = new MockAssemblyExpectedResult("netcore-8.0"),
             ExtensionsNeeded = new [] { Extensions.NUnitProjectLoader }
         });
 

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnitNetCore31Driver.cs
@@ -8,6 +8,7 @@ using System.IO;
 using NUnit.Engine.Internal;
 using System.Reflection;
 using NUnit.Engine.Extensibility;
+using System.Runtime.Loader;
 
 namespace NUnit.Engine.Drivers
 {
@@ -38,7 +39,8 @@ namespace NUnit.Engine.Drivers
         Assembly _frameworkAssembly;
         object _frameworkController;
         Type _frameworkControllerType;
-        TestAssemblyLoadContext _assemblyLoadContext;
+        AssemblyLoadContext _assemblyLoadContext;
+        TestAssemblyResolver _testAssemblyResolver;
 
         /// <summary>
         /// An id prefix that will be passed to the test framework and used as part of the
@@ -54,11 +56,17 @@ namespace NUnit.Engine.Drivers
         /// <returns>An XML string representing the loaded test</returns>
         public string Load(string assemblyPath, IDictionary<string, object> settings)
         {
+            //if (assemblyPath.EndsWith("WpfTest.dll"))
+            //    System.Diagnostics.Debugger.Launch();
+
             log.Debug($"Loading {assemblyPath}");
             var idPrefix = string.IsNullOrEmpty(ID) ? "" : ID + "-";
 
             assemblyPath = Path.GetFullPath(assemblyPath);  //AssemblyLoadContext requires an absolute path
-            _assemblyLoadContext = new TestAssemblyLoadContext(assemblyPath);
+            //_assemblyLoadContext = new TestAssemblyLoadContext(assemblyPath);
+            //_assemblyLoadContext = AssemblyLoadContext.Default;
+            _assemblyLoadContext = new AssemblyLoadContext(assemblyPath);
+            _testAssemblyResolver = new TestAssemblyResolver(_assemblyLoadContext, assemblyPath);
 
             try
             {
@@ -102,6 +110,11 @@ namespace NUnit.Engine.Drivers
 
             log.Info("Loading {0} - see separate log file", _testAssembly.FullName);
             return ExecuteMethod(LOAD_METHOD) as string;
+        }
+
+        private Assembly _assemblyLoadContext_Resolving(AssemblyLoadContext arg1, AssemblyName arg2)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyLoadContext.cs
+++ b/src/NUnitEngine/nunit.engine.core/Internal/TestAssemblyLoadContext.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER && false
 
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine.core/Runners/DirectTestRunner.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using NUnit.Engine.Extensibility;
 using NUnit.Engine.Internal;


### PR DESCRIPTION
Fixes #1795 

NOTE: Fixes problem raised for NUnit3 Test Adapter. Unable to repro successfully using the console runner.