### PR TITLE
Eliminate use of StopRun(true)

### DIFF
--- a/.github/workflows/NUnitConsoleAndEngine.CI.yml
+++ b/.github/workflows/NUnitConsoleAndEngine.CI.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 🔨 Build, Test, Package and Publish (Cake script decides)
         run: dotnet cake --target=ContinuousIntegration --configuration=Release #--verbosity=diagnostic
 
-      # Upload packages before publishing in case of later failures
+      # Upload packages
       - name: 💾 Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,7 +22,7 @@
         <DebugSymbols>true</DebugSymbols>
         <!-- Commonly Used Package Versions -->
         <AnnotatedReferenceAssemblyVersion>8.0.0</AnnotatedReferenceAssemblyVersion>
-        <EngineApiVersion>4.0.0-beta.3</EngineApiVersion>
+        <EngineApiVersion>4.0.0-beta.4</EngineApiVersion>
         <!-- Informational Settings -->
         <Company>NUnit Software</Company>
         <Product>NUnit 4 Runner and Engine</Product>

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerExceptionTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerExceptionTests.cs
@@ -115,18 +115,7 @@ namespace NUnit.Engine.Runners
                 .Do(x => { throw new NUnitEngineException("Message"); });
 
             var ex = Assert.Throws<NUnitEngineException>(() => _runner.ForcedStop());
-            Assert.That(ex.Message, Is.EqualTo("Message"));
-        }
-
-        [Test]
-        public void StopRun_Throws_ArgumentException()
-        {
-            _driver.When(x => x.ForcedStop())
-                .Do(x => { throw new ArgumentException("Message"); });
-
-            var ex = Assert.Throws<ArgumentException>(() => _runner.ForcedStop());
-            Assert.That(ex.
-                Message, Is.EqualTo("Message"));
+            Assert.That(ex?.Message, Is.EqualTo("Message"));
         }
     }
 }

--- a/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerExceptionTests.cs
+++ b/src/NUnitCommon/nunit.agent.core.tests/Runners/TestAgentRunnerExceptionTests.cs
@@ -111,7 +111,7 @@ namespace NUnit.Engine.Runners
         [Test]
         public void StopRun_Passes_Along_NUnitEngineException()
         {
-            _driver.When(x => x.StopRun(Arg.Any<bool>()))
+            _driver.When(x => x.ForcedStop())
                 .Do(x => { throw new NUnitEngineException("Message"); });
 
             var ex = Assert.Throws<NUnitEngineException>(() => _runner.ForcedStop());
@@ -119,15 +119,14 @@ namespace NUnit.Engine.Runners
         }
 
         [Test]
-        public void StopRun_Throws_NUnitEngineException()
+        public void StopRun_Throws_ArgumentException()
         {
-            _driver.When(x => x.StopRun(Arg.Any<bool>()))
+            _driver.When(x => x.ForcedStop())
                 .Do(x => { throw new ArgumentException("Message"); });
 
-            var ex = Assert.Throws<NUnitEngineException>(() => _runner.ForcedStop());
-            Assert.That(ex.InnerException, Is.Not.Null);
-            Assert.That(ex.InnerException, Is.InstanceOf<ArgumentException>());
-            Assert.That(ex.InnerException.Message, Is.EqualTo("Message"));
+            var ex = Assert.Throws<ArgumentException>(() => _runner.ForcedStop());
+            Assert.That(ex.
+                Message, Is.EqualTo("Message"));
         }
     }
 }

--- a/src/NUnitCommon/nunit.agent.core/Drivers/InvalidAssemblyFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/InvalidAssemblyFrameworkDriver.cs
@@ -55,7 +55,11 @@ namespace NUnit.Engine.Drivers
             return GetLoadResult();
         }
 
-        public void StopRun(bool force)
+        public void RequestStop()
+        {
+        }
+
+        public void ForcedStop()
         {
         }
 

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnit3DriverFactory.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnit3DriverFactory.cs
@@ -18,7 +18,7 @@ namespace NUnit.Engine.Drivers
         /// <param name="reference">An AssemblyName referring to the possible test framework.</param>
         public bool IsSupportedTestFramework(AssemblyName reference)
         {
-            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && reference.Version?.Major >= 3;
+            return NUNIT_FRAMEWORK.Equals(reference.Name, StringComparison.OrdinalIgnoreCase) && reference.Version?.Major is 3 or 4;
         }
 
 #if NETFRAMEWORK

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 
 namespace NUnit.Engine.Drivers
 {
+    /// <summary>
+    /// Driver API for the NUnit Framework. Provides a common interface to al
+    /// versions of the framework, in spite of differences in their own API.
+    /// </summary>
     public interface NUnitFrameworkApi
     {
         /// <summary>
@@ -47,6 +51,15 @@ namespace NUnit.Engine.Drivers
         /// </summary>
         void RequestStop();
 
+        /// <summary>
+        /// Force the current test run to stop, killing threads or processes if necessary.
+        /// </summary>
+        /// <exception cref="NotImplementedException" />
         void ForcedStop();
+
+        /// <summary>
+        /// Gets a flag indicating whether ForcedStop is supported for the framework version in use.
+        /// </summary>
+        bool ForcedStopSupported { get; }
     }
 }

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi.cs
@@ -45,7 +45,8 @@ namespace NUnit.Engine.Drivers
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
         /// </summary>
