### PR TITLE
Add AssemblyTargetFramework to IExtensionNode

### DIFF
--- a/src/NUnitCommon/nunit.extensibility.api/IExtensionNode.cs
+++ b/src/NUnitCommon/nunit.extensibility.api/IExtensionNode.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 
 namespace NUnit.Extensibility
 {
@@ -70,6 +71,11 @@ namespace NUnit.Extensibility
         /// The version of the assembly implementing this extension.
         /// </summary>
         Version AssemblyVersion { get; }
+
+        /// <summary>
+        /// The target framework of the assembly implementing this extension.
+        /// </summary>
+        FrameworkName AssemblyTargetFramework { get; }
 
         /// <summary>
         /// Gets a collection of the values of a particular named property.

--- a/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
+++ b/src/NUnitCommon/nunit.extensibility/ExtensionNode.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Versioning;
 using TestCentric.Metadata;
 
 namespace NUnit.Extensibility
@@ -30,6 +31,7 @@ namespace NUnit.Extensibility
         {
             AssemblyPath = extensionAssembly.FilePath;
             AssemblyVersion = extensionAssembly.AssemblyVersion;
+            AssemblyTargetFramework = extensionAssembly.FrameworkName;
             TypeName = extensionType.FullName;
             Status = ExtensionStatus.Unloaded;
             Enabled = true; // By default
@@ -46,6 +48,11 @@ namespace NUnit.Extensibility
         /// Gets the version of the extension assembly.
         /// </summary>
         public Version AssemblyVersion { get; }
+
+        /// <summary>
+        /// Gets the target framework of the extension assembly.
+        /// </summary>
+        public FrameworkName AssemblyTargetFramework { get; }
 
         /// <summary>
         /// Gets the full name of the Type of the extension object.

--- a/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
+++ b/src/NUnitConsole/nunit4-console/ConsoleRunner.cs
@@ -7,7 +7,6 @@ using NUnit.Engine;
 using NUnit.Engine.Extensibility;
 using NUnit.Extensibility;
 using NUnit.TextDisplay;
-using TestCentric.Metadata;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -414,7 +413,7 @@ namespace NUnit.ConsoleRunner
             _outWriter.WriteLine(ColorStyle.Value, node.AssemblyVersion.ToString());
 
             _outWriter.Write(INDENT8 + "Framework: ");
-            _outWriter.WriteLine(ColorStyle.Value, GetTargetFrameworkDisplayName(node.AssemblyPath));
+            _outWriter.WriteLine(ColorStyle.Value, node.AssemblyTargetFramework.ToString());
 
             _outWriter.Write(INDENT8 + "Status: ");
             _outWriter.WriteLine(ColorStyle.Value, node.Status.ToString());
@@ -436,32 +435,6 @@ namespace NUnit.ConsoleRunner
                         _outWriter.Write(ColorStyle.Value, " " + val);
                     _outWriter.WriteLine();
                 }
-            }
-        }
-
-        // Reads the target framework declared by the extension's own assembly metadata,
-        // rather than the runtime framework of this console, which is what an extension
-        // node's own runtime type may otherwise appear to reflect. See issue #839.
-        private static string GetTargetFrameworkDisplayName(string assemblyPath)
-        {
-            try
-            {
-                var resolver = new DefaultAssemblyResolver();
-                resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
-                resolver.AddSearchDirectory(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
-                var parameters = new ReaderParameters { AssemblyResolver = resolver };
-
-                using var assemblyDefinition = AssemblyDefinition.ReadAssembly(assemblyPath, parameters);
-
-                if (assemblyDefinition.TryGetFrameworkName(out string frameworkName))
-                    return frameworkName;
-
-                var runtimeVersion = assemblyDefinition.GetRuntimeVersion();
-                return $".NETFramework,Version=v{runtimeVersion.Major}.{runtimeVersion.Minor}";
-            }
-            catch (Exception)
-            {
-                return "Unknown";
             }
         }
 

--- a/src/NUnitConsole/nunit4-console/nunit4-console.csproj
+++ b/src/NUnitConsole/nunit4-console/nunit4-console.csproj
@@ -31,8 +31,4 @@
     <ProjectReference Include="..\..\NUnitCommon\nunit.common\nunit.common.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="TestCentric.Metadata" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary
- Adds `AssemblyTargetFramework` (`System.Runtime.Versioning.FrameworkName`) to `IExtensionNode`, alongside the existing `AssemblyPath`/`AssemblyVersion`, populated the same way from `ExtensionAssembly.FrameworkName` in `ExtensionNode`'s constructor.
- Simplifies the workaround added by #1861 (fixing #839): `ConsoleRunner.DisplayExtension` previously had to independently re-read each extension assembly's metadata via Mono.Cecil/TestCentric.Metadata (`GetTargetFrameworkDisplayName`) just to display its target framework, since the interface didn't expose it. That method is now removed and the console reads `node.AssemblyTargetFramework` directly. The now-unused `TestCentric.Metadata` package reference is dropped from `nunit4-console.csproj` (still used elsewhere in the solution, so the central `PackageVersion` entry is untouched).

Fixes #1866

## Test plan
- [x] `dotnet cake -t Test` (via `build.cmd -t Test`) — full Build + Test succeeded (300/300 net462 non-skipped tests passed, 313/313 net8.0 non-skipped tests passed).
- [x] `build.cmd -t Package` fails locally with `MSB4041` on `nunit.extensibility.api.csproj`, but this reproduces identically on a clean checkout of `main` with no changes applied — pre-existing local MSBuild-toolchain issue (old .NET Framework MSBuild 4.8 invoked by the Package task can't parse the SDK-style `<Project Sdk=...>` project), unrelated to this change.