### PR TITLE
Clarify driver support for NUnit versions

### DIFF
--- a/.github/workflows/NUnitConsoleAndEngine.CI.yml
+++ b/.github/workflows/NUnitConsoleAndEngine.CI.yml
@@ -4,11 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches-ignore:
-      - "azure-*"
-    paths-ignore:
-      - "*.txt"
-      - "*.md"
+    branches:
+      - version3
 
 env:
   DOTNET_NOLOGO: true # Disable the .NET logo

--- a/NUnitConsole.sln
+++ b/NUnitConsole.sln
@@ -1,8 +1,5 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32228.430
-MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{49D441DF-39FD-4F4D-AECA-86CF8EFE23AF}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig

--- a/build.cake
+++ b/build.cake
@@ -116,7 +116,7 @@ BuildSettings.Packages.AddRange(new PackageDefinition[] {
             HasDirectory("tools/agents/net10.0").WithFiles(AGENT_FILES_NETCORE)
         },
         testRunner: new ConsoleRunnerSelfTester(BuildSettings.ChocolateyTestDirectory
-            + $"nunit-console-runner.{BuildSettings.ChocolateyPackageVersion}/tools/nunit3-console.exe"),
+            + $"nunit-console-runner.{BuildSettings.PackageVersion}/tools/nunit3-console.exe"),
         tests: PackageTests.StandardRunnerTests),
 
     NUnitConsoleZipPackage = new ZipPackage(

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 ﻿// Load the recipe 
-#load nuget:?package=NUnit.Cake.Recipe&version=1.6.0-alpha.5
+#load nuget:?package=NUnit.Cake.Recipe&version=1.6.0
 // Comment out above line and uncomment below for local tests of recipe changes
 //#load ../NUnit.Cake.Recipe/recipe/*.cake
 

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
@@ -18,11 +18,8 @@ namespace NUnit.Engine.Drivers
         /// represent a test framework supported by this factory.
         /// </summary>
         /// <param name="reference">An AssemblyName referring to the possible test framework.</param>
-        public bool IsSupportedTestFramework(AssemblyName reference)
-        {
-            int major = reference.Version.Major;
-            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && (major == 3 || major == 4);
-        }
+        public bool IsSupportedTestFramework(AssemblyName reference) =>
+            NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && reference.Version.Major is 3 or 4;
 
 #if NETFRAMEWORK
         /// <summary>

--- a/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitEngine/nunit.engine.core/Drivers/NUnit3DriverFactory.cs
@@ -20,7 +20,8 @@ namespace NUnit.Engine.Drivers
         /// <param name="reference">An AssemblyName referring to the possible test framework.</param>
         public bool IsSupportedTestFramework(AssemblyName reference)
         {
-            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && reference.Version.Major >= 3;
+            int major = reference.Version.Major;
+            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && (major == 3 || major == 4);
         }
 
 #if NETFRAMEWORK


### PR DESCRIPTION
This PR is part of #1856, fixing the version3 code so that it doesn't report support for NUnit versions past V4. We'll release this in conjunction with the framework V5 release.