-        /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
-        void StopRun(bool force);
+        void RequestStop();
+
+        void ForcedStop();
     }
 }

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
@@ -107,6 +107,8 @@ namespace NUnit.Engine.Drivers
 
         public void ForcedStop() => ExecuteAction(STOP_RUN_ACTION, true);
 
+        public bool ForcedStopSupported => true;
+
         public string Explore(string filter)
         {
             CheckLoadWasCalled();

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2009.cs
@@ -103,7 +103,9 @@ namespace NUnit.Engine.Drivers
 
         public void RunAsync(Action<string>? callback, string filter) => throw new NotImplementedException();
 
-        public void StopRun(bool force) => ExecuteAction(STOP_RUN_ACTION, force);
+        public void RequestStop() => ExecuteAction(STOP_RUN_ACTION, false);
+
+        public void ForcedStop() => ExecuteAction(STOP_RUN_ACTION, true);
 
         public string Explore(string filter)
         {

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
@@ -178,9 +178,14 @@ namespace NUnit.Engine.Drivers
             ExecuteMethod(RUN_ASYNC_METHOD, [typeof(Action<string>), typeof(string)], callback, filter);
         }
 
-        public void StopRun(bool force)
+        public void RequestStop()
         {
-            ExecuteMethod(STOP_RUN_METHOD, force);
+            ExecuteMethod(STOP_RUN_METHOD, false);
+        }
+
+        public void ForcedStop()
+        {
+            ExecuteMethod(STOP_RUN_METHOD, true);
         }
 
         public string Explore(string filter)

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkApi2018.cs
@@ -188,6 +188,8 @@ namespace NUnit.Engine.Drivers
             ExecuteMethod(STOP_RUN_METHOD, true);
         }
 
+        public bool ForcedStopSupported => _nunitRef.Version.ShouldNotBeNull().Major is 3 or 4;
+
         public string Explore(string filter)
         {
             CheckLoadWasCalled();

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
@@ -3,6 +3,7 @@
 using NUnit.Engine.Extensibility;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Reflection;
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -20,6 +21,8 @@ namespace NUnit.Engine.Drivers
         private static readonly Version MINIMUM_NUNIT_VERSION = new(3, 2, 0);
         private static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkDriver));
 
+        private readonly Version _nunitVersion;
+
 #if NETFRAMEWORK
         private readonly NUnitFrameworkApi _api;
 
@@ -35,6 +38,7 @@ namespace NUnit.Engine.Drivers
             Guard.ArgumentNotNull(nunitRef);
 
             ID = id;
+            _nunitVersion = nunitRef.Version.ShouldNotBeNull();
 
             if (nunitRef.Version >= MINIMUM_NUNIT_VERSION)
             {
@@ -69,6 +73,8 @@ namespace NUnit.Engine.Drivers
             Guard.ArgumentNotNullOrEmpty(id);
             Guard.ArgumentNotNull(nunitRef);
 
+            _nunitVersion = nunitRef.Version.ShouldNotBeNull();
+
             ID = id;
             API = api;
 
@@ -99,6 +105,7 @@ namespace NUnit.Engine.Drivers
             ID = id;
             API = "2018";
 
+            _nunitVersion = nunitRef.Version.ShouldNotBeNull();
             _api = new NUnitFrameworkApi2018(ID, nunitRef);
         }
 
@@ -154,7 +161,17 @@ namespace NUnit.Engine.Drivers
         /// </summary>
         public void RequestStop() => _api.RequestStop();
 
