### PR TITLE
Fix --list-extensions showing wrong target framework for extensions

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 // Load the recipe
-#load nuget:?package=NUnit.Cake.Recipe&version=2.0.0-beta.4.3
+#load nuget:?package=NUnit.Cake.Recipe&version=2.0.0-beta.4.9
 // Comment out above line and uncomment below for local tests of recipe changes
 //#load ../NUnit.Cake.Recipe/src/NUnit.Cake.Recipe/content/*.cake
 

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -7,6 +7,7 @@ using NUnit.Engine;
 using NUnit.Engine.Extensibility;
 using NUnit.Extensibility;
 using NUnit.TextDisplay;
+using TestCentric.Metadata;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -412,6 +413,9 @@ namespace NUnit.ConsoleRunner
             _outWriter.Write(INDENT8 + "Version: ");
             _outWriter.WriteLine(ColorStyle.Value, node.AssemblyVersion.ToString());
 
+            _outWriter.Write(INDENT8 + "Framework: ");
+            _outWriter.WriteLine(ColorStyle.Value, GetTargetFrameworkDisplayName(node.AssemblyPath));
+
             _outWriter.Write(INDENT8 + "Status: ");
             _outWriter.WriteLine(ColorStyle.Value, node.Status.ToString());
 
@@ -432,6 +436,32 @@ namespace NUnit.ConsoleRunner
                         _outWriter.Write(ColorStyle.Value, " " + val);
                     _outWriter.WriteLine();
                 }
+            }
+        }
+
+        // Reads the target framework declared by the extension's own assembly metadata,
+        // rather than the runtime framework of this console, which is what an extension
+        // node's own runtime type may otherwise appear to reflect. See issue #839.
+        private static string GetTargetFrameworkDisplayName(string assemblyPath)
+        {
+            try
+            {
+                var resolver = new DefaultAssemblyResolver();
+                resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+                resolver.AddSearchDirectory(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
+                var parameters = new ReaderParameters { AssemblyResolver = resolver };
+
+                using var assemblyDefinition = AssemblyDefinition.ReadAssembly(assemblyPath, parameters);
+
+                if (assemblyDefinition.TryGetFrameworkName(out string frameworkName))
+                    return frameworkName;
+
+                var runtimeVersion = assemblyDefinition.GetRuntimeVersion();
+                return $".NETFramework,Version=v{runtimeVersion.Major}.{runtimeVersion.Minor}";
+            }
+            catch (Exception)
+            {
+                return "Unknown";
             }
         }
 

--- a/src/NUnitConsole/nunit4-console/nunit4-console.csproj
+++ b/src/NUnitConsole/nunit4-console/nunit4-console.csproj
@@ -31,4 +31,8 @@
     <ProjectReference Include="..\..\NUnitCommon\nunit.common\nunit.common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="TestCentric.Metadata" Version="$(TestCentricMetadataVersion)" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes #839

## Problem
`--list-extensions` never displayed a target framework for installed extensions. The user-visible symptom reported in #839 was that a TeamCity extension targeting .NET Standard 2.0 appeared to be running under .NET 4.0/4.7 — the runtime the console itself was running on, not the extension's own declared target.

## Root cause
`ExtensionAssembly` (`src/NUnitCommon/nunit.extensibility/ExtensionAssembly.cs`) already reads an extension assembly's *own* `TargetFrameworkAttribute` correctly via `TestCentric.Metadata`, exposed as `FrameworkName`. But that value was never surfaced anywhere — `ConsoleRunner.DisplayExtension` (`src/NUnitConsole/nunit4-console/ConsoleRunner.cs`) never printed a framework field at all.

The natural fix would be adding `TargetFramework` to `NUnit.Extensibility.IExtensionNode` and threading it through `ExtensionNode`. However, `nunit4-console` only ever sees extension nodes through the console's `IExtensionService`/`IExtensionNode`, which resolve (transitively, through `nunit.engine`'s `NUnit.Engine.Api` package reference) to the **externally published, version-pinned** `NUnit.Extensibility.Api` NuGet package rather than this repo's local project source. Extending the local interface doesn't reach the console without also bumping and republishing that package — out of scope for this fix.

## Fix
`ConsoleRunner` now reads each listed extension's declared target framework directly from its own assembly file (`node.AssemblyPath`), using the same `TestCentric.Metadata` technique already used by `ExtensionAssembly`. This reports what the extension itself declares, independent of the console's own runtime.

Note: the issue also speculated about a secondary bug where an extension targeting .NET 4.7 might display as .NET 4.0 — that would be in `TestCentric.Metadata`'s own attribute/runtime-version parsing (an external dependency), not in this repo, so it isn't addressed here.

## Testing
- `dotnet build` on the affected projects (0 warnings, 0 errors).
- Verified via a standalone harness against `net462` and `netstandard2.0` builds of the repo's own `FakeExtensions` test data that the new code path correctly reports `.NETFramework,Version=v4.6.2` vs `.NETStandard,Version=v2.0` for each assembly's own target, rather than the console's runtime.
- Wasn't able to get `--extensionDirectory` to pick up the loose `FakeExtensions` build locally to screenshot full CLI output (addin discovery/packaging format), so verification was done at the metadata-reading level directly. `dotnet test` for `nunit4-console.tests` currently fails to run in this environment due to a pre-existing, unrelated NUnit3TestAdapter/`nunit.engine.api v3.0.0.0` binding issue (reproduces identically on `main` without this change).