-        public void ForcedStop() => _api.ForcedStop();
+        /// <summary>
+        /// Force the current test run to stop, killing threads or processes if necessary.
+        /// If no tests are running, the call is ignored.
+        /// </summary>
+        public void ForcedStop()
+        {
+            if (_api.ForcedStopSupported)
+                _api.ForcedStop();
+            else
+                Process.GetCurrentProcess().Kill();
+        }
 
         /// <summary>
         /// Returns information about the tests in an assembly.

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
@@ -152,8 +152,9 @@ namespace NUnit.Engine.Drivers
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
         /// </summary>
-        /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
-        public void StopRun(bool force) => _api.StopRun(force);
+        public void RequestStop() => _api.RequestStop();
+
+        public void ForcedStop() => _api.ForcedStop();
 
         /// <summary>
         /// Returns information about the tests in an assembly.

--- a/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
+++ b/src/NUnitCommon/nunit.agent.core/Drivers/NUnitFrameworkDriver.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+using NUnit.Common;
 using NUnit.Engine.Extensibility;
 using System;
 using System.Collections.Generic;
@@ -18,7 +19,7 @@ namespace NUnit.Engine.Drivers
     /// </summary>
     public class NUnitFrameworkDriver : IFrameworkDriver
     {
-        private static readonly Version MINIMUM_NUNIT_VERSION = new(3, 2, 0);
+        private static readonly Version MINIMUM_NUNIT_VERSION_FOR_2018_API = new(3, 2, 0);
         private static readonly Logger log = InternalTrace.GetLogger(nameof(NUnitFrameworkDriver));
 
         private readonly Version _nunitVersion;
@@ -40,7 +41,7 @@ namespace NUnit.Engine.Drivers
             ID = id;
             _nunitVersion = nunitRef.Version.ShouldNotBeNull();
 
-            if (nunitRef.Version >= MINIMUM_NUNIT_VERSION)
+            if (_nunitVersion >= MINIMUM_NUNIT_VERSION_FOR_2018_API)
             {
                 API = "2018";
                 _api = (NUnitFrameworkApi)testDomain.CreateInstanceFromAndUnwrap(
@@ -170,7 +171,7 @@ namespace NUnit.Engine.Drivers
             if (_api.ForcedStopSupported)
                 _api.ForcedStop();
             else
-                Process.GetCurrentProcess().Kill();
+                Environment.Exit(AgentExitCodes.CANCELLED_BY_FORCED_STOP);
         }
 
         /// <summary>

--- a/src/NUnitCommon/nunit.agent.core/Runners/TestAgentRunner.cs
+++ b/src/NUnitCommon/nunit.agent.core/Runners/TestAgentRunner.cs
@@ -244,25 +244,13 @@ namespace NUnit.Engine.Runners
         /// Request the current test run to stop. If no tests are running,
         /// the call is ignored.
         /// </summary>
-        public void RequestStop() => StopRun(false);
+        public void RequestStop() => GetLoadedDriver().RequestStop();
 
         /// <summary>
         /// Force the current test run to stop, killing threads or processes if necessary.
         /// If no tests are running, the call is ignored.
         /// </summary>
-        public void ForcedStop() => StopRun(true);
-
-        private void StopRun(bool force)
-        {
-            try
-            {
-                GetLoadedDriver().StopRun(force);
-            }
-            catch (Exception ex) when (!(ex is NUnitEngineException))
-            {
-                throw new NUnitEngineException("An exception occurred in the driver while stopping the run.", ex);
-            }
-        }
+        public void ForcedStop() => GetLoadedDriver().ForcedStop();
 
         private IFrameworkDriver GetLoadedDriver()
         {

--- a/src/NUnitCommon/nunit.common/AgentExitCodes.cs
+++ b/src/NUnitCommon/nunit.common/AgentExitCodes.cs
@@ -10,6 +10,7 @@ namespace NUnit.Common
         public const int DEBUGGER_SECURITY_VIOLATION = -3;
         public const int DEBUGGER_NOT_IMPLEMENTED = -4;
         public const int UNABLE_TO_LOCATE_AGENCY = -5;
+        public const int CANCELLED_BY_FORCED_STOP = -6;
         public const int UNEXPECTED_EXCEPTION = -100;
         public const int STACK_OVERFLOW_EXCEPTION = -1073741571;
     }

--- a/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
+++ b/src/NUnitEngine/nunit.engine.tests/Runners/MasterTestRunnerTests.cs
@@ -94,16 +94,13 @@ namespace NUnit.Engine.Runners
             _engineRunner.Received().Run(Arg.Any<TestEventDispatcher>(), filter);
         }
 
-        [TestCase(false)]
-        [TestCase(true)]
-        public void StopRun(bool force)
+        [Test]
+        public void RequestStop()
         {
             _masterTestRunner.GetEngineRunner();
-            _masterTestRunner.StopRun(force);
-            if (force)
-                _engineRunner.Received().ForcedStop();
-            else
-                _engineRunner.Received().RequestStop();
+            _masterTestRunner.RequestStop();
+
+            _engineRunner.Received().RequestStop();
         }
 #endif
     }

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Charlie Poole, Rob Prouse and Contributors. MIT License - see LICENSE.txt
 
+#define USE_WORK_ITEM_TRACKER
+
 using System;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
+++ b/src/NUnitEngine/nunit.engine/Runners/MasterTestRunner.cs
@@ -51,7 +51,9 @@ namespace NUnit.Engine.Runners
         private bool _disposed;
 
         private TestEventDispatcher _eventDispatcher = new TestEventDispatcher();
+#if USE_WORK_ITEM_TRACKER
         private WorkItemTracker _workItemTracker = new WorkItemTracker();
+#endif
 
         private int _testRunTimeout;
         private Timer? _testRunTimer;
@@ -186,19 +188,16 @@ namespace NUnit.Engine.Runners
         /// <summary>
         /// Cancel the ongoing test run. If no  test is running, the call is ignored.
         /// </summary>
-        /// <param name="force">If true, cancel any ongoing test threads, otherwise wait for them to complete.</param>
-        public void StopRun(bool force)
-        {
-            if (_engineRunner is null)
-                return; // No test is was even started.
+        public void RequestStop() => _engineRunner?.RequestStop();
 
-            if (!force)
-                _engineRunner.RequestStop();
-            else
+        public void ForcedStop()
+        {
+            if (_engineRunner is not null)
             {
                 _engineRunner.ForcedStop();
 
-                // Frameworks should handle StopRun(true) by cancelling all tests and notifying
+#if USE_WORK_ITEM_TRACKER
+                // Framework drivers should handle ForcedStop() by cancelling all tests and notifying
                 // us of the completion of any tests that were running. However, this feature
                 // may be absent in some frameworks or may be broken and we may not pass on the
                 // notifications needed by some runners. In fact, such a bug is present in the
@@ -225,6 +224,7 @@ namespace NUnit.Engine.Runners
 
                     _engineRunner.Unload();
                 }
+#endif
             }
         }
 
@@ -454,9 +454,11 @@ namespace NUnit.Engine.Runners
         /// <returns>A TestEngineResult giving the result of the test execution</returns>
         private TestEngineResult RunTests(ITestEventListener? listener, TestFilter filter)
         {
-            _workItemTracker.Clear();
             _eventDispatcher.Listeners.Clear();
+#if USE_WORK_ITEM_TRACKER
+            _workItemTracker.Clear();
             _eventDispatcher.Listeners.Add(_workItemTracker);
+#endif
 
             if (listener is not null)
                 _eventDispatcher.Listeners.Add(listener);
@@ -530,15 +532,18 @@ namespace NUnit.Engine.Runners
         private void OnTestRunTimeout(object? sender, ElapsedEventArgs e)
         {
             // Unlikely as it is, let's see if we can stop this cooperatively
-            StopRun(false);
+            RequestStop();
+            // TODO: Should we wait for run complete if we are not using WorkItemTracker?
 
             // We wait for the cooperative stop and do a forced stop if it fails.
             // WaitForCompletion will actually be called twice, once here and
-            // again in StopRun(true), so the wait is doubled but no harm done.
-            // StopRun(True) also calls _workItemTracker to try to fix up any
+            // again in ForcedStop(), so the wait is doubled but no harm done.
+            // ForcedStop() also calls _workItemTracker to try to fix up any
             // in-flight items and produce as informative a result as possible.
+#if USE_WORK_ITEM_TRACKER
             if (!_workItemTracker.WaitForCompletion(WAIT_FOR_CANCEL_TO_COMPLETE))
-                StopRun(true);
+                ForcedStop();
+#endif
         }
 
         private AsyncTestEngineResult RunTestsAsync(ITestEventListener? listener, TestFilter filter)


### PR DESCRIPTION
Eliminates use of `StopRun(bool)` in the engine and agent core and fixes #1856.

`StopRun(false)` is replaced by `RequestStop()`, which is intended to make it clear that the test may not stop. The caller may only request it and the result depends on the test framework, possibly its version and the test code itself.

`StopRun(true)` is replace by `ForcedStop()`. If the test framework provides any facilities for such a stop, they are used. Otherwise, any non terminated processes are canceled by the engine.

The initial commit makes the necessary replacements but code to kill agent processes is not yet implemented